### PR TITLE
[#3] Google OAuth 로그인 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+    // WebClient 관련 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/example/temp/auth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/auth/application/OAuthService.java
@@ -1,0 +1,40 @@
+package com.example.temp.auth.application;
+
+import com.example.temp.auth.dto.response.LoginInfoResponse;
+import com.example.temp.auth.oauth.OAuthMember;
+import com.example.temp.auth.oauth.OAuthProviderResolver;
+import com.example.temp.auth.oauth.OAuthResponse;
+import com.example.temp.auth.oauth.domain.OAuthMemberRepository;
+import com.example.temp.member.domain.Member;
+import com.example.temp.member.domain.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OAuthService {
+
+    private final OAuthProviderResolver oAuthProviderResolver;
+    private final OAuthMemberRepository oAuthMemberRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public LoginInfoResponse login(String provider, String authCode) {
+        OAuthResponse oAuthResponse = oAuthProviderResolver.fetch(provider, authCode);
+        Optional<OAuthMember> oAuthMemberOpt = oAuthMemberRepository.findByS(oAuthResponse.idUsingResourceServer(),
+            provider);
+        if (oAuthMemberOpt.isEmpty()) {
+            Member savedMember = memberRepository.save(Member.of(oAuthResponse));
+            OAuthMember oAuthMember = OAuthMember.from(oAuthResponse, savedMember);
+            oAuthMemberRepository.save(oAuthMember);
+            return LoginInfoResponse.of(savedMember);
+        } else {
+            OAuthMember oAuthMember = oAuthMemberOpt.get();
+            return LoginInfoResponse.of(oAuthMember.getMember());
+        }
+    }
+
+}

--- a/src/main/java/com/example/temp/auth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/auth/application/OAuthService.java
@@ -3,6 +3,7 @@ package com.example.temp.auth.application;
 import com.example.temp.auth.dto.response.LoginInfoResponse;
 import com.example.temp.auth.oauth.OAuthMember;
 import com.example.temp.auth.oauth.OAuthProviderResolver;
+import com.example.temp.auth.oauth.OAuthProviderType;
 import com.example.temp.auth.oauth.OAuthResponse;
 import com.example.temp.auth.oauth.domain.OAuthMemberRepository;
 import com.example.temp.member.domain.Member;
@@ -29,8 +30,9 @@ public class OAuthService {
     }
 
     private Member findOrSaveMember(String provider, OAuthResponse oAuthResponse) {
-        Optional<OAuthMember> oAuthMemberOpt = oAuthMemberRepository.findByS(oAuthResponse.idUsingResourceServer(),
-            provider);
+        Optional<OAuthMember> oAuthMemberOpt = oAuthMemberRepository.findByIdUsingResourceServerAndType(
+            oAuthResponse.idUsingResourceServer(),
+            OAuthProviderType.find(provider));
         if (oAuthMemberOpt.isPresent()) {
             return oAuthMemberOpt.get().getMember();
         }

--- a/src/main/java/com/example/temp/auth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/auth/application/OAuthService.java
@@ -38,7 +38,7 @@ public class OAuthService {
             return oAuthMemberOpt.get().getMember();
         }
         Member savedMember = memberRepository.save(Member.of(oAuthResponse));
-        OAuthMember oAuthMember = OAuthMember.from(oAuthResponse, savedMember);
+        OAuthMember oAuthMember = OAuthMember.of(oAuthResponse, savedMember, oAuthProviderType);
         oAuthMemberRepository.save(oAuthMember);
         return savedMember;
     }

--- a/src/main/java/com/example/temp/auth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/auth/application/OAuthService.java
@@ -1,7 +1,7 @@
 package com.example.temp.auth.application;
 
 import com.example.temp.auth.dto.response.LoginInfoResponse;
-import com.example.temp.auth.oauth.OAuthMember;
+import com.example.temp.auth.oauth.domain.OAuthMember;
 import com.example.temp.auth.oauth.OAuthProviderResolver;
 import com.example.temp.auth.oauth.OAuthProviderType;
 import com.example.temp.auth.oauth.OAuthResponse;

--- a/src/main/java/com/example/temp/auth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/auth/application/OAuthService.java
@@ -24,15 +24,16 @@ public class OAuthService {
 
     @Transactional
     public LoginInfoResponse login(String provider, String authCode) {
-        OAuthResponse oAuthResponse = oAuthProviderResolver.fetch(provider, authCode);
-        Member member = findOrSaveMember(provider, oAuthResponse);
+        OAuthProviderType oAuthProviderType = OAuthProviderType.find(provider);
+        OAuthResponse oAuthResponse = oAuthProviderResolver.fetch(oAuthProviderType, authCode);
+        Member member = findOrSaveMember(oAuthProviderType, oAuthResponse);
         return LoginInfoResponse.of(member);
     }
 
-    private Member findOrSaveMember(String provider, OAuthResponse oAuthResponse) {
+    private Member findOrSaveMember(OAuthProviderType oAuthProviderType, OAuthResponse oAuthResponse) {
         Optional<OAuthMember> oAuthMemberOpt = oAuthMemberRepository.findByIdUsingResourceServerAndType(
             oAuthResponse.idUsingResourceServer(),
-            OAuthProviderType.find(provider));
+            oAuthProviderType);
         if (oAuthMemberOpt.isPresent()) {
             return oAuthMemberOpt.get().getMember();
         }

--- a/src/main/java/com/example/temp/auth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/auth/application/OAuthService.java
@@ -1,10 +1,10 @@
 package com.example.temp.auth.application;
 
 import com.example.temp.auth.dto.response.LoginInfoResponse;
-import com.example.temp.auth.oauth.domain.OAuthMember;
 import com.example.temp.auth.oauth.OAuthProviderResolver;
 import com.example.temp.auth.oauth.OAuthProviderType;
 import com.example.temp.auth.oauth.OAuthResponse;
+import com.example.temp.auth.oauth.domain.OAuthMember;
 import com.example.temp.auth.oauth.domain.OAuthMemberRepository;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
@@ -38,7 +38,7 @@ public class OAuthService {
             return oAuthMemberOpt.get().getMember();
         }
         Member savedMember = memberRepository.save(Member.of(oAuthResponse));
-        OAuthMember oAuthMember = OAuthMember.of(oAuthResponse, savedMember, oAuthProviderType);
+        OAuthMember oAuthMember = OAuthMember.of(oAuthResponse.idUsingResourceServer(), oAuthProviderType, savedMember);
         oAuthMemberRepository.save(oAuthMember);
         return savedMember;
     }

--- a/src/main/java/com/example/temp/auth/dto/request/OAuthLoginRequest.java
+++ b/src/main/java/com/example/temp/auth/dto/request/OAuthLoginRequest.java
@@ -1,0 +1,7 @@
+package com.example.temp.auth.dto.request;
+
+public record OAuthLoginRequest(
+    String authCode
+) {
+
+}

--- a/src/main/java/com/example/temp/auth/dto/response/AccessToken.java
+++ b/src/main/java/com/example/temp/auth/dto/response/AccessToken.java
@@ -1,0 +1,6 @@
+package com.example.temp.auth.dto.response;
+
+@SuppressWarnings("java:S2094")
+public record AccessToken() {
+
+}

--- a/src/main/java/com/example/temp/auth/dto/response/LoginInfoResponse.java
+++ b/src/main/java/com/example/temp/auth/dto/response/LoginInfoResponse.java
@@ -1,0 +1,6 @@
+package com.example.temp.auth.dto.response;
+
+@SuppressWarnings("java:S2094")
+public record LoginInfoResponse() {
+
+}

--- a/src/main/java/com/example/temp/auth/dto/response/LoginInfoResponse.java
+++ b/src/main/java/com/example/temp/auth/dto/response/LoginInfoResponse.java
@@ -1,6 +1,14 @@
 package com.example.temp.auth.dto.response;
 
-@SuppressWarnings("java:S2094")
-public record LoginInfoResponse() {
+import com.example.temp.member.domain.Member;
 
+public record LoginInfoResponse(
+    Long id,
+    String email,
+    String profileUrl
+) {
+
+    public static LoginInfoResponse of(Member member) {
+        return new LoginInfoResponse(member.getId(), member.getEmail(), member.getProfileUrl());
+    }
 }

--- a/src/main/java/com/example/temp/auth/oauth/OAuthMember.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthMember.java
@@ -1,0 +1,62 @@
+package com.example.temp.auth.oauth;
+
+import com.example.temp.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "oauth_members")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OAuthMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private Long idUsingResourceServer;
+
+    @Column(nullable = false)
+    private String profileUrl;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    private OAuthMember(String email, String nickname, Long idUsingResourceServer, String profileUrl, Member member) {
+        this.email = email;
+        this.nickname = nickname;
+        this.idUsingResourceServer = idUsingResourceServer;
+        this.profileUrl = profileUrl;
+        this.member = member;
+    }
+
+    public static OAuthMember from(OAuthResponse response, Member member) {
+        return OAuthMember.builder()
+            .email(response.email())
+            .nickname(response.nickname())
+            .idUsingResourceServer(response.idUsingResourceServer())
+            .profileUrl(response.profileUrl())
+            .member(member)
+            .build();
+    }
+}

--- a/src/main/java/com/example/temp/auth/oauth/OAuthProvider.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthProvider.java
@@ -1,0 +1,5 @@
+package com.example.temp.auth.oauth;
+
+public interface OAuthProvider {
+
+}

--- a/src/main/java/com/example/temp/auth/oauth/OAuthProvider.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthProvider.java
@@ -2,4 +2,7 @@ package com.example.temp.auth.oauth;
 
 public interface OAuthProvider {
 
+    boolean support(OAuthProviderType providerType);
+
+    OAuthResponse fetch(String authCode);
 }

--- a/src/main/java/com/example/temp/auth/oauth/OAuthProviderResolver.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthProviderResolver.java
@@ -1,0 +1,16 @@
+package com.example.temp.auth.oauth;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthProviderResolver {
+
+    private final Set<OAuthProvider> providers;
+
+    public OAuthResponse fetch(String provider, String authCode) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/temp/auth/oauth/OAuthProviderResolver.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthProviderResolver.java
@@ -11,6 +11,11 @@ public class OAuthProviderResolver {
     private final Set<OAuthProvider> providers;
 
     public OAuthResponse fetch(OAuthProviderType providerType, String authCode) {
-        return null;
+        OAuthProvider oAuthProvider = providers.stream()
+            .filter(provider -> provider.support(providerType))
+            .findAny()
+            .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 OAuth 타입입니다."));
+        return oAuthProvider.fetch(authCode);
     }
 }
+

--- a/src/main/java/com/example/temp/auth/oauth/OAuthProviderResolver.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthProviderResolver.java
@@ -10,7 +10,7 @@ public class OAuthProviderResolver {
 
     private final Set<OAuthProvider> providers;
 
-    public OAuthResponse fetch(String provider, String authCode) {
+    public OAuthResponse fetch(OAuthProviderType providerType, String authCode) {
         return null;
     }
 }

--- a/src/main/java/com/example/temp/auth/oauth/OAuthProviderType.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthProviderType.java
@@ -1,0 +1,22 @@
+package com.example.temp.auth.oauth;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public enum OAuthProviderType {
+    GOOGLE("google"),
+    KAKAO("kakao");
+
+    private final String text;
+
+    OAuthProviderType(String text) {
+        this.text = text;
+    }
+
+    public static OAuthProviderType find(String providerName) {
+        return Arrays.stream(OAuthProviderType.values())
+            .filter(each -> Objects.equals(each.text, providerName))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 OAuth 타입입니다."));
+    }
+}

--- a/src/main/java/com/example/temp/auth/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthResponse.java
@@ -1,7 +1,5 @@
 package com.example.temp.auth.oauth;
 
-import com.example.temp.auth.oauth.impl.google.GoogleUserInfo;
-
 public record OAuthResponse(
     OAuthProviderType type,
     String email,
@@ -10,8 +8,8 @@ public record OAuthResponse(
     String profileUrl
 ) {
 
-    public static OAuthResponse of(OAuthProviderType type, GoogleUserInfo googleUserInfo) {
-        return new OAuthResponse(type, googleUserInfo.email(), googleUserInfo.name(),
-            googleUserInfo.idUsingResourceServer(), googleUserInfo.profileUrl());
+    public static OAuthResponse of(OAuthProviderType type, OAuthUserInfo oAuthUserInfo) {
+        return new OAuthResponse(type, oAuthUserInfo.getEmail(), oAuthUserInfo.getName(),
+            oAuthUserInfo.getIdUsingResourceServer(), oAuthUserInfo.getProfileUrl());
     }
 }

--- a/src/main/java/com/example/temp/auth/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthResponse.java
@@ -1,10 +1,17 @@
 package com.example.temp.auth.oauth;
 
+import com.example.temp.auth.oauth.impl.google.GoogleUserInfo;
+
 public record OAuthResponse(
     OAuthProviderType type,
     String email,
-    String nickname,
-    Long idUsingResourceServer,
+    String name,
+    String idUsingResourceServer,
     String profileUrl
 ) {
+
+    public static OAuthResponse of(OAuthProviderType type, GoogleUserInfo googleUserInfo) {
+        return new OAuthResponse(type, googleUserInfo.email(), googleUserInfo.name(),
+            googleUserInfo.idUsingResourceServer(), googleUserInfo.profileUrl());
+    }
 }

--- a/src/main/java/com/example/temp/auth/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthResponse.java
@@ -1,0 +1,9 @@
+package com.example.temp.auth.oauth;
+
+public record OAuthResponse(
+    String email,
+    String nickname,
+    Long idUsingResourceServer,
+    String profileUrl
+) {
+}

--- a/src/main/java/com/example/temp/auth/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthResponse.java
@@ -1,6 +1,7 @@
 package com.example.temp.auth.oauth;
 
 public record OAuthResponse(
+    OAuthProviderType type,
     String email,
     String nickname,
     Long idUsingResourceServer,

--- a/src/main/java/com/example/temp/auth/oauth/OAuthUserInfo.java
+++ b/src/main/java/com/example/temp/auth/oauth/OAuthUserInfo.java
@@ -1,0 +1,13 @@
+package com.example.temp.auth.oauth;
+
+public interface OAuthUserInfo {
+
+    String getProfileUrl();
+
+    String getEmail();
+
+    String getIdUsingResourceServer();
+
+    String getName();
+
+}

--- a/src/main/java/com/example/temp/auth/oauth/domain/OAuthMember.java
+++ b/src/main/java/com/example/temp/auth/oauth/domain/OAuthMember.java
@@ -1,5 +1,6 @@
-package com.example.temp.auth.oauth;
+package com.example.temp.auth.oauth.domain;
 
+import com.example.temp.auth.oauth.OAuthResponse;
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/example/temp/auth/oauth/domain/OAuthMember.java
+++ b/src/main/java/com/example/temp/auth/oauth/domain/OAuthMember.java
@@ -1,5 +1,6 @@
 package com.example.temp.auth.oauth.domain;
 
+import com.example.temp.auth.oauth.OAuthProviderType;
 import com.example.temp.auth.oauth.OAuthResponse;
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.Column;
@@ -36,6 +37,9 @@ public class OAuthMember {
     private Long idUsingResourceServer;
 
     @Column(nullable = false)
+    private OAuthProviderType type;
+
+    @Column(nullable = false)
     private String profileUrl;
 
     @OneToOne(fetch = FetchType.LAZY)
@@ -43,21 +47,25 @@ public class OAuthMember {
     private Member member;
 
     @Builder
-    private OAuthMember(String email, String nickname, Long idUsingResourceServer, String profileUrl, Member member) {
+    private OAuthMember(String email, String nickname, Long idUsingResourceServer, OAuthProviderType type,
+        String profileUrl,
+        Member member) {
         this.email = email;
         this.nickname = nickname;
         this.idUsingResourceServer = idUsingResourceServer;
+        this.type = type;
         this.profileUrl = profileUrl;
         this.member = member;
     }
 
-    public static OAuthMember from(OAuthResponse response, Member member) {
+    public static OAuthMember of(OAuthResponse response, Member member, OAuthProviderType oAuthProviderType) {
         return OAuthMember.builder()
             .email(response.email())
             .nickname(response.nickname())
             .idUsingResourceServer(response.idUsingResourceServer())
             .profileUrl(response.profileUrl())
             .member(member)
+            .type(oAuthProviderType)
             .build();
     }
 }

--- a/src/main/java/com/example/temp/auth/oauth/domain/OAuthMember.java
+++ b/src/main/java/com/example/temp/auth/oauth/domain/OAuthMember.java
@@ -1,7 +1,6 @@
 package com.example.temp.auth.oauth.domain;
 
 import com.example.temp.auth.oauth.OAuthProviderType;
-import com.example.temp.auth.oauth.OAuthResponse;
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -28,44 +27,27 @@ public class OAuthMember {
     private Long id;
 
     @Column(nullable = false)
-    private String email;
-
-    @Column(nullable = false)
-    private String nickname;
-
-    @Column(nullable = false)
     private String idUsingResourceServer;
 
     @Column(nullable = false)
     private OAuthProviderType type;
-
-    @Column(nullable = false)
-    private String profileUrl;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder
-    private OAuthMember(String email, String nickname, String idUsingResourceServer, OAuthProviderType type,
-        String profileUrl,
-        Member member) {
-        this.email = email;
-        this.nickname = nickname;
+    private OAuthMember(String idUsingResourceServer, OAuthProviderType type, Member member) {
         this.idUsingResourceServer = idUsingResourceServer;
         this.type = type;
-        this.profileUrl = profileUrl;
         this.member = member;
     }
 
-    public static OAuthMember of(OAuthResponse response, Member member, OAuthProviderType oAuthProviderType) {
+    public static OAuthMember of(String idUsingResourceServer, OAuthProviderType oAuthProviderType, Member member) {
         return OAuthMember.builder()
-            .email(response.email())
-            .nickname(response.name())
-            .idUsingResourceServer(response.idUsingResourceServer())
-            .profileUrl(response.profileUrl())
-            .member(member)
+            .idUsingResourceServer(idUsingResourceServer)
             .type(oAuthProviderType)
+            .member(member)
             .build();
     }
 }

--- a/src/main/java/com/example/temp/auth/oauth/domain/OAuthMember.java
+++ b/src/main/java/com/example/temp/auth/oauth/domain/OAuthMember.java
@@ -34,7 +34,7 @@ public class OAuthMember {
     private String nickname;
 
     @Column(nullable = false)
-    private Long idUsingResourceServer;
+    private String idUsingResourceServer;
 
     @Column(nullable = false)
     private OAuthProviderType type;
@@ -47,7 +47,7 @@ public class OAuthMember {
     private Member member;
 
     @Builder
-    private OAuthMember(String email, String nickname, Long idUsingResourceServer, OAuthProviderType type,
+    private OAuthMember(String email, String nickname, String idUsingResourceServer, OAuthProviderType type,
         String profileUrl,
         Member member) {
         this.email = email;
@@ -61,7 +61,7 @@ public class OAuthMember {
     public static OAuthMember of(OAuthResponse response, Member member, OAuthProviderType oAuthProviderType) {
         return OAuthMember.builder()
             .email(response.email())
-            .nickname(response.nickname())
+            .nickname(response.name())
             .idUsingResourceServer(response.idUsingResourceServer())
             .profileUrl(response.profileUrl())
             .member(member)

--- a/src/main/java/com/example/temp/auth/oauth/domain/OAuthMemberRepository.java
+++ b/src/main/java/com/example/temp/auth/oauth/domain/OAuthMemberRepository.java
@@ -1,0 +1,11 @@
+package com.example.temp.auth.oauth.domain;
+
+import com.example.temp.auth.oauth.OAuthMember;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OAuthMemberRepository extends JpaRepository<OAuthMember, Long> {
+
+    // TODO JPQL 적용, 메서드 이름 변경
+    Optional<OAuthMember> findByS(Long aLong, String provider);
+}

--- a/src/main/java/com/example/temp/auth/oauth/domain/OAuthMemberRepository.java
+++ b/src/main/java/com/example/temp/auth/oauth/domain/OAuthMemberRepository.java
@@ -1,6 +1,5 @@
 package com.example.temp.auth.oauth.domain;
 
-import com.example.temp.auth.oauth.OAuthMember;
 import com.example.temp.auth.oauth.OAuthProviderType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/temp/auth/oauth/domain/OAuthMemberRepository.java
+++ b/src/main/java/com/example/temp/auth/oauth/domain/OAuthMemberRepository.java
@@ -1,11 +1,11 @@
 package com.example.temp.auth.oauth.domain;
 
 import com.example.temp.auth.oauth.OAuthMember;
+import com.example.temp.auth.oauth.OAuthProviderType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OAuthMemberRepository extends JpaRepository<OAuthMember, Long> {
 
-    // TODO JPQL 적용, 메서드 이름 변경
-    Optional<OAuthMember> findByS(Long aLong, String provider);
+    Optional<OAuthMember> findByIdUsingResourceServerAndType(Long idUsingResourceServer, OAuthProviderType type);
 }

--- a/src/main/java/com/example/temp/auth/oauth/domain/OAuthMemberRepository.java
+++ b/src/main/java/com/example/temp/auth/oauth/domain/OAuthMemberRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OAuthMemberRepository extends JpaRepository<OAuthMember, Long> {
 
-    Optional<OAuthMember> findByIdUsingResourceServerAndType(Long idUsingResourceServer, OAuthProviderType type);
+    Optional<OAuthMember> findByIdUsingResourceServerAndType(String idUsingResourceServer, OAuthProviderType type);
 }

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthClient.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthClient.java
@@ -1,0 +1,13 @@
+package com.example.temp.auth.oauth.impl.google;
+
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface GoogleOAuthClient {
+
+    @PostExchange(url = "/oauth2/v4/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
+    GoogleToken fetchToken(@RequestBody MultiValueMap<String, String> params);
+}

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthClient.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthClient.java
@@ -2,12 +2,19 @@ package com.example.temp.auth.oauth.impl.google;
 
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
 public interface GoogleOAuthClient {
 
     @PostExchange(url = "/oauth2/v4/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
     GoogleToken fetchToken(@RequestBody MultiValueMap<String, String> params);
+
+    @GetExchange(url = "/oauth2/v3/userinfo")
+    GoogleUserInfo fetchUserInfo(@RequestHeader(name = HttpHeaders.AUTHORIZATION) String authorizationValue);
+
 }

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProperties.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProperties.java
@@ -1,0 +1,47 @@
+package com.example.temp.auth.oauth.impl.google;
+
+import java.util.Arrays;
+import java.util.Objects;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+
+@ConfigurationProperties(prefix = "oauth.google")
+@ConfigurationPropertiesBinding
+public record GoogleOAuthProperties(
+    String clientId,
+    String clientSecret,
+    String redirectUri,
+    String[] scope
+) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GoogleOAuthProperties that = (GoogleOAuthProperties) o;
+        return Objects.equals(clientId, that.clientId) && Objects.equals(clientSecret,
+            that.clientSecret) && Objects.equals(redirectUri, that.redirectUri) && Arrays.equals(scope,
+            that.scope);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(clientId, clientSecret, redirectUri);
+        result = 31 * result + Arrays.hashCode(scope);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GoogleOAuthProperties{" +
+            "clientId='" + clientId + '\'' +
+            ", clientSecret='" + clientSecret + '\'' +
+            ", redirectUri='" + redirectUri + '\'' +
+            ", scope=" + Arrays.toString(scope) +
+            '}';
+    }
+}

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProperties.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProperties.java
@@ -3,10 +3,8 @@ package com.example.temp.auth.oauth.impl.google;
 import java.util.Arrays;
 import java.util.Objects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
 @ConfigurationProperties(prefix = "oauth.google")
-@ConfigurationPropertiesBinding
 public record GoogleOAuthProperties(
     String clientId,
     String clientSecret,

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
@@ -24,7 +24,7 @@ public class GoogleOAuthProvider implements OAuthProvider {
     @Override
     public OAuthResponse fetch(String authCode) {
         GoogleToken googleToken = googleOAuthClient.fetchToken(getFetchTokenParams(authCode));
-        GoogleUserInfo googleUserInfo = googleOAuthClient.fetchUserInfo(googleToken.getAuthorizationValue());
+        GoogleUserInfo googleUserInfo = googleOAuthClient.fetchUserInfo(googleToken.getValueUsingAuthorizationHeader());
         return OAuthResponse.of(OAuthProviderType.GOOGLE, googleUserInfo);
     }
 

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
@@ -1,0 +1,19 @@
+package com.example.temp.auth.oauth.impl.google;
+
+import com.example.temp.auth.oauth.OAuthProvider;
+import com.example.temp.auth.oauth.OAuthProviderType;
+import com.example.temp.auth.oauth.OAuthResponse;
+import java.util.Objects;
+
+public class GoogleOAuthProvider implements OAuthProvider {
+
+    @Override
+    public boolean support(OAuthProviderType providerType) {
+        return Objects.equals(OAuthProviderType.GOOGLE, providerType);
+    }
+
+    @Override
+    public OAuthResponse fetch(String authCode) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
@@ -6,11 +6,14 @@ import com.example.temp.auth.oauth.OAuthResponse;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 @Component
 @RequiredArgsConstructor
 public class GoogleOAuthProvider implements OAuthProvider {
 
+    private final GoogleOAuthClient googleOAuthClient;
     private final GoogleOAuthProperties properties;
 
     @Override
@@ -20,6 +23,18 @@ public class GoogleOAuthProvider implements OAuthProvider {
 
     @Override
     public OAuthResponse fetch(String authCode) {
+        GoogleToken googleToken = googleOAuthClient.fetchToken(getFetchTokenParams(authCode));
+
         return null;
+    }
+
+    private MultiValueMap<String, String> getFetchTokenParams(String authCode) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", properties.clientId());
+        params.add("client_secret", properties.clientSecret());
+        params.add("code", authCode);
+        params.add("redirect_uri", properties.redirectUri());
+        params.add("grant_type", "authorization_code");
+        return params;
     }
 }

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
@@ -24,7 +24,7 @@ public class GoogleOAuthProvider implements OAuthProvider {
     @Override
     public OAuthResponse fetch(String authCode) {
         GoogleToken googleToken = googleOAuthClient.fetchToken(getFetchTokenParams(authCode));
-
+        GoogleUserInfo googleUserInfo = googleOAuthClient.fetchUserInfo(googleToken.getAuthorizationValue());
         return null;
     }
 

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
@@ -25,7 +25,7 @@ public class GoogleOAuthProvider implements OAuthProvider {
     public OAuthResponse fetch(String authCode) {
         GoogleToken googleToken = googleOAuthClient.fetchToken(getFetchTokenParams(authCode));
         GoogleUserInfo googleUserInfo = googleOAuthClient.fetchUserInfo(googleToken.getAuthorizationValue());
-        return null;
+        return OAuthResponse.of(OAuthProviderType.GOOGLE, googleUserInfo);
     }
 
     private MultiValueMap<String, String> getFetchTokenParams(String authCode) {

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProvider.java
@@ -4,8 +4,14 @@ import com.example.temp.auth.oauth.OAuthProvider;
 import com.example.temp.auth.oauth.OAuthProviderType;
 import com.example.temp.auth.oauth.OAuthResponse;
 import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class GoogleOAuthProvider implements OAuthProvider {
+
+    private final GoogleOAuthProperties properties;
 
     @Override
     public boolean support(OAuthProviderType providerType) {

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleToken.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleToken.java
@@ -4,6 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record GoogleToken(
     @JsonProperty("access_token")
-    String accessToken
+    String accessToken,
+    @JsonProperty("token_type")
+    String tokenType
 ) {
+
+    public String getAuthorizationValue() {
+        return String.format("%s %s", tokenType, accessToken);
+    }
 }
+

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleToken.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleToken.java
@@ -1,0 +1,9 @@
+package com.example.temp.auth.oauth.impl.google;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleToken(
+    @JsonProperty("access_token")
+    String accessToken
+) {
+}

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleToken.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleToken.java
@@ -9,7 +9,7 @@ public record GoogleToken(
     String tokenType
 ) {
 
-    public String getAuthorizationValue() {
+    public String getValueUsingAuthorizationHeader() {
         return String.format("%s %s", tokenType, accessToken);
     }
 }

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleUserInfo.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleUserInfo.java
@@ -1,19 +1,38 @@
 package com.example.temp.auth.oauth.impl.google;
 
+import com.example.temp.auth.oauth.OAuthUserInfo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record GoogleUserInfo(
+public class GoogleUserInfo implements OAuthUserInfo {
     @JsonProperty("picture")
-    String profileUrl,
+    String profileUrl;
 
     @JsonProperty("email")
-    String email,
+    String email;
 
     @JsonProperty("sub")
-    String idUsingResourceServer,
+    String idUsingResourceServer;
 
     @JsonProperty("name")
-    String name
-) {
+    String name;
 
+    @Override
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getIdUsingResourceServer() {
+        return idUsingResourceServer;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleUserInfo.java
+++ b/src/main/java/com/example/temp/auth/oauth/impl/google/GoogleUserInfo.java
@@ -1,0 +1,19 @@
+package com.example.temp.auth.oauth.impl.google;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleUserInfo(
+    @JsonProperty("picture")
+    String profileUrl,
+
+    @JsonProperty("email")
+    String email,
+
+    @JsonProperty("sub")
+    String idUsingResourceServer,
+
+    @JsonProperty("name")
+    String name
+) {
+
+}

--- a/src/main/java/com/example/temp/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/temp/auth/presentation/AuthController.java
@@ -1,0 +1,32 @@
+package com.example.temp.auth.presentation;
+
+import com.example.temp.auth.dto.response.AccessToken;
+import com.example.temp.auth.dto.response.LoginInfoResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+public class AuthController {
+
+    @PostMapping("/oauth/{provider}/login")
+    public ResponseEntity<LoginInfoResponse> oauthLogin(@PathVariable String provider) {
+        log.info("Hello {}", provider);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/auth/refresh")
+    public ResponseEntity<AccessToken> reissueToken() {
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/auth/logout")
+    public ResponseEntity<Void> logout() {
+        log.info("로그아웃 성공");
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/example/temp/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/temp/auth/presentation/AuthController.java
@@ -1,21 +1,29 @@
 package com.example.temp.auth.presentation;
 
+import com.example.temp.auth.application.OAuthService;
+import com.example.temp.auth.dto.request.OAuthLoginRequest;
 import com.example.temp.auth.dto.response.AccessToken;
 import com.example.temp.auth.dto.response.LoginInfoResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @Slf4j
 public class AuthController {
 
+    private final OAuthService oAuthService;
+
     @PostMapping("/oauth/{provider}/login")
-    public ResponseEntity<LoginInfoResponse> oauthLogin(@PathVariable String provider) {
-        log.info("Hello {}", provider);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<LoginInfoResponse> oauthLogin(@PathVariable String provider,
+        @RequestBody OAuthLoginRequest request) {
+        LoginInfoResponse response = oAuthService.login(provider, request.authCode());
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/auth/refresh")

--- a/src/main/java/com/example/temp/common/config/ScanningPropertiesConfiguration.java
+++ b/src/main/java/com/example/temp/common/config/ScanningPropertiesConfiguration.java
@@ -1,0 +1,11 @@
+package com.example.temp.common.config;
+
+import com.example.temp.GymHubBackApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan(basePackageClasses = GymHubBackApplication.class)
+public class ScanningPropertiesConfiguration {
+
+}

--- a/src/main/java/com/example/temp/common/config/ScanningPropertiesConfiguration.java
+++ b/src/main/java/com/example/temp/common/config/ScanningPropertiesConfiguration.java
@@ -1,11 +1,10 @@
 package com.example.temp.common.config;
 
-import com.example.temp.GymHubBackApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationPropertiesScan(basePackageClasses = GymHubBackApplication.class)
+@ConfigurationPropertiesScan(basePackages = "com.example")
 public class ScanningPropertiesConfiguration {
 
 }

--- a/src/main/java/com/example/temp/common/config/WebClientConfiguration.java
+++ b/src/main/java/com/example/temp/common/config/WebClientConfiguration.java
@@ -1,0 +1,29 @@
+package com.example.temp.common.config;
+
+import com.example.temp.auth.oauth.impl.google.GoogleOAuthClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.support.WebClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class WebClientConfiguration {
+
+    @Bean
+    public GoogleOAuthClient googleOAuthClient() {
+        return createHttpInterface(GoogleOAuthClient.class);
+    }
+
+    private <T> T createHttpInterface(Class<T> clazz) {
+        WebClient webClient = WebClient.builder()
+            .baseUrl("https://www.googleapis.com")
+            .build();
+
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory
+            .builder(WebClientAdapter.forClient(webClient))
+            .build();
+        return factory.createClient(clazz);
+    }
+
+}

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -1,0 +1,40 @@
+package com.example.temp.member.domain;
+
+import com.example.temp.auth.oauth.OAuthResponse;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "members")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private String profileUrl;
+
+    @Builder
+    private Member(String email, String profileUrl) {
+        this.email = email;
+        this.profileUrl = profileUrl;
+    }
+
+    public static Member of(OAuthResponse oAuthResponse) {
+        return Member.builder()
+            .email(oAuthResponse.email())
+            .profileUrl(oAuthResponse.profileUrl())
+            .build();
+    }
+}

--- a/src/main/java/com/example/temp/member/domain/MemberRepository.java
+++ b/src/main/java/com/example/temp/member/domain/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.example.temp.member.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.temp.auth.dto.response.LoginInfoResponse;
-import com.example.temp.auth.oauth.OAuthMember;
+import com.example.temp.auth.oauth.domain.OAuthMember;
 import com.example.temp.auth.oauth.OAuthProviderResolver;
 import com.example.temp.auth.oauth.OAuthProviderType;
 import com.example.temp.auth.oauth.OAuthResponse;

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -1,0 +1,129 @@
+package com.example.temp.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.temp.auth.dto.response.LoginInfoResponse;
+import com.example.temp.auth.oauth.OAuthMember;
+import com.example.temp.auth.oauth.OAuthProviderResolver;
+import com.example.temp.auth.oauth.OAuthResponse;
+import com.example.temp.auth.oauth.domain.OAuthMemberRepository;
+import com.example.temp.member.domain.Member;
+import com.example.temp.member.domain.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthServiceUnitTest {
+
+    OAuthService oAuthService;
+
+    @Mock
+    OAuthProviderResolver oAuthProviderResolver;
+
+    @Mock
+    OAuthMemberRepository oAuthMemberRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    OAuthResponse oAuthResponse;
+
+    OAuthMember oAuthMember;
+
+    Member member;
+
+    @BeforeEach
+    void setUp() {
+        oAuthService = new OAuthService(oAuthProviderResolver, oAuthMemberRepository, memberRepository);
+        oAuthResponse = new OAuthResponse("이메일", "닉네임", 1L, "프로필주소");
+        member = Member.builder().build();
+        oAuthMember = OAuthMember.builder()
+            .member(member)
+            .build();
+    }
+
+    @Test
+    @DisplayName("OAuth 로그인을 처음 한 사용자는 로그인에 성공한다")
+    void successFirstLogin() throws Exception {
+        // given
+        when(oAuthProviderResolver.fetch(anyString(), anyString()))
+            .thenReturn(oAuthResponse);
+        when(oAuthMemberRepository.findByS(anyLong(), anyString()))
+            .thenReturn(Optional.empty());
+        when(memberRepository.save(any(Member.class)))
+            .thenReturn(member);
+
+        // when
+        LoginInfoResponse response = oAuthService.login("google", "1234");
+
+        // then
+        assertThat(response).isNotNull(); // TODO
+    }
+
+    @Test
+    @DisplayName("기존 OAuth 로그인을 했던 사용자는 로그인에 성공한다")
+    void successLoginThatUserAlreadyLogin() throws Exception {
+        // given
+        when(oAuthProviderResolver.fetch(anyString(), anyString()))
+            .thenReturn(oAuthResponse);
+        when(oAuthMemberRepository.findByS(anyLong(), anyString()))
+            .thenReturn(Optional.of(oAuthMember));
+
+        // when
+        LoginInfoResponse response = oAuthService.login("google", "1234");
+
+        // then
+        assertThat(response).isNotNull(); // TODO
+    }
+
+    @Test
+    @DisplayName("OAuth 로그인을 처음 한 사용자는 DB에 저장된다")
+    void saveDatabaseIfFirstLogin() throws Exception {
+        // given
+        when(oAuthProviderResolver.fetch(anyString(), anyString()))
+            .thenReturn(oAuthResponse);
+        when(oAuthMemberRepository.findByS(anyLong(), anyString()))
+            .thenReturn(Optional.empty());
+        when(memberRepository.save(any(Member.class)))
+            .thenReturn(member);
+
+        // when
+        oAuthService.login("google", "1234");
+
+        // then
+        verify(memberRepository, times(1))
+            .save(any(Member.class));
+        verify(oAuthMemberRepository, times(1))
+            .save(any(OAuthMember.class));
+    }
+
+    @Test
+    @DisplayName("기존에 OAuth 로그인을 한 사용자는 DB에 저장되지 않는다")
+    void notSaveDatabaseIfAlreadyLogin() throws Exception {
+        // given
+        when(oAuthProviderResolver.fetch(anyString(), anyString()))
+            .thenReturn(oAuthResponse);
+        when(oAuthMemberRepository.findByS(anyLong(), anyString()))
+            .thenReturn(Optional.of(oAuthMember));
+
+        // when
+        oAuthService.login("google", "1234");
+
+        // then
+        verify(memberRepository, never())
+            .save(any(Member.class));
+    }
+
+}

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -59,7 +59,7 @@ class OAuthServiceUnitTest {
     @DisplayName("OAuth 로그인을 처음 한 사용자는 로그인에 성공한다")
     void successFirstLogin() throws Exception {
         // given
-        when(oAuthProviderResolver.fetch(anyString(), anyString()))
+        when(oAuthProviderResolver.fetch(any(OAuthProviderType.class), anyString()))
             .thenReturn(oAuthResponse);
         when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
             .thenReturn(Optional.empty());
@@ -77,7 +77,7 @@ class OAuthServiceUnitTest {
     @DisplayName("기존 OAuth 로그인을 했던 사용자는 로그인에 성공한다")
     void successLoginThatUserAlreadyLogin() throws Exception {
         // given
-        when(oAuthProviderResolver.fetch(anyString(), anyString()))
+        when(oAuthProviderResolver.fetch(any(OAuthProviderType.class), anyString()))
             .thenReturn(oAuthResponse);
         when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
             .thenReturn(Optional.of(oAuthMember));
@@ -93,7 +93,7 @@ class OAuthServiceUnitTest {
     @DisplayName("OAuth 로그인을 처음 한 사용자는 DB에 저장된다")
     void saveDatabaseIfFirstLogin() throws Exception {
         // given
-        when(oAuthProviderResolver.fetch(anyString(), anyString()))
+        when(oAuthProviderResolver.fetch(any(OAuthProviderType.class), anyString()))
             .thenReturn(oAuthResponse);
         when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
             .thenReturn(Optional.empty());
@@ -114,7 +114,7 @@ class OAuthServiceUnitTest {
     @DisplayName("기존에 OAuth 로그인을 한 사용자는 DB에 저장되지 않는다")
     void notSaveDatabaseIfAlreadyLogin() throws Exception {
         // given
-        when(oAuthProviderResolver.fetch(anyString(), anyString()))
+        when(oAuthProviderResolver.fetch(any(OAuthProviderType.class), anyString()))
             .thenReturn(oAuthResponse);
         when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
             .thenReturn(Optional.of(oAuthMember));

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -70,7 +70,9 @@ class OAuthServiceUnitTest {
         LoginInfoResponse response = oAuthService.login("google", "1234");
 
         // then
-        assertThat(response).isNotNull(); // TODO
+        assertThat(response.id()).isEqualTo(member.getId());
+        assertThat(response.email()).isEqualTo(member.getEmail());
+        assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
     }
 
     @Test
@@ -86,7 +88,9 @@ class OAuthServiceUnitTest {
         LoginInfoResponse response = oAuthService.login("google", "1234");
 
         // then
-        assertThat(response).isNotNull(); // TODO
+        assertThat(response.id()).isEqualTo(member.getId());
+        assertThat(response.email()).isEqualTo(member.getEmail());
+        assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
     }
 
     @Test

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -48,7 +48,7 @@ class OAuthServiceUnitTest {
     @BeforeEach
     void setUp() {
         oAuthService = new OAuthService(oAuthProviderResolver, oAuthMemberRepository, memberRepository);
-        oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", 1L, "프로필주소");
+        oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", "123", "프로필주소");
         member = Member.builder().build();
         oAuthMember = OAuthMember.builder()
             .member(member)
@@ -61,7 +61,7 @@ class OAuthServiceUnitTest {
         // given
         when(oAuthProviderResolver.fetch(any(OAuthProviderType.class), anyString()))
             .thenReturn(oAuthResponse);
-        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
+        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyString(), any(OAuthProviderType.class)))
             .thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class)))
             .thenReturn(member);
@@ -79,7 +79,7 @@ class OAuthServiceUnitTest {
         // given
         when(oAuthProviderResolver.fetch(any(OAuthProviderType.class), anyString()))
             .thenReturn(oAuthResponse);
-        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
+        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyString(), any(OAuthProviderType.class)))
             .thenReturn(Optional.of(oAuthMember));
 
         // when
@@ -95,7 +95,7 @@ class OAuthServiceUnitTest {
         // given
         when(oAuthProviderResolver.fetch(any(OAuthProviderType.class), anyString()))
             .thenReturn(oAuthResponse);
-        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
+        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyString(), any(OAuthProviderType.class)))
             .thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class)))
             .thenReturn(member);
@@ -116,7 +116,7 @@ class OAuthServiceUnitTest {
         // given
         when(oAuthProviderResolver.fetch(any(OAuthProviderType.class), anyString()))
             .thenReturn(oAuthResponse);
-        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
+        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyString(), any(OAuthProviderType.class)))
             .thenReturn(Optional.of(oAuthMember));
 
         // when

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.example.temp.auth.dto.response.LoginInfoResponse;
 import com.example.temp.auth.oauth.OAuthMember;
 import com.example.temp.auth.oauth.OAuthProviderResolver;
+import com.example.temp.auth.oauth.OAuthProviderType;
 import com.example.temp.auth.oauth.OAuthResponse;
 import com.example.temp.auth.oauth.domain.OAuthMemberRepository;
 import com.example.temp.member.domain.Member;
@@ -60,7 +61,7 @@ class OAuthServiceUnitTest {
         // given
         when(oAuthProviderResolver.fetch(anyString(), anyString()))
             .thenReturn(oAuthResponse);
-        when(oAuthMemberRepository.findByS(anyLong(), anyString()))
+        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
             .thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class)))
             .thenReturn(member);
@@ -78,7 +79,7 @@ class OAuthServiceUnitTest {
         // given
         when(oAuthProviderResolver.fetch(anyString(), anyString()))
             .thenReturn(oAuthResponse);
-        when(oAuthMemberRepository.findByS(anyLong(), anyString()))
+        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
             .thenReturn(Optional.of(oAuthMember));
 
         // when
@@ -94,7 +95,7 @@ class OAuthServiceUnitTest {
         // given
         when(oAuthProviderResolver.fetch(anyString(), anyString()))
             .thenReturn(oAuthResponse);
-        when(oAuthMemberRepository.findByS(anyLong(), anyString()))
+        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
             .thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class)))
             .thenReturn(member);
@@ -115,7 +116,7 @@ class OAuthServiceUnitTest {
         // given
         when(oAuthProviderResolver.fetch(anyString(), anyString()))
             .thenReturn(oAuthResponse);
-        when(oAuthMemberRepository.findByS(anyLong(), anyString()))
+        when(oAuthMemberRepository.findByIdUsingResourceServerAndType(anyLong(), any(OAuthProviderType.class)))
             .thenReturn(Optional.of(oAuthMember));
 
         // when

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -48,7 +48,7 @@ class OAuthServiceUnitTest {
     @BeforeEach
     void setUp() {
         oAuthService = new OAuthService(oAuthProviderResolver, oAuthMemberRepository, memberRepository);
-        oAuthResponse = new OAuthResponse("이메일", "닉네임", 1L, "프로필주소");
+        oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", 1L, "프로필주소");
         member = Member.builder().build();
         oAuthMember = OAuthMember.builder()
             .member(member)

--- a/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
@@ -1,0 +1,29 @@
+package com.example.temp.auth.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OAuthMemberTest {
+
+    @Test
+    @DisplayName("OAuthResponse 인스턴스와 Member 인스턴스를 사용해 OAuthMember를 생성한다")
+    void createOAuthMemberUsingOAuthResponse() throws Exception {
+        // given
+        OAuthResponse oAuthResponse = new OAuthResponse("이메일", "닉네임", 1L, "프로필주소");
+        Member member = Member.builder().build();
+
+        // when
+        OAuthMember oAuthMember = OAuthMember.from(oAuthResponse, member);
+
+        // then
+        assertThat(oAuthMember).isNotNull();
+        assertThat(oAuthMember.getEmail()).isEqualTo(oAuthResponse.email());
+        assertThat(oAuthMember.getNickname()).isEqualTo(oAuthResponse.nickname());
+        assertThat(oAuthMember.getIdUsingResourceServer()).isEqualTo(oAuthResponse.idUsingResourceServer());
+        assertThat(oAuthMember.getProfileUrl()).isEqualTo(oAuthResponse.profileUrl());
+        assertThat(oAuthMember.getMember()).isEqualTo(member);
+    }
+}

--- a/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
@@ -13,18 +13,17 @@ class OAuthMemberTest {
     @DisplayName("OAuthResponse 인스턴스와 Member 인스턴스를 사용해 OAuthMember를 생성한다")
     void createOAuthMemberUsingOAuthResponse() throws Exception {
         // given
-        OAuthResponse oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", "123", "프로필주소");
+        String idUsingResourceServer = "1234";
         Member member = Member.builder().build();
+        OAuthProviderType type = OAuthProviderType.GOOGLE;
 
         // when
-        OAuthMember oAuthMember = OAuthMember.of(oAuthResponse, member, OAuthProviderType.GOOGLE);
+        OAuthMember oAuthMember = OAuthMember.of(idUsingResourceServer, type, member);
 
         // then
         assertThat(oAuthMember).isNotNull();
-        assertThat(oAuthMember.getEmail()).isEqualTo(oAuthResponse.email());
-        assertThat(oAuthMember.getNickname()).isEqualTo(oAuthResponse.name());
-        assertThat(oAuthMember.getIdUsingResourceServer()).isEqualTo(oAuthResponse.idUsingResourceServer());
-        assertThat(oAuthMember.getProfileUrl()).isEqualTo(oAuthResponse.profileUrl());
+        assertThat(oAuthMember.getIdUsingResourceServer()).isEqualTo(idUsingResourceServer);
+        assertThat(oAuthMember.getType()).isEqualTo(type);
         assertThat(oAuthMember.getMember()).isEqualTo(member);
     }
 }

--- a/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
@@ -2,6 +2,7 @@ package com.example.temp.auth.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.auth.oauth.domain.OAuthMember;
 import com.example.temp.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
@@ -17,7 +17,7 @@ class OAuthMemberTest {
         Member member = Member.builder().build();
 
         // when
-        OAuthMember oAuthMember = OAuthMember.from(oAuthResponse, member);
+        OAuthMember oAuthMember = OAuthMember.of(oAuthResponse, member, OAuthProviderType.GOOGLE);
 
         // then
         assertThat(oAuthMember).isNotNull();

--- a/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
@@ -13,7 +13,7 @@ class OAuthMemberTest {
     @DisplayName("OAuthResponse 인스턴스와 Member 인스턴스를 사용해 OAuthMember를 생성한다")
     void createOAuthMemberUsingOAuthResponse() throws Exception {
         // given
-        OAuthResponse oAuthResponse = new OAuthResponse("이메일", "닉네임", 1L, "프로필주소");
+        OAuthResponse oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", 1L, "프로필주소");
         Member member = Member.builder().build();
 
         // when

--- a/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/OAuthMemberTest.java
@@ -13,7 +13,7 @@ class OAuthMemberTest {
     @DisplayName("OAuthResponse 인스턴스와 Member 인스턴스를 사용해 OAuthMember를 생성한다")
     void createOAuthMemberUsingOAuthResponse() throws Exception {
         // given
-        OAuthResponse oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", 1L, "프로필주소");
+        OAuthResponse oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", "123", "프로필주소");
         Member member = Member.builder().build();
 
         // when
@@ -22,7 +22,7 @@ class OAuthMemberTest {
         // then
         assertThat(oAuthMember).isNotNull();
         assertThat(oAuthMember.getEmail()).isEqualTo(oAuthResponse.email());
-        assertThat(oAuthMember.getNickname()).isEqualTo(oAuthResponse.nickname());
+        assertThat(oAuthMember.getNickname()).isEqualTo(oAuthResponse.name());
         assertThat(oAuthMember.getIdUsingResourceServer()).isEqualTo(oAuthResponse.idUsingResourceServer());
         assertThat(oAuthMember.getProfileUrl()).isEqualTo(oAuthResponse.profileUrl());
         assertThat(oAuthMember.getMember()).isEqualTo(member);

--- a/src/test/java/com/example/temp/auth/oauth/OAuthProviderResolverUnitTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/OAuthProviderResolverUnitTest.java
@@ -1,0 +1,69 @@
+package com.example.temp.auth.oauth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthProviderResolverUnitTest {
+
+    OAuthProviderResolver resolver;
+
+    @Mock
+    OAuthProvider oAuthProvider1;
+
+    @Mock
+    OAuthProvider oAuthProvider2;
+
+    @BeforeEach
+    void setUp() {
+        Set<OAuthProvider> providers = new HashSet<>(List.of(oAuthProvider1, oAuthProvider2));
+        resolver = new OAuthProviderResolver(providers);
+    }
+
+    @Test
+    @DisplayName("입력된 OAuthProviderType에 해당되는 Provider의 fetch를 실행한다")
+    void fetchSuccess() throws Exception {
+        // given
+        when(oAuthProvider1.support(any(OAuthProviderType.class)))
+            .thenReturn(true);
+
+        // when
+        resolver.fetch(OAuthProviderType.KAKAO, "123");
+
+        // then
+        verify(oAuthProvider1, times(1)).fetch(anyString());
+        verify(oAuthProvider2, never()).fetch(anyString());
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 OAuthProviderType을 입력받으면 예외를 반환한다")
+    void fetchFailNotSupportOAuthType() throws Exception {
+        // given
+        when(oAuthProvider1.support(any(OAuthProviderType.class)))
+            .thenReturn(false);
+        when(oAuthProvider2.support(any(OAuthProviderType.class)))
+            .thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> resolver.fetch(OAuthProviderType.KAKAO, "123"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("지원하지 않는 OAuth 타입입니다.");
+        verify(oAuthProvider1, never()).fetch(anyString());
+        verify(oAuthProvider2, never()).fetch(anyString());
+    }
+}

--- a/src/test/java/com/example/temp/auth/oauth/OAuthProviderTypeTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/OAuthProviderTypeTest.java
@@ -1,0 +1,39 @@
+package com.example.temp.auth.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OAuthProviderTypeTest {
+
+    @Test
+    @DisplayName("google을 입력받아 타입을 찾는다")
+    void findTypeGoogle() throws Exception {
+        // when
+        OAuthProviderType result = OAuthProviderType.find("google");
+
+        // then
+        assertThat(result).isEqualTo(OAuthProviderType.GOOGLE);
+    }
+
+    @Test
+    @DisplayName("kakao를 입력받아 타입을 찾는다")
+    void findTypeKakao() throws Exception {
+        // when
+        OAuthProviderType result = OAuthProviderType.find("kakao");
+
+        // then
+        assertThat(result).isEqualTo(OAuthProviderType.KAKAO);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 타입을 찾으려 하면 예외를 반환한다")
+    void findNotExistType() throws Exception {
+        // when & then
+        assertThatThrownBy(() -> OAuthProviderType.find("notExist"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("지원하지 않는 OAuth 타입입니다.");
+    }
+}

--- a/src/test/java/com/example/temp/auth/oauth/OAuthResponseTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/OAuthResponseTest.java
@@ -1,0 +1,48 @@
+package com.example.temp.auth.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OAuthResponseTest {
+
+    @Test
+    @DisplayName("OAuthProviderType과 OAuthUserInfo를 사용해 OAuthResponse를 생성한다")
+    void create() throws Exception {
+        // given
+        OAuthProviderType type = OAuthProviderType.GOOGLE;
+        OAuthUserInfo info = new OAuthUserInfo() {
+            @Override
+            public String getProfileUrl() {
+                return "profile";
+            }
+
+            @Override
+            public String getEmail() {
+                return "email";
+            }
+
+            @Override
+            public String getIdUsingResourceServer() {
+                return "id";
+            }
+
+            @Override
+            public String getName() {
+                return "name";
+            }
+        };
+
+        // when
+        OAuthResponse result = OAuthResponse.of(type, info);
+
+        // then
+        assertThat(result.type()).isEqualTo(type);
+        assertThat(result.email()).isEqualTo(info.getEmail());
+        assertThat(result.name()).isEqualTo(info.getName());
+        assertThat(result.idUsingResourceServer()).isEqualTo(info.getIdUsingResourceServer());
+        assertThat(result.profileUrl()).isEqualTo(info.getProfileUrl());
+    }
+
+}

--- a/src/test/java/com/example/temp/auth/oauth/domain/OAuthMemberRepositoryTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/domain/OAuthMemberRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.example.temp.auth.oauth.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.auth.oauth.OAuthProviderType;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class OAuthMemberRepositoryTest {
+
+    @Autowired
+    OAuthMemberRepository repository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("리소스서버의 ID와 타입이 일치하는 OAuthMember를 찾는다")
+    void findByIdUsingResourceServerAndType() throws Exception {
+        // given
+        String idUsingResourceServer = "123";
+        OAuthProviderType type = OAuthProviderType.GOOGLE;
+        OAuthMember oAuthMember = OAuthMember.builder()
+            .idUsingResourceServer(idUsingResourceServer)
+            .type(type)
+            .build();
+        em.persist(oAuthMember);
+
+        // when
+        OAuthMember result = repository.findByIdUsingResourceServerAndType(idUsingResourceServer, type).get();
+
+        // then
+        assertThat(result).isEqualTo(oAuthMember);
+    }
+
+    @Test
+    @DisplayName("리소스서버의 ID와 타입이 일치하는 OAuthMember가 없을 때 비어있는 Optional 반환한다")
+    void findByIdUsingResourceServerAndTypeNotFound() throws Exception {
+        // given
+        String notRegisteredId = "123";
+        OAuthProviderType type = OAuthProviderType.GOOGLE;
+
+        // when
+        Optional<OAuthMember> resultOpt = repository.findByIdUsingResourceServerAndType(
+            notRegisteredId, type);
+
+        // then
+        assertThat(resultOpt).isEmpty();
+    }
+}

--- a/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProviderTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProviderTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -14,9 +15,12 @@ class GoogleOAuthProviderTest {
 
     GoogleOAuthProvider provider;
 
+    @Mock
+    GoogleOAuthProperties properties;
+
     @BeforeEach
     void setUp() {
-        provider = new GoogleOAuthProvider();
+        provider = new GoogleOAuthProvider(properties);
     }
 
     @Test

--- a/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProviderTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProviderTest.java
@@ -1,0 +1,39 @@
+package com.example.temp.auth.oauth.impl.google;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.auth.oauth.OAuthProviderType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleOAuthProviderTest {
+
+    GoogleOAuthProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new GoogleOAuthProvider();
+    }
+
+    @Test
+    @DisplayName("GoogleOAuthProvider 객체는 Google 타입을 지원한다")
+    void supportTest() throws Exception {
+        assertThat(provider.support(OAuthProviderType.GOOGLE)).isTrue();
+    }
+
+    @Test
+    @DisplayName("GoogleOAuthProvider 객체는 Google 이외의 타입은 지원하지 않는다")
+    void supportTestFailInvalidType1() throws Exception {
+        assertThat(provider.support(OAuthProviderType.KAKAO)).isFalse();
+    }
+
+    @Test
+    @DisplayName("GoogleOAuthProvider 객체는 null 타입에 대해 지원하지 않는다")
+    void supportTestFailInvalidType2() throws Exception {
+        assertThat(provider.support(null)).isFalse();
+    }
+}

--- a/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProviderTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProviderTest.java
@@ -16,11 +16,14 @@ class GoogleOAuthProviderTest {
     GoogleOAuthProvider provider;
 
     @Mock
+    GoogleOAuthClient client;
+
+    @Mock
     GoogleOAuthProperties properties;
 
     @BeforeEach
     void setUp() {
-        provider = new GoogleOAuthProvider(properties);
+        provider = new GoogleOAuthProvider(client, properties);
     }
 
     @Test

--- a/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProviderTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleOAuthProviderTest.java
@@ -1,14 +1,21 @@
 package com.example.temp.auth.oauth.impl.google;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import com.example.temp.auth.oauth.OAuthProviderType;
+import com.example.temp.auth.oauth.OAuthResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @ExtendWith(MockitoExtension.class)
 class GoogleOAuthProviderTest {
@@ -21,9 +28,15 @@ class GoogleOAuthProviderTest {
     @Mock
     GoogleOAuthProperties properties;
 
+    GoogleToken googleToken;
+
+    GoogleUserInfo googleUserInfo;
+
     @BeforeEach
     void setUp() {
         provider = new GoogleOAuthProvider(client, properties);
+        googleToken = new GoogleToken("access", "Bearer");
+        googleUserInfo = new GoogleUserInfo();
     }
 
     @Test
@@ -42,5 +55,66 @@ class GoogleOAuthProviderTest {
     @DisplayName("GoogleOAuthProvider 객체는 null 타입에 대해 지원하지 않는다")
     void supportTestFailInvalidType2() throws Exception {
         assertThat(provider.support(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Google의 authCode를 사용해서 OAuthResponse를 만든다")
+    void fetch() throws Exception {
+        // given
+        when(client.fetchToken(any(MultiValueMap.class)))
+            .thenReturn(googleToken);
+        when(client.fetchUserInfo(anyString()))
+            .thenReturn(googleUserInfo);
+
+        // when
+        OAuthResponse result = provider.fetch("authCode");
+
+        // then
+        assertThat(result.type()).isEqualTo(OAuthProviderType.GOOGLE);
+        assertThat(result.email()).isEqualTo(googleUserInfo.getEmail());
+        assertThat(result.name()).isEqualTo(googleUserInfo.getName());
+        assertThat(result.idUsingResourceServer()).isEqualTo(googleUserInfo.getIdUsingResourceServer());
+        assertThat(result.profileUrl()).isEqualTo(googleUserInfo.getProfileUrl());
+    }
+
+    @Test
+    @DisplayName("Google의 authCode가 적절하지 않으면 예외를 반환한다")
+    void fetchFailInvalidAuthCode() throws Exception {
+        // given
+        when(client.fetchToken(any(MultiValueMap.class)))
+            .thenThrow(WebClientResponseException.create(400, "에러메세지", null, null, null));
+
+        // when & then
+        assertThatThrownBy(() -> provider.fetch("authCode"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("적절하지 않은 Auth Code 입니다.");
+    }
+
+    @Test
+    @DisplayName("fetchToken 요청을 보낼 때, Google 서버에 문제가 발생하면 예외를 반환한다")
+    void fetchFailInvalidGoogleServer1() throws Exception {
+        // given
+        when(client.fetchToken(any(MultiValueMap.class)))
+            .thenReturn(googleToken);
+        when(client.fetchUserInfo(anyString()))
+            .thenThrow(WebClientResponseException.create(500, "에러메세지", null, null, null));
+
+        // when & then
+        assertThatThrownBy(() -> provider.fetch("authCode"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Google 서버에서 문제가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("fetchUserInfo 요청을 보낼 때, Google 서버에 문제가 발생하면 예외를 반환한다")
+    void fetchFailInvalidGoogleServer2() throws Exception {
+        // given
+        when(client.fetchToken(any(MultiValueMap.class)))
+            .thenThrow(WebClientResponseException.create(500, "에러메세지", null, null, null));
+
+        // when & then
+        assertThatThrownBy(() -> provider.fetch("authCode"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Google 서버에서 문제가 발생했습니다.");
     }
 }

--- a/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleTokenTest.java
+++ b/src/test/java/com/example/temp/auth/oauth/impl/google/GoogleTokenTest.java
@@ -1,0 +1,23 @@
+package com.example.temp.auth.oauth.impl.google;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GoogleTokenTest {
+
+    @Test
+    @DisplayName("인증헤더에 사용할 Value를 만든다")
+    void getAuthorizationValue() throws Exception {
+        // given
+        GoogleToken token = new GoogleToken("access", "Bearer");
+
+        // when
+        String result = token.getValueUsingAuthorizationHeader();
+
+        // then
+        assertThat(result).isEqualTo("Bearer access");
+    }
+
+}

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -1,0 +1,26 @@
+package com.example.temp.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.auth.oauth.OAuthResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("OAuthResponse 객체를 사용해 Member를 생성한다")
+    void createMemberUsingOAuthResponse() throws Exception {
+        // given
+        OAuthResponse oAuthResponse = new OAuthResponse("이메일", "닉네임", 1L, "프로필주소");
+
+        // when
+        Member member = Member.of(oAuthResponse);
+
+        // then
+        assertThat(member).isNotNull();
+        assertThat(member.getEmail()).isEqualTo(oAuthResponse.email());
+        assertThat(member.getProfileUrl()).isEqualTo(oAuthResponse.profileUrl());
+    }
+
+}

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -13,7 +13,7 @@ class MemberTest {
     @DisplayName("OAuthResponse 객체를 사용해 Member를 생성한다")
     void createMemberUsingOAuthResponse() throws Exception {
         // given
-        OAuthResponse oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", 1L, "프로필주소");
+        OAuthResponse oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", "123", "프로필주소");
 
         // when
         Member member = Member.of(oAuthResponse);

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -2,6 +2,7 @@ package com.example.temp.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.auth.oauth.OAuthProviderType;
 import com.example.temp.auth.oauth.OAuthResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,7 +13,7 @@ class MemberTest {
     @DisplayName("OAuthResponse 객체를 사용해 Member를 생성한다")
     void createMemberUsingOAuthResponse() throws Exception {
         // given
-        OAuthResponse oAuthResponse = new OAuthResponse("이메일", "닉네임", 1L, "프로필주소");
+        OAuthResponse oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", 1L, "프로필주소");
 
         // when
         Member member = Member.of(oAuthResponse);


### PR DESCRIPTION
## 👊🏻 작업 내용
프론트엔드에서 Auth Code를 입력하면 서버는 다음과 같이 동작합니다.
1. `POST https://www.googleapis.com/oauth2/v4/token` 에 요청을 보내 구글 Access Token을 받아옵니다.
2. 받아온 Access Token을 사용해서 `GET https://www.googleapis.com/oauth2/v3/userinfo`에 요청을 보냅니다.
    (profileUrl, email, name을 받아옵니다)
2-1. 회원가입된 적 없는 사용자라면 2에서 받아온 정보를 사용해 회원가입을 진행합니다.
4. DB에 저장되어 있는 정보를 바탕으로 로그인한 사용자에게 profileUrl, email 을 반환합니다.

## 🏌🏻 리뷰 포인트
리뷰하실 때 도움이 되도록 몇 가지를 적어둘게요.

**사용자가 최초로 로그인을 했을 때**
흐름이 단순하지는 않은 거 같아서 시퀀스 다이어그램을 추가했어요. 
<img width="1246" alt="스크린샷 2024-01-31 오후 1 25 45" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/fcdd84fd-0c21-4f44-bea4-d40a1af588d7">

<br>

**각 객체들의 책임**
이해를 돕기 위해 특정 객체들의 역할에 대해 설명드릴게요.
- OAuthProviderResolver : 사용자가 입력한 provider에 해당하는 Provider 객체를 찾아와서 대신 요청을 보내는 역할
OAuthProvider를 유연하게 확장할 수 있게 만들어요. 자세한 내용은 [여기](https://velog.io/@iamtaehoon/%ED%99%95%EC%9E%A5%EA%B0%80%EB%8A%A5%ED%95%9C-OAuth-%EC%9D%B8%EC%A6%9D-API-%EC%84%A4%EA%B3%84%ED%95%98%EA%B8%B0)에 적어뒀어요!

- GoogleOAuthProvider: **구글**에게 필요한 정보를 받아와서 데이터를 가공하는 역할

- GoogleOAuthClient: 실제로 요청을 보내는 역할. 내부적으로 WebClient가 사용되고 있어요.
GoogleOAuthClient는 인터페이스인데요, 해당 부분은 HttpInterface를 도입해서 외부 요청을 쉽게 보낼 수 있도록 만들었어요. [이 글](https://mangkyu.tistory.com/291) 을 참고해서 구현했어요!

## 🧘🏻 기타 사항
**login 응답에 nickname이 포함되지 않았어요**
다음 작업으로 Nickname 생성기를 개발할 생각이며 해당 단계에서 포함시킬 예정입니다.
가장 좋은 건 Mock 데이터라도 넣어 두는 건데, 아직 프론트엔드와 협업하고 있지 않은 상태라 API가 달라도 큰 의미 없다고 생각했습니다.

****
close #3 