### PR TITLE
[GymHubCommunity#5] chore: Dockerfile 생성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM gradle:8.5-jdk17 AS build
+
+WORKDIR /app
+
+COPY . /app
+
+RUN gradle clean build --no-daemon
+
+FROM amazoncorretto:17.0.10-alpine3.19
+
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar /app/gymhub.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java"]
+CMD ["-jar", "gymhub.jar"]


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X]  DockerFile 생성

## 🏌🏻 리뷰 포인트

- 저희는 현재 개발서버와 운영서버를 분리하지 않고 하나의 서버만 올려서 진행한다고 했기 때문에 dockerfile을 하나만 만들었는데요. 혹시 개발서버와 운영서버를 나누게 되면 해당 서버에 올릴 Dockerfile을 분리해서 작성해야할까요?

- 멀티 스테이지 빌드를 사용해서 빌드에는 필요하지만 최종 이미지파일에는 필요없는 부분을 줄이도록 작성했습니다.

- 포트같은 경우는 기본포트인 8080을 사용하도록 했는데 혹시 다른 의견은 있으신지 궁금합니다.


```Dockerfile
FROM gradle:8.5-jdk17 AS build

WORKDIR /app

COPY . /app

RUN gradle clean build --no-daemon

FROM amazoncorretto:17.0.10-alpine3.19

WORKDIR /app

COPY --from=build /app/build/libs/*.jar /app/gymhub.jar

EXPOSE 8080
ENTRYPOINT ["java"]
CMD ["-jar", "gymhub.jar"]
```

## 🧘🏻 기타 사항

EC2 서버에 MySQL서버도 띄우려고 하는데 해당 작업도 Docker를 사용 여부에 대해 논의해 보고 싶습니다.

close #5 