### PR TITLE
[#21] 예외 공통 처리 기능 구현

### DIFF
--- a/src/main/java/com/example/temp/exception/ApiException.java
+++ b/src/main/java/com/example/temp/exception/ApiException.java
@@ -1,0 +1,14 @@
+package com.example.temp.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/temp/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.temp.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // 공통
+    TEST(HttpStatus.BAD_REQUEST, "테스트용 예외 메시지입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/temp/exception/ErrorResponse.java
+++ b/src/main/java/com/example/temp/exception/ErrorResponse.java
@@ -1,0 +1,5 @@
+package com.example.temp.exception;
+
+public record ErrorResponse(String message) {
+
+}

--- a/src/main/java/com/example/temp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/temp/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.example.temp.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(ApiException exception) {
+        return ResponseEntity.status(exception.getErrorCode().getHttpStatus())
+            .body(new ErrorResponse(exception.getMessage()));
+    }
+}

--- a/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
+++ b/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
@@ -1,0 +1,30 @@
+package com.example.temp.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+class GlobalExceptionHandlerUnitTest {
+
+    GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("ApiException이 들어오면 ErrorCode가 들고 있는 status와 message를 반환한다.")
+    void handleApiException() throws Exception {
+        // given
+        ErrorCode errorCode = ErrorCode.TEST;
+        ApiException exception = new ApiException(errorCode);
+
+        // when
+        ResponseEntity<ErrorResponse> response = handler.handleApiException(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(errorCode.getHttpStatus());
+
+        ErrorResponse body = response.getBody();
+        assertThat(body.message()).isEqualTo(errorCode.getMessage());
+    }
+}


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] GlobalExceptionHandler 구현
- [x] ApiException 구현
- [x] ErrorCode 생성

## 🏌🏻 리뷰 포인트
GlobalExceptionHandler 테스트를 단위테스트로 만들었는데요.
나중에 @WebMvcTest 할 때 GlobalExceptionHandler도 함께 실행되면서 예외에 맞는 응답이 나가는지 테스트를 할 수 있어요.
`ex. 서비스 계층에서 UNAUTHORIZED 상태코드를 가지고 예외를 반환하면 -> 401 응답을 반환한다.`
그래서 지금 단계에서는 ApiException이 입력되면 목표한대로 동작하는지만 테스트해도 되겠다 싶어 단위테스트로 만들었습니다.

각 예외들이 잘 적용되는지는 해당 부분에서 테스트가 가능하다고 생각해요.

## 🧘🏻 기타 사항
회의했던 거처럼 Enum을 사용한 CustomException을 사용하기로 했습니다.
현재 저희에게 가장 중요한 건 "생산성"이니까요. (작업이 너무 많아요 ㅜㅜ)

경험상 커스텀 예외를 하나하나 만들어주는 것보다 Enum을 활용하는 방식이 훨씬 빨라서 해당 방식을 채택했습니다.

close #21 