### PR TITLE
[#13,#18,#19,#20, #26] 팔로우 요청 보내기/수락하기/취소/거절, 언팔로우, 팔로워/팔로잉 리스트 받기

### DIFF
--- a/src/main/java/com/example/temp/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/temp/auth/presentation/AuthController.java
@@ -3,9 +3,7 @@ package com.example.temp.auth.presentation;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 import com.example.temp.auth.dto.request.OAuthLoginRequest;
-import com.example.temp.auth.dto.response.AccessToken;
 import com.example.temp.auth.dto.response.AuthorizedUrl;
-import com.example.temp.auth.dto.response.LoginInfoResponse;
 import com.example.temp.auth.dto.response.LoginMemberResponse;
 import com.example.temp.auth.dto.response.LoginResponse;
 import com.example.temp.auth.dto.response.TokenInfo;

--- a/src/main/java/com/example/temp/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/exception/ErrorCode.java
@@ -7,7 +7,22 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 공통
-    TEST(HttpStatus.BAD_REQUEST, "테스트용 예외 메시지입니다.");
+    TEST(HttpStatus.BAD_REQUEST, "테스트용 예외 메시지입니다."),
+
+    // 인증
+    AUTHENTICATED_FAIL(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    AUTHORIZED_FAIL(HttpStatus.FORBIDDEN, "인가 권한이 없는 사용자입니다."),
+
+    // 회원
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당되는 회원을 찾을 수 없습니다."),
+
+    // 팔로우
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "두 회원 간에 팔로우 관계를 찾을 수 없습니다."),
+    FOLLOW_SELF_FAIL(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
+    FOLLOW_ALREADY_RELATED(HttpStatus.BAD_REQUEST, "둘 사이에는 이미 관계가 존재합니다."),
+    FOLLOW_STATUS_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "입력된 팔로우 상태로는 변경이 불가능합니다."),
+    FOLLOW_NOT_PENDING(HttpStatus.BAD_REQUEST, "팔로우의 상태가 PENDING이 아니므로, 해당 요청을 수행할 수 없습니다."),
+    FOLLOW_INACTIVE(HttpStatus.BAD_REQUEST, "해당 Follow는 비활성화된 상태이기 때문에, 해당 요청을 수행할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -51,6 +51,17 @@ public class FollowService {
         follow.accept();
     }
 
+    @Transactional
+    public void rejectFollowRequest(long executorId, long followId) {
+        Follow follow = followRepository.findById(followId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Follow"));
+        Member target = follow.getTo();
+        if (target.getId() != executorId) {
+            throw new IllegalArgumentException("권한없음");
+        }
+        follow.reject();
+    }
+
     private Follow saveFollow(Member fromMember, Member target) {
         Follow follow = Follow.builder()
             .from(fromMember)
@@ -59,6 +70,5 @@ public class FollowService {
             .build();
         return followRepository.save(follow);
     }
-
 }
 

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -1,0 +1,10 @@
+package com.example.temp.follow.application;
+
+import com.example.temp.follow.response.FollowResponse;
+
+public class FollowService {
+
+    public FollowResponse follow(long fromId, Long toId) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -2,6 +2,7 @@ package com.example.temp.follow.application;
 
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowRepository;
+import com.example.temp.follow.dto.response.FollowInfos;
 import com.example.temp.follow.response.FollowResponse;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
@@ -16,6 +17,15 @@ public class FollowService {
 
     private final FollowRepository followRepository;
     private final MemberRepository memberRepository;
+
+
+    public FollowInfos getFollowings(long authenticatedMemberId, long memberId) {
+        return null;
+    }
+
+    public FollowInfos getFollowers(long authenticatedMemberId, long memberId) {
+        return null;
+    }
 
     @Transactional
     public FollowResponse follow(long fromId, Long toId) {
@@ -73,5 +83,6 @@ public class FollowService {
             .build();
         return followRepository.save(follow);
     }
+
 }
 

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -33,7 +33,14 @@ public class FollowService {
     }
 
     public List<FollowInfo> getFollowers(long executorId, long targetId) {
-        return null;
+        Member target = memberRepository.findById(targetId)
+            .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
+        if (!target.isPublicAccount()) {
+            validateViewAuthorization(targetId, executorId);
+        }
+        return followRepository.findAllByToIdAndStatus(targetId, FollowStatus.SUCCESS).stream()
+            .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
+            .toList();
     }
 
     private void validateViewAuthorization(long targetId, long executorId) {

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -19,6 +19,9 @@ public class FollowService {
 
     @Transactional
     public FollowResponse follow(long fromId, Long toId) {
+        if (fromId == toId) {
+            throw new IllegalArgumentException("자기 자신을 팔로우할 수 없습니다.");
+        }
         Member fromMember = memberRepository.findById(fromId)
             .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
         Member target = memberRepository.findById(toId)

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -28,7 +28,7 @@ public class FollowService {
             validateViewAuthorization(targetId, executorId);
         }
         return followRepository.findAllByFromIdAndStatus(targetId, FollowStatus.SUCCESS).stream()
-            .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
+            .map(follow -> FollowInfo.of(follow.getTo(), follow.getId()))
             .toList();
     }
 

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -2,10 +2,12 @@ package com.example.temp.follow.application;
 
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowRepository;
-import com.example.temp.follow.dto.response.FollowInfos;
+import com.example.temp.follow.domain.FollowStatus;
+import com.example.temp.follow.dto.response.FollowInfo;
 import com.example.temp.follow.response.FollowResponse;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,11 +21,14 @@ public class FollowService {
     private final MemberRepository memberRepository;
 
 
-    public FollowInfos getFollowings(long authenticatedMemberId, long memberId) {
-        return null;
+    public List<FollowInfo> getFollowings(long executorId, long targetId) {
+        return followRepository.findAllByFromIdAndStatus(targetId, FollowStatus.SUCCESS).stream()
+            .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
+            .toList();
     }
 
-    public FollowInfos getFollowers(long authenticatedMemberId, long memberId) {
+    public List<FollowInfo> getFollowers(long executorId, long targetId) {
+
         return null;
     }
 

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -2,7 +2,6 @@ package com.example.temp.follow.application;
 
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowRepository;
-import com.example.temp.follow.domain.FollowStatus;
 import com.example.temp.follow.response.FollowResponse;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
@@ -23,7 +22,7 @@ public class FollowService {
     public FollowResponse follow(long fromId, Long toId) {
         Member fromMember = memberRepository.findById(fromId)
             .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
-        Member toMember = memberRepository.findById(toId)
+        Member target = memberRepository.findById(toId)
             .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
 
         Optional<Follow> followOpt = followRepository.findByFromIdAndToId(fromId, toId);
@@ -31,8 +30,8 @@ public class FollowService {
             // 새롭게 가입
             Follow follow = Follow.builder()
                 .from(fromMember)
-                .to(toMember)
-                .status(FollowStatus.SUCCESS)
+                .to(target)
+                .status(target.getStatusBasedOnStrategy())
                 .build();
             Follow savedFollow = followRepository.save(follow);
             return FollowResponse.from(savedFollow);
@@ -41,7 +40,7 @@ public class FollowService {
             if (follow.isValid()) {
                 throw new IllegalArgumentException("이미 둘 사이에 관계가 존재합니다.");
             }
-            follow.setStatus(FollowStatus.SUCCESS);
+            follow.setStatus(target.getStatusBasedOnStrategy());
             return FollowResponse.from(follow);
         }
     }

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -30,6 +30,11 @@ public class FollowService {
         return FollowResponse.from(savedFollow);
     }
 
+
+    public void unfollow(long fromId, Long toId) {
+
+    }
+
     private Follow saveFollow(Member fromMember, Member target) {
         Follow follow = Follow.builder()
             .from(fromMember)

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -30,15 +30,25 @@ public class FollowService {
         return FollowResponse.from(savedFollow);
     }
 
-
+    @Transactional
     public void unfollow(long fromId, Long toId) {
         if (!memberRepository.existsById(toId)) {
             throw new IllegalArgumentException("찾을 수 없는 사용자");
         }
-
         Follow follow = followRepository.findByFromIdAndToId(fromId, toId)
             .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 관계"));
         follow.unfollow();
+    }
+
+    @Transactional
+    public void acceptFollowRequest(long targetId, Long followId) {
+        Follow follow = followRepository.findById(followId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Follow"));
+        Member target = follow.getTo();
+        if (target.getId() != targetId) {
+            throw new IllegalArgumentException("권한없음");
+        }
+        follow.accept();
     }
 
     private Follow saveFollow(Member fromMember, Member target) {
@@ -49,5 +59,6 @@ public class FollowService {
             .build();
         return followRepository.save(follow);
     }
+
 }
 

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -1,10 +1,48 @@
 package com.example.temp.follow.application;
 
+import com.example.temp.follow.domain.Follow;
+import com.example.temp.follow.domain.FollowRepository;
+import com.example.temp.follow.domain.FollowStatus;
 import com.example.temp.follow.response.FollowResponse;
+import com.example.temp.member.domain.Member;
+import com.example.temp.member.domain.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class FollowService {
 
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
     public FollowResponse follow(long fromId, Long toId) {
-        return null;
+        Member fromMember = memberRepository.findById(fromId)
+            .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
+        Member toMember = memberRepository.findById(toId)
+            .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
+
+        Optional<Follow> followOpt = followRepository.findByFromIdAndToId(fromId, toId);
+        if (followOpt.isEmpty()) {
+            // 새롭게 가입
+            Follow follow = Follow.builder()
+                .from(fromMember)
+                .to(toMember)
+                .status(FollowStatus.SUCCESS)
+                .build();
+            Follow savedFollow = followRepository.save(follow);
+            return FollowResponse.from(savedFollow);
+        } else {
+            Follow follow = followOpt.get();
+            if (follow.isValid()) {
+                throw new IllegalArgumentException("이미 둘 사이에 관계가 존재합니다.");
+            }
+            follow.setStatus(FollowStatus.SUCCESS);
+            return FollowResponse.from(follow);
+        }
     }
 }

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -22,13 +22,30 @@ public class FollowService {
 
 
     public List<FollowInfo> getFollowings(long executorId, long targetId) {
+        Member target = memberRepository.findById(targetId)
+            .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
+        if (!target.isPublicAccount()) {
+            validateAuthorization(targetId, executorId);
+        }
         return followRepository.findAllByFromIdAndStatus(targetId, FollowStatus.SUCCESS).stream()
             .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
             .toList();
     }
 
-    public List<FollowInfo> getFollowers(long executorId, long targetId) {
+    private void validateAuthorization(long targetId, long executorId) {
+        if (targetId == executorId) {
+            return;
+        }
+        if (!isTargetsFollower(targetId, executorId)) {
+            throw new IllegalArgumentException("권한없음");
+        }
+    }
 
+    private boolean isTargetsFollower(long targetId, long executorId) {
+        return followRepository.checkExecutorFollowsTarget(executorId, targetId);
+    }
+
+    public List<FollowInfo> getFollowers(long executorId, long targetId) {
         return null;
     }
 

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -25,15 +25,19 @@ public class FollowService {
         Member target = memberRepository.findById(targetId)
             .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
         if (!target.isPublicAccount()) {
-            validateAuthorization(targetId, executorId);
+            validateViewAuthorization(targetId, executorId);
         }
         return followRepository.findAllByFromIdAndStatus(targetId, FollowStatus.SUCCESS).stream()
             .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
             .toList();
     }
 
-    private void validateAuthorization(long targetId, long executorId) {
-        if (targetId == executorId) {
+    public List<FollowInfo> getFollowers(long executorId, long targetId) {
+        return null;
+    }
+
+    private void validateViewAuthorization(long targetId, long executorId) {
+        if (isMyAccount(targetId, executorId)) {
             return;
         }
         if (!isTargetsFollower(targetId, executorId)) {
@@ -41,36 +45,45 @@ public class FollowService {
         }
     }
 
+    private boolean isMyAccount(long targetId, long executorId) {
+        return targetId == executorId;
+    }
+
     private boolean isTargetsFollower(long targetId, long executorId) {
         return followRepository.checkExecutorFollowsTarget(executorId, targetId);
     }
 
-    public List<FollowInfo> getFollowers(long executorId, long targetId) {
-        return null;
-    }
-
     @Transactional
-    public FollowResponse follow(long fromId, Long toId) {
-        if (fromId == toId) {
+    public FollowResponse follow(long executorId, Long targetId) {
+        if (isMyAccount(executorId, targetId)) {
             throw new IllegalArgumentException("자기 자신을 팔로우할 수 없습니다.");
         }
-        Member fromMember = memberRepository.findById(fromId)
+        Member fromMember = memberRepository.findById(executorId)
             .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
-        Member target = memberRepository.findById(toId)
+        Member target = memberRepository.findById(targetId)
             .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 사용자"));
 
-        Follow savedFollow = followRepository.findByFromIdAndToId(fromId, toId)
+        Follow savedFollow = followRepository.findByFromIdAndToId(executorId, targetId)
             .map(follow -> follow.reactive(target.getStatusBasedOnStrategy()))
             .orElseGet(() -> saveFollow(fromMember, target));
         return FollowResponse.from(savedFollow);
     }
 
+    private Follow saveFollow(Member fromMember, Member target) {
+        Follow follow = Follow.builder()
+            .from(fromMember)
+            .to(target)
+            .status(target.getStatusBasedOnStrategy())
+            .build();
+        return followRepository.save(follow);
+    }
+
     @Transactional
-    public void unfollow(long fromId, Long toId) {
-        if (!memberRepository.existsById(toId)) {
+    public void unfollow(long executorId, Long targetId) {
+        if (!memberRepository.existsById(targetId)) {
             throw new IllegalArgumentException("찾을 수 없는 사용자");
         }
-        Follow follow = followRepository.findByFromIdAndToId(fromId, toId)
+        Follow follow = followRepository.findByFromIdAndToId(executorId, targetId)
             .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 관계"));
         follow.unfollow();
     }
@@ -91,19 +104,10 @@ public class FollowService {
         Follow follow = followRepository.findById(followId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Follow"));
         Member target = follow.getTo();
-        if (target.getId() != executorId) {
+        if (!isMyAccount(target.getId(), executorId)) {
             throw new IllegalArgumentException("권한없음");
         }
         follow.reject();
-    }
-
-    private Follow saveFollow(Member fromMember, Member target) {
-        Follow follow = Follow.builder()
-            .from(fromMember)
-            .to(target)
-            .status(target.getStatusBasedOnStrategy())
-            .build();
-        return followRepository.save(follow);
     }
 
 }

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -32,7 +32,13 @@ public class FollowService {
 
 
     public void unfollow(long fromId, Long toId) {
+        if (!memberRepository.existsById(toId)) {
+            throw new IllegalArgumentException("찾을 수 없는 사용자");
+        }
 
+        Follow follow = followRepository.findByFromIdAndToId(fromId, toId)
+            .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 관계"));
+        follow.unfollow();
     }
 
     private Follow saveFollow(Member fromMember, Member target) {

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -41,7 +41,7 @@ public class FollowService {
         if (!target.isPublicAccount()) {
             validateViewAuthorization(targetId, executorId);
         }
-        return followRepository.findAllByFromIdAndStatus(targetId, FollowStatus.SUCCESS).stream()
+        return followRepository.findAllByFromIdAndStatus(targetId, FollowStatus.APPROVED).stream()
             .map(follow -> FollowInfo.of(follow.getTo(), follow.getId()))
             .toList();
     }
@@ -60,7 +60,7 @@ public class FollowService {
         if (!target.isPublicAccount()) {
             validateViewAuthorization(targetId, executorId);
         }
-        return followRepository.findAllByToIdAndStatus(targetId, FollowStatus.SUCCESS).stream()
+        return followRepository.findAllByToIdAndStatus(targetId, FollowStatus.APPROVED).stream()
             .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
             .toList();
     }
@@ -124,7 +124,6 @@ public class FollowService {
      * @param targetId   언팔로우 하려는 대상의 ID
      * @throws ApiException MEMBER_NOT_FOUND: 언팔로우를 하려는 대상을 찾을 수 없을 때 발생합니다.
      * @throws ApiException FOLLOW_INACTIVE: 팔로우가 이미 비활성화되어있을 때 발생합니다.
-
      */
     @Transactional
     public void unfollow(long executorId, Long targetId) {

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -20,6 +20,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "follows")
@@ -41,6 +42,7 @@ public class Follow {
     private Member to;
 
     @Enumerated(value = EnumType.STRING)
+    @Setter
     private FollowStatus status;
 
     @Builder

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -61,4 +61,10 @@ public class Follow {
         return this;
     }
 
+    public void unfollow() {
+        if (!isActive()) {
+            throw new IllegalArgumentException("이미 비활성화된 관계입니다.");
+        }
+        this.status = FollowStatus.CANCELED;
+    }
 }

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -51,4 +51,16 @@ public class Follow {
     public boolean isActive() {
         return getStatus().isActive();
     }
+
+    public Follow reactive(FollowStatus changedStatus) {
+        if (!changedStatus.isActive()) {
+            throw new IllegalArgumentException("해당 상태로는 변경할 수 없습니다.");
+        }
+        if (isActive()) {
+            throw new IllegalArgumentException("이미 둘 사이에 관계가 존재합니다.");
+        }
+        this.status = changedStatus;
+        return this;
+    }
+
 }

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -1,0 +1,48 @@
+package com.example.temp.follow.domain;
+
+import com.example.temp.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "follows")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_id")
+    private Member from;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_id")
+    private Member to;
+
+    @Enumerated(value = EnumType.STRING)
+    private FollowStatus status;
+
+    @Builder
+    private Follow(Member from, Member to, FollowStatus status) {
+        this.from = from;
+        this.to = to;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -61,6 +61,13 @@ public class Follow {
         return this;
     }
 
+    public void accept() {
+        if (this.getStatus() != FollowStatus.PENDING) {
+            throw new IllegalArgumentException("잘못된 상태입니다.");
+        }
+        this.status = FollowStatus.SUCCESS;
+    }
+
     public void unfollow() {
         if (!isActive()) {
             throw new IllegalArgumentException("이미 비활성화된 관계입니다.");

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -1,5 +1,8 @@
 package com.example.temp.follow.domain;
 
+import static com.example.temp.follow.domain.FollowStatus.PENDING;
+import static com.example.temp.follow.domain.FollowStatus.SUCCESS;
+
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,5 +48,9 @@ public class Follow {
         this.from = from;
         this.to = to;
         this.status = status;
+    }
+
+    public boolean isValid() {
+        return List.of(SUCCESS, PENDING).contains(getStatus());
     }
 }

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -16,7 +16,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "follows")
@@ -38,7 +37,6 @@ public class Follow {
     private Member to;
 
     @Enumerated(value = EnumType.STRING)
-    @Setter
     private FollowStatus status;
 
     @Builder

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -1,8 +1,5 @@
 package com.example.temp.follow.domain;
 
-import static com.example.temp.follow.domain.FollowStatus.PENDING;
-import static com.example.temp.follow.domain.FollowStatus.SUCCESS;
-
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -51,7 +48,7 @@ public class Follow {
         this.status = status;
     }
 
-    public boolean isValid() {
-        return getStatus().isValid();
+    public boolean isActive() {
+        return getStatus().isActive();
     }
 }

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -65,13 +65,22 @@ public class Follow {
         if (this.getStatus() != FollowStatus.PENDING) {
             throw new IllegalArgumentException("잘못된 상태입니다.");
         }
-        this.status = FollowStatus.SUCCESS;
+        changeStatus(FollowStatus.SUCCESS);
     }
 
     public void unfollow() {
+        changeStatus(FollowStatus.CANCELED);
+    }
+
+    public void reject() {
+        changeStatus(FollowStatus.REJECTED);
+    }
+
+    private void changeStatus(FollowStatus status) {
         if (!isActive()) {
             throw new IllegalArgumentException("이미 비활성화된 관계입니다.");
         }
-        this.status = FollowStatus.CANCELED;
+        this.status = status;
     }
+
 }

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -15,7 +15,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,6 +52,6 @@ public class Follow {
     }
 
     public boolean isValid() {
-        return List.of(SUCCESS, PENDING).contains(getStatus());
+        return getStatus().isValid();
     }
 }

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -71,7 +71,7 @@ public class Follow {
         if (this.getStatus() != FollowStatus.PENDING) {
             throw new ApiException(FOLLOW_NOT_PENDING);
         }
-        changeStatus(FollowStatus.SUCCESS);
+        changeStatus(FollowStatus.APPROVED);
     }
 
     public void unfollow() {

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -1,5 +1,11 @@
 package com.example.temp.follow.domain;
 
+import static com.example.temp.exception.ErrorCode.FOLLOW_ALREADY_RELATED;
+import static com.example.temp.exception.ErrorCode.FOLLOW_INACTIVE;
+import static com.example.temp.exception.ErrorCode.FOLLOW_NOT_PENDING;
+import static com.example.temp.exception.ErrorCode.FOLLOW_STATUS_CHANGE_NOT_ALLOWED;
+
+import com.example.temp.exception.ApiException;
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -52,10 +58,10 @@ public class Follow {
 
     public Follow reactive(FollowStatus changedStatus) {
         if (!changedStatus.isActive()) {
-            throw new IllegalArgumentException("해당 상태로는 변경할 수 없습니다.");
+            throw new ApiException(FOLLOW_STATUS_CHANGE_NOT_ALLOWED);
         }
         if (isActive()) {
-            throw new IllegalArgumentException("이미 둘 사이에 관계가 존재합니다.");
+            throw new ApiException(FOLLOW_ALREADY_RELATED);
         }
         this.status = changedStatus;
         return this;
@@ -63,7 +69,7 @@ public class Follow {
 
     public void accept() {
         if (this.getStatus() != FollowStatus.PENDING) {
-            throw new IllegalArgumentException("잘못된 상태입니다.");
+            throw new ApiException(FOLLOW_NOT_PENDING);
         }
         changeStatus(FollowStatus.SUCCESS);
     }
@@ -78,7 +84,7 @@ public class Follow {
 
     private void changeStatus(FollowStatus status) {
         if (!isActive()) {
-            throw new IllegalArgumentException("이미 비활성화된 관계입니다.");
+            throw new ApiException(FOLLOW_INACTIVE);
         }
         this.status = status;
     }

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -1,9 +1,12 @@
 package com.example.temp.follow.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByFromIdAndToId(long fromId, Long toId);
+
+    List<Follow> findAllByFromIdAndStatus(long fromId, FollowStatus status);
 }

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -1,0 +1,9 @@
+package com.example.temp.follow.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    Optional<Follow> findByFromIdAndToId(long fromId, Long toId);
+}

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -11,7 +11,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     List<Follow> findAllByFromIdAndStatus(long fromId, FollowStatus status);
 
+    List<Follow> findAllByToIdAndStatus(long toId, FollowStatus status);
+
     @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END FROM Follow f"
         + " WHERE f.from.id = :executorId AND f.to.id = :targetId and f.status = 'SUCCESS'")
     boolean checkExecutorFollowsTarget(long executorId, long targetId);
+
 }

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -3,10 +3,15 @@ package com.example.temp.follow.domain;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByFromIdAndToId(long fromId, Long toId);
 
     List<Follow> findAllByFromIdAndStatus(long fromId, FollowStatus status);
+
+    @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END FROM Follow f"
+        + " WHERE f.from.id = :executorId AND f.to.id = :targetId and f.status = 'SUCCESS'")
+    boolean checkExecutorFollowsTarget(long executorId, long targetId);
 }

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -17,7 +17,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findAllByToIdAndStatus(@Param("toId") long toId, @Param("status") FollowStatus status);
 
     @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END FROM Follow f"
-        + " WHERE f.from.id = :executorId AND f.to.id = :targetId and f.status = 'SUCCESS'")
+        + " WHERE f.from.id = :executorId AND f.to.id = :targetId and f.status = 'APPROVED'")
     boolean checkExecutorFollowsTarget(@Param("executorId") long executorId, @Param("targetId") long targetId);
 
 }

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -10,9 +10,11 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByFromIdAndToId(long fromId, Long toId);
 
+    @Query("SELECT f FROM Follow f join fetch f.to where f.from.id = :fromId and f.status = :status")
     List<Follow> findAllByFromIdAndStatus(long fromId, FollowStatus status);
 
-    List<Follow> findAllByToIdAndStatus(long toId, FollowStatus status);
+    @Query("SELECT f FROM Follow f join fetch f.from where f.to.id = :toId and f.status = :status")
+    List<Follow> findAllByToIdAndStatus(@Param("toId") long toId, @Param("status") FollowStatus status);
 
     @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END FROM Follow f"
         + " WHERE f.from.id = :executorId AND f.to.id = :targetId and f.status = 'SUCCESS'")

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
@@ -15,6 +16,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END FROM Follow f"
         + " WHERE f.from.id = :executorId AND f.to.id = :targetId and f.status = 'SUCCESS'")
-    boolean checkExecutorFollowsTarget(long executorId, long targetId);
+    boolean checkExecutorFollowsTarget(@Param("executorId") long executorId, @Param("targetId") long targetId);
 
 }

--- a/src/main/java/com/example/temp/follow/domain/FollowStatus.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowStatus.java
@@ -1,5 +1,7 @@
 package com.example.temp.follow.domain;
 
+import java.util.List;
+
 public enum FollowStatus {
     SUCCESS("성공"),
     PENDING("보류"),
@@ -10,5 +12,9 @@ public enum FollowStatus {
 
     FollowStatus(String text) {
         this.text = text;
+    }
+
+    public boolean isValid() {
+        return List.of(SUCCESS, PENDING).contains(this);
     }
 }

--- a/src/main/java/com/example/temp/follow/domain/FollowStatus.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowStatus.java
@@ -3,10 +3,10 @@ package com.example.temp.follow.domain;
 import java.util.List;
 
 public enum FollowStatus {
-    SUCCESS("성공"),
-    PENDING("보류"),
-    REJECTED("거절"),
-    CANCELED("취소");
+    SUCCESS("현재 팔로우중인 상태"),
+    PENDING("팔로우 요청이 승인되지 않은 상태"),
+    REJECTED("팔로우 요청을 거절한 상태"),
+    CANCELED("기존 팔로우를 취소한 상태");
 
     private final String text;
 

--- a/src/main/java/com/example/temp/follow/domain/FollowStatus.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowStatus.java
@@ -3,7 +3,7 @@ package com.example.temp.follow.domain;
 import java.util.List;
 
 public enum FollowStatus {
-    SUCCESS("현재 팔로우중인 상태"),
+    APPROVED("팔로우가 승인된 상태"),
     PENDING("팔로우 요청이 승인되지 않은 상태"),
     REJECTED("팔로우 요청을 거절한 상태"),
     CANCELED("기존 팔로우를 취소한 상태");
@@ -15,6 +15,6 @@ public enum FollowStatus {
     }
 
     public boolean isActive() {
-        return List.of(SUCCESS, PENDING).contains(this);
+        return List.of(APPROVED, PENDING).contains(this);
     }
 }

--- a/src/main/java/com/example/temp/follow/domain/FollowStatus.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowStatus.java
@@ -14,7 +14,7 @@ public enum FollowStatus {
         this.text = text;
     }
 
-    public boolean isValid() {
+    public boolean isActive() {
         return List.of(SUCCESS, PENDING).contains(this);
     }
 }

--- a/src/main/java/com/example/temp/follow/domain/FollowStatus.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowStatus.java
@@ -1,0 +1,5 @@
+package com.example.temp.follow.domain;
+
+public enum FollowStatus {
+
+}

--- a/src/main/java/com/example/temp/follow/domain/FollowStatus.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowStatus.java
@@ -1,5 +1,14 @@
 package com.example.temp.follow.domain;
 
 public enum FollowStatus {
+    SUCCESS("성공"),
+    PENDING("보류"),
+    REJECTED("거절"),
+    CANCELED("취소");
 
+    private final String text;
+
+    FollowStatus(String text) {
+        this.text = text;
+    }
 }

--- a/src/main/java/com/example/temp/follow/dto/response/FollowInfo.java
+++ b/src/main/java/com/example/temp/follow/dto/response/FollowInfo.java
@@ -1,5 +1,14 @@
 package com.example.temp.follow.dto.response;
 
-public record FollowInfo() {
+import com.example.temp.member.domain.Member;
 
+public record FollowInfo(
+    Long id,
+    Long memberId,
+    String profileUrl
+) {
+
+    public static FollowInfo of(Member member, Long id) {
+        return new FollowInfo(id, member.getId(), member.getProfileUrl());
+    }
 }

--- a/src/main/java/com/example/temp/follow/dto/response/FollowInfo.java
+++ b/src/main/java/com/example/temp/follow/dto/response/FollowInfo.java
@@ -1,0 +1,5 @@
+package com.example.temp.follow.dto.response;
+
+public record FollowInfo() {
+
+}

--- a/src/main/java/com/example/temp/follow/dto/response/FollowInfos.java
+++ b/src/main/java/com/example/temp/follow/dto/response/FollowInfos.java
@@ -1,5 +1,10 @@
 package com.example.temp.follow.dto.response;
 
+import java.util.List;
+
 public record FollowInfos() {
 
+    public static FollowInfos from(List<FollowInfo> infos) {
+        return null;
+    }
 }

--- a/src/main/java/com/example/temp/follow/dto/response/FollowInfos.java
+++ b/src/main/java/com/example/temp/follow/dto/response/FollowInfos.java
@@ -1,0 +1,5 @@
+package com.example.temp.follow.dto.response;
+
+public record FollowInfos() {
+
+}

--- a/src/main/java/com/example/temp/follow/dto/response/FollowInfos.java
+++ b/src/main/java/com/example/temp/follow/dto/response/FollowInfos.java
@@ -2,9 +2,11 @@ package com.example.temp.follow.dto.response;
 
 import java.util.List;
 
-public record FollowInfos() {
+public record FollowInfos(
+    List<FollowInfo> follows
+) {
 
     public static FollowInfos from(List<FollowInfo> infos) {
-        return null;
+        return new FollowInfos(infos);
     }
 }

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -1,8 +1,10 @@
 package com.example.temp.follow.presentation;
 
 import com.example.temp.follow.application.FollowService;
+import com.example.temp.follow.dto.response.FollowInfo;
 import com.example.temp.follow.dto.response.FollowInfos;
 import com.example.temp.follow.response.FollowResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,14 +26,14 @@ public class FollowController {
 
     @GetMapping("/members/{memberId}/followings")
     public ResponseEntity<FollowInfos> getFollowings(@PathVariable Long memberId) {
-        FollowInfos followInfos = followService.getFollowings(AUTHENTICATED_MEMBER_ID, memberId);
-        return ResponseEntity.ok(followInfos);
+        List<FollowInfo> followInfos = followService.getFollowings(AUTHENTICATED_MEMBER_ID, memberId);
+        return ResponseEntity.ok(FollowInfos.from(followInfos));
     }
 
     @GetMapping("/members/{memberId}/followers")
     public ResponseEntity<FollowInfos> getFollowers(@PathVariable Long memberId) {
-        FollowInfos followInfos = followService.getFollowers(AUTHENTICATED_MEMBER_ID, memberId);
-        return ResponseEntity.ok(followInfos);
+        List<FollowInfo> followInfos = followService.getFollowers(AUTHENTICATED_MEMBER_ID, memberId);
+        return ResponseEntity.ok(FollowInfos.from(followInfos));
     }
 
     @PostMapping("/members/{memberId}/follow")

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -1,10 +1,12 @@
 package com.example.temp.follow.presentation;
 
 import com.example.temp.follow.application.FollowService;
+import com.example.temp.follow.dto.response.FollowInfos;
 import com.example.temp.follow.response.FollowResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +21,18 @@ public class FollowController {
     public static final long AUTHENTICATED_MEMBER_ID = 1L;
 
     private final FollowService followService;
+
+    @GetMapping("/members/{memberId}/followings")
+    public ResponseEntity<FollowInfos> getFollowings(@PathVariable Long memberId) {
+        FollowInfos followInfos = followService.getFollowings(AUTHENTICATED_MEMBER_ID, memberId);
+        return ResponseEntity.ok(followInfos);
+    }
+
+    @GetMapping("/members/{memberId}/followers")
+    public ResponseEntity<FollowInfos> getFollowers(@PathVariable Long memberId) {
+        FollowInfos followInfos = followService.getFollowers(AUTHENTICATED_MEMBER_ID, memberId);
+        return ResponseEntity.ok(followInfos);
+    }
 
     @PostMapping("/members/{memberId}/follow")
     public ResponseEntity<FollowResponse> follow(@PathVariable Long memberId) {

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -25,4 +25,10 @@ public class FollowController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/members/{memberId}/unfollow")
+    public ResponseEntity<Void> unfollow(@PathVariable Long memberId) {
+        followService.unfollow(AUTHENTICATED_MEMBER_ID, memberId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -4,6 +4,7 @@ import com.example.temp.follow.application.FollowService;
 import com.example.temp.follow.response.FollowResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,6 +35,12 @@ public class FollowController {
     @PostMapping("/follows/{followId}")
     public ResponseEntity<Void> acceptFollowRequest(@PathVariable Long followId) {
         followService.acceptFollowRequest(AUTHENTICATED_MEMBER_ID, followId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/follows/{followId}")
+    public ResponseEntity<Void> rejectFollowRequest(@PathVariable Long followId) {
+        followService.rejectFollowRequest(AUTHENTICATED_MEMBER_ID, followId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -1,0 +1,28 @@
+package com.example.temp.follow.presentation;
+
+import com.example.temp.follow.application.FollowService;
+import com.example.temp.follow.response.FollowResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FollowController {
+
+    /**
+     * 로그인된 사용자의 ID를 모킹했습니다. 현재 access token을 통해 사용자의 id를 받아오는 로직이 만들어지지 않아, 임시로 사용중입니다.
+     */
+    public static final long AUTHENTICATED_MEMBER_ID = 1L;
+
+    private final FollowService followService;
+
+    @PostMapping("/members/{memberId}/follow")
+    public ResponseEntity<FollowResponse> follow(@PathVariable Long memberId) {
+        FollowResponse response = followService.follow(AUTHENTICATED_MEMBER_ID, memberId);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -31,4 +31,9 @@ public class FollowController {
         return ResponseEntity.noContent().build();
     }
 
+    @PostMapping("/follows/{followId}")
+    public ResponseEntity<Void> acceptFollowRequest(@PathVariable Long followId) {
+        followService.acceptFollowRequest(AUTHENTICATED_MEMBER_ID, followId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/temp/follow/response/FollowResponse.java
+++ b/src/main/java/com/example/temp/follow/response/FollowResponse.java
@@ -1,0 +1,10 @@
+package com.example.temp.follow.response;
+
+import com.example.temp.follow.domain.FollowStatus;
+
+public record FollowResponse(
+    long id,
+    FollowStatus status
+) {
+
+}

--- a/src/main/java/com/example/temp/follow/response/FollowResponse.java
+++ b/src/main/java/com/example/temp/follow/response/FollowResponse.java
@@ -1,5 +1,6 @@
 package com.example.temp.follow.response;
 
+import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowStatus;
 
 public record FollowResponse(
@@ -7,4 +8,7 @@ public record FollowResponse(
     FollowStatus status
 ) {
 
+    public static FollowResponse from(Follow follow) {
+        return new FollowResponse(follow.getId(), follow.getStatus());
+    }
 }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -30,7 +30,7 @@ public class MemberService {
      * @throws NicknameDuplicatedException 중복된 닉네임으로 Member를 저장하려 할 때 발생합니다.
      */
     @Transactional
-    @Retryable(retryFor = NicknameDuplicatedException.class, maxAttempts = LOOP_MAX_CNT)
+    @Retryable(retryFor = NicknameDuplicatedException.class, maxAttempts = LOOP_MAX_CNT, backoff = @Backoff(delay = 0))
     public Member register(OAuthResponse oAuthResponse) {
         try {
             String nickname = nicknameGenerator.generate();

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -7,6 +7,7 @@ import com.example.temp.member.infrastructure.nickname.NicknameGenerator;
 import com.example.temp.oauth.OAuthResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/example/temp/member/domain/FollowStrategy.java
+++ b/src/main/java/com/example/temp/member/domain/FollowStrategy.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 public enum FollowStrategy {
-    EAGER("팔로우 요청 즉시 팔로우가 되는 전략", FollowStatus.SUCCESS),
+    EAGER("팔로우 요청 즉시 팔로우가 되는 전략", FollowStatus.APPROVED),
     LAZY("팔로우 요청이 들어오면 사용자가 확인 후 허가하는 전략", FollowStatus.PENDING);
 
     private final String text;

--- a/src/main/java/com/example/temp/member/domain/FollowStrategy.java
+++ b/src/main/java/com/example/temp/member/domain/FollowStrategy.java
@@ -1,0 +1,18 @@
+package com.example.temp.member.domain;
+
+import com.example.temp.follow.domain.FollowStatus;
+import lombok.Getter;
+
+@Getter
+public enum FollowStrategy {
+    EAGER("팔로우 요청 즉시 팔로우가 되는 전략", FollowStatus.SUCCESS),
+    LAZY("팔로우 요청이 들어오면 사용자가 확인 후 허가하는 전략", FollowStatus.PENDING);
+
+    private final String text;
+    private final FollowStatus followStatus;
+
+    FollowStrategy(String text, FollowStatus followStatus) {
+        this.text = text;
+        this.followStatus = followStatus;
+    }
+}

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.example.temp.member.domain;
 
+import com.example.temp.follow.domain.FollowStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,10 +32,17 @@ public class Member {
     @Column(nullable = false, unique = true)
     private String nickname;
 
+    private FollowStrategy followStrategy;
+
     @Builder
-    private Member(String email, String profileUrl, String nickname) {
+    private Member(String email, String profileUrl, String nickname, FollowStrategy followStrategy) {
         this.email = email;
         this.profileUrl = profileUrl;
         this.nickname = nickname;
+        this.followStrategy = followStrategy;
+    }
+
+    public FollowStatus getStatusBasedOnStrategy() {
+        return followStrategy.getFollowStatus();
     }
 }

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -3,6 +3,8 @@ package com.example.temp.member.domain;
 import com.example.temp.follow.domain.FollowStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,6 +34,7 @@ public class Member {
     @Column(nullable = false, unique = true)
     private String nickname;
 
+    @Enumerated(EnumType.STRING)
     private FollowStrategy followStrategy;
 
     private boolean publicAccount;

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -35,6 +35,7 @@ public class Member {
     private String nickname;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private FollowStrategy followStrategy;
 
     private boolean publicAccount;

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -34,12 +34,16 @@ public class Member {
 
     private FollowStrategy followStrategy;
 
+    private boolean publicAccount;
+
     @Builder
-    private Member(String email, String profileUrl, String nickname, FollowStrategy followStrategy) {
+    private Member(String email, String profileUrl, String nickname,
+        FollowStrategy followStrategy, boolean publicAccount) {
         this.email = email;
         this.profileUrl = profileUrl;
         this.nickname = nickname;
         this.followStrategy = followStrategy;
+        this.publicAccount = publicAccount;
     }
 
     public FollowStatus getStatusBasedOnStrategy() {

--- a/src/main/java/com/example/temp/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/oauth/OAuthResponse.java
@@ -1,5 +1,6 @@
 package com.example.temp.oauth;
 
+import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 
 public record OAuthResponse(
@@ -20,6 +21,8 @@ public record OAuthResponse(
             .email(this.email())
             .profileUrl(this.profileUrl())
             .nickname(nickname)
+            .followStrategy(FollowStrategy.EAGER)
+            .publicAccount(true)
             .build();
     }
 }

--- a/src/main/java/com/example/temp/oauth/domain/OAuthInfo.java
+++ b/src/main/java/com/example/temp/oauth/domain/OAuthInfo.java
@@ -4,6 +4,8 @@ import com.example.temp.member.domain.Member;
 import com.example.temp.oauth.OAuthProviderType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -30,6 +32,7 @@ public class OAuthInfo {
     @Column(nullable = false)
     private String idUsingResourceServer;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private OAuthProviderType type;
 

--- a/src/test/java/com/example/temp/auth/dto/response/LoginMemberResponseTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/LoginMemberResponseTest.java
@@ -2,6 +2,7 @@ package com.example.temp.auth.dto.response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,7 @@ class LoginMemberResponseTest {
             .email("이멜")
             .profileUrl("프로필주소")
             .nickname("생성된 닉네임")
+            .followStrategy(FollowStrategy.EAGER)
             .build();
         em.persist(member);
 

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -155,6 +155,46 @@ class FollowServiceTest {
             .hasMessageContaining("찾을 수 없는 사용자");
     }
 
+    @Test
+    @DisplayName("언팔로우한다.")
+    void unfollowSuccess() throws Exception {
+        // given
+        Member fromMember = saveMember();
+        Member target = saveMember();
+        Follow follow = saveFollow(fromMember, target, FollowStatus.SUCCESS);
+
+        // when
+        followService.unfollow(fromMember.getId(), target.getId());
+
+        // then
+        assertThat(follow.getStatus()).isEqualTo(FollowStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("기존에 팔로우 관계가 존재하지 않으면 언팔로우를 할 수 없다.")
+    void unfollowFailFollowNotFound() throws Exception {
+        // given
+        Member fromMember = saveMember();
+        Member target = saveMember();
+
+        // when & then
+        assertThatThrownBy(() -> followService.unfollow(fromMember.getId(), target.getId()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("찾을 수 없는 관계");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 대상에게 언팔로우를 할 수 없다")
+    void unfollowFailTargetNotFound() throws Exception {
+        // given
+        Member fromMember = saveMember();
+
+        // when & then
+        assertThatThrownBy(() -> followService.unfollow(fromMember.getId(), notExistMemberId))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("찾을 수 없는 사용자");
+    }
+
     private void validateFollowResponse(FollowResponse response, Member fromMember, Member toMember) {
         Follow result = em.find(Follow.class, response.id());
         assertThat(result.getId()).isNotNull();

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -308,7 +308,7 @@ class FollowServiceTest {
         // then
         assertThat(infos).hasSize(successCnt)
             .containsAnyElementsOf(targetFollowInfos);
-        assertThat(infos.get(0).id()).isNotEqualTo(target.getId());
+        assertThat(infos.get(0).memberId()).isNotEqualTo(target.getId());
     }
 
     @Test
@@ -382,6 +382,28 @@ class FollowServiceTest {
         assertThatThrownBy(() -> followService.getFollowings(anotherMember.getId(), publicAccountMember.getId()))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("권한없음");
+    }
+
+    @Test
+    @DisplayName("특정 사용자가 팔로우한 사람들을 전부 보여준다.")
+    void getFollowersSuccess() throws Exception {
+        // given
+        Member target = saveMember();
+        int successCnt = 10;
+        List<Member> members = saveMembers(successCnt);
+        List<Follow> targetFollows = saveTargetFollowers(FollowStatus.SUCCESS, target, members, 0, successCnt);
+
+        List<FollowInfo> targetFollowInfos = targetFollows.stream()
+            .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
+            .toList();
+
+        // when
+        List<FollowInfo> infos = followService.getFollowers(target.getId(), target.getId());
+
+        // then
+        assertThat(infos).hasSize(successCnt)
+            .containsAnyElementsOf(targetFollowInfos);
+        assertThat(infos.get(0).memberId()).isNotEqualTo(target.getId());
     }
 
     @Test

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -75,7 +75,7 @@ class FollowServiceTest {
     }
 
     @Test
-    @DisplayName("팔로우를 할 때, target의 전략이 EAGER면 SUCCESS 상태의 follow가 생성된다.")
+    @DisplayName("팔로우를 할 때, target의 전략이 EAGER면 APPROVED 상태의 follow가 생성된다.")
     void validateCreateSuccessFollowThatTargetStrategyIsEager() throws Exception {
         // given
         Member fromMember = saveMember();
@@ -85,7 +85,7 @@ class FollowServiceTest {
         FollowResponse response = followService.follow(fromMember.getId(), toMember.getId());
 
         // then
-        assertThat(response.status()).isEqualTo(FollowStatus.SUCCESS);
+        assertThat(response.status()).isEqualTo(FollowStatus.APPROVED);
     }
 
     @Test
@@ -108,7 +108,7 @@ class FollowServiceTest {
         // given
         Member fromMember = saveMember();
         Member toMember = saveMember();
-        saveFollow(fromMember, toMember, FollowStatus.SUCCESS);
+        saveFollow(fromMember, toMember, FollowStatus.APPROVED);
 
         // when & then
         assertThatThrownBy(() -> followService.follow(fromMember.getId(), toMember.getId()))
@@ -143,7 +143,7 @@ class FollowServiceTest {
         FollowResponse response = followService.follow(fromMember.getId(), toMember.getId());
 
         // then
-        assertThat(response.status()).isEqualTo(FollowStatus.SUCCESS);
+        assertThat(response.status()).isEqualTo(FollowStatus.APPROVED);
         validateFollowResponse(response, fromMember, toMember);
     }
 
@@ -178,7 +178,7 @@ class FollowServiceTest {
         // given
         Member fromMember = saveMember();
         Member target = saveMember();
-        Follow follow = saveFollow(fromMember, target, FollowStatus.SUCCESS);
+        Follow follow = saveFollow(fromMember, target, FollowStatus.APPROVED);
 
         // when
         followService.unfollow(fromMember.getId(), target.getId());
@@ -224,7 +224,7 @@ class FollowServiceTest {
         followService.acceptFollowRequest(target.getId(), follow.getId());
 
         // then
-        assertThat(follow.getStatus()).isEqualTo(FollowStatus.SUCCESS);
+        assertThat(follow.getStatus()).isEqualTo(FollowStatus.APPROVED);
     }
 
     @Test
@@ -244,7 +244,7 @@ class FollowServiceTest {
 
     @ParameterizedTest
     @DisplayName("pending 상태의 follow에 대해서만 요청을 수락할 수 있다.")
-    @ValueSource(strings = {"SUCCESS", "REJECTED", "CANCELED"})
+    @ValueSource(strings = {"APPROVED", "REJECTED", "CANCELED"})
     void acceptFollowRequestFailInvalidFollowTarget(String statusStr) throws Exception {
         // given
         Member fromMember = saveMember();
@@ -259,7 +259,7 @@ class FollowServiceTest {
 
     @ParameterizedTest
     @DisplayName("상대의 팔로우를 거절한다")
-    @ValueSource(strings = {"SUCCESS", "PENDING"})
+    @ValueSource(strings = {"APPROVED", "PENDING"})
     void rejectFollowRequest(String prevStatus) throws Exception {
         // given
         Member fromMember = saveMember();
@@ -295,7 +295,7 @@ class FollowServiceTest {
         Member target = saveMember();
         int followingCnt = 10;
         List<Member> members = saveMembers(followingCnt);
-        List<Follow> targetFollows = saveTargetFollowings(FollowStatus.SUCCESS, target, members, 0, followingCnt);
+        List<Follow> targetFollows = saveTargetFollowings(FollowStatus.APPROVED, target, members, 0, followingCnt);
 
         List<FollowInfo> targetFollowInfos = targetFollows.stream()
             .map(follow -> FollowInfo.of(follow.getTo(), follow.getId()))
@@ -311,16 +311,16 @@ class FollowServiceTest {
     }
 
     @Test
-    @DisplayName("특정 사용자의 팔로잉 목록을 가져올 때, SUCCESS 상태인 것만 가져온다.")
+    @DisplayName("특정 사용자의 팔로잉 목록을 가져올 때, APPROVED 상태인 것만 가져온다.")
     void getFollowingsThatStatusIsSuccess() throws Exception {
         // given
         Member target = saveMember();
         int pendingCnt = 1;
         int rejectCnt = 1;
         int canceledCnt = 1;
-        int successCnt = 10;
+        int approvedCnt = 10;
 
-        List<Member> members = saveMembers(pendingCnt + rejectCnt + canceledCnt + successCnt);
+        List<Member> members = saveMembers(pendingCnt + rejectCnt + canceledCnt + approvedCnt);
 
         int idx = 0;
         saveTargetFollowings(FollowStatus.PENDING, target, members, idx, pendingCnt);
@@ -329,13 +329,13 @@ class FollowServiceTest {
         idx += rejectCnt;
         saveTargetFollowings(FollowStatus.CANCELED, target, members, idx, canceledCnt);
         idx += canceledCnt;
-        saveTargetFollowings(FollowStatus.SUCCESS, target, members, idx, successCnt);
+        saveTargetFollowings(FollowStatus.APPROVED, target, members, idx, approvedCnt);
 
         // when
         List<FollowInfo> infos = followService.getFollowings(target.getId(), target.getId());
 
         // then
-        assertThat(infos).hasSize(successCnt);
+        assertThat(infos).hasSize(approvedCnt);
     }
 
     @Test
@@ -360,7 +360,7 @@ class FollowServiceTest {
         em.persist(privateMember);
 
         Member anotherMember = saveMember();
-        saveFollow(anotherMember, privateMember, FollowStatus.SUCCESS);
+        saveFollow(anotherMember, privateMember, FollowStatus.APPROVED);
 
         // when & then
         assertThatCode(() -> followService.getFollowings(anotherMember.getId(), privateMember.getId()))
@@ -389,9 +389,9 @@ class FollowServiceTest {
     void getFollowersSuccess() throws Exception {
         // given
         Member target = saveMember();
-        int successCnt = 10;
-        List<Member> members = saveMembers(successCnt);
-        List<Follow> targetFollows = saveTargetFollowers(FollowStatus.SUCCESS, target, members, 0, successCnt);
+        int approvedCnt = 10;
+        List<Member> members = saveMembers(approvedCnt);
+        List<Follow> targetFollows = saveTargetFollowers(FollowStatus.APPROVED, target, members, 0, approvedCnt);
 
         List<FollowInfo> targetFollowInfos = targetFollows.stream()
             .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
@@ -403,22 +403,22 @@ class FollowServiceTest {
         List<FollowInfo> infos = followService.getFollowers(target.getId(), target.getId());
 
         // then
-        assertThat(infos).hasSize(successCnt)
+        assertThat(infos).hasSize(approvedCnt)
             .containsAnyElementsOf(targetFollowInfos);
         assertThat(infos.get(0).memberId()).isNotEqualTo(target.getId());
     }
 
     @Test
-    @DisplayName("특정 사용자의 팔로워 목록을 가져올 때, SUCCESS 상태인 것만 가져온다.")
+    @DisplayName("특정 사용자의 팔로워 목록을 가져올 때, APPROVED 상태인 것만 가져온다.")
     void getFollowersThatStatusIsSuccess() throws Exception {
         // given
         Member target = saveMember();
         int pendingCnt = 1;
         int rejectCnt = 1;
         int canceledCnt = 1;
-        int successCnt = 10;
+        int approvedCnt = 10;
 
-        List<Member> members = saveMembers(pendingCnt + rejectCnt + canceledCnt + successCnt);
+        List<Member> members = saveMembers(pendingCnt + rejectCnt + canceledCnt + approvedCnt);
 
         int idx = 0;
         saveTargetFollowers(FollowStatus.PENDING, target, members, idx, pendingCnt);
@@ -427,13 +427,13 @@ class FollowServiceTest {
         idx += rejectCnt;
         saveTargetFollowers(FollowStatus.CANCELED, target, members, idx, canceledCnt);
         idx += canceledCnt;
-        saveTargetFollowers(FollowStatus.SUCCESS, target, members, idx, successCnt);
+        saveTargetFollowers(FollowStatus.APPROVED, target, members, idx, approvedCnt);
 
         // when
         List<FollowInfo> infos = followService.getFollowers(target.getId(), target.getId());
 
         // then
-        assertThat(infos).hasSize(successCnt);
+        assertThat(infos).hasSize(approvedCnt);
     }
 
     @Test
@@ -458,7 +458,7 @@ class FollowServiceTest {
         em.persist(privateMember);
 
         Member anotherMember = saveMember();
-        saveFollow(anotherMember, privateMember, FollowStatus.SUCCESS);
+        saveFollow(anotherMember, privateMember, FollowStatus.APPROVED);
 
         // when & then
         assertThatCode(() -> followService.getFollowers(anotherMember.getId(), privateMember.getId()))

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -324,13 +324,13 @@ class FollowServiceTest {
         List<Member> members = saveMembers(pendingCnt + rejectCnt + canceledCnt + successCnt);
 
         int idx = 0;
-        saveFollows(FollowStatus.PENDING, target, members, idx, pendingCnt);
+        saveTargetFollowings(FollowStatus.PENDING, target, members, idx, pendingCnt);
         idx += pendingCnt;
-        saveFollows(FollowStatus.REJECTED, target, members, idx, rejectCnt);
+        saveTargetFollowings(FollowStatus.REJECTED, target, members, idx, rejectCnt);
         idx += rejectCnt;
-        saveFollows(FollowStatus.CANCELED, target, members, idx, canceledCnt);
+        saveTargetFollowings(FollowStatus.CANCELED, target, members, idx, canceledCnt);
         idx += canceledCnt;
-        saveFollows(FollowStatus.SUCCESS, target, members, idx, successCnt);
+        saveTargetFollowings(FollowStatus.SUCCESS, target, members, idx, successCnt);
 
         // when
         List<FollowInfo> infos = followService.getFollowings(target.getId(), target.getId());
@@ -384,11 +384,93 @@ class FollowServiceTest {
             .hasMessageContaining("권한없음");
     }
 
-    private List<Follow> saveFollows(FollowStatus followStatus, Member target, List<Member> members, int start,
+    @Test
+    @DisplayName("특정 사용자의 팔로워 목록을 가져올 때, SUCCESS 상태인 것만 가져온다.")
+    void getFollowersThatStatusIsSuccess() throws Exception {
+        // given
+        Member target = saveMember();
+        int pendingCnt = 1;
+        int rejectCnt = 1;
+        int canceledCnt = 1;
+        int successCnt = 10;
+
+        List<Member> members = saveMembers(pendingCnt + rejectCnt + canceledCnt + successCnt);
+
+        int idx = 0;
+        saveTargetFollowers(FollowStatus.PENDING, target, members, idx, pendingCnt);
+        idx += pendingCnt;
+        saveTargetFollowers(FollowStatus.REJECTED, target, members, idx, rejectCnt);
+        idx += rejectCnt;
+        saveTargetFollowers(FollowStatus.CANCELED, target, members, idx, canceledCnt);
+        idx += canceledCnt;
+        saveTargetFollowers(FollowStatus.SUCCESS, target, members, idx, successCnt);
+
+        // when
+        List<FollowInfo> infos = followService.getFollowers(target.getId(), target.getId());
+
+        // then
+        assertThat(infos).hasSize(successCnt);
+    }
+
+    @Test
+    @DisplayName("공개 계정은 누구나 팔로워 목록을 볼 수 있다.")
+    void canSeeFollowersEveryoneOnPublicAccount() throws Exception {
+        // given
+        Member publicAccountMember = Member.builder().publicAccount(true).build();
+        em.persist(publicAccountMember);
+
+        Member anotherMember = saveMember();
+
+        // when & then
+        assertThatCode(() -> followService.getFollowers(anotherMember.getId(), publicAccountMember.getId()))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("비공개 계정은 자신을 팔로우한 사람들만 팔로워 목록을 볼 수 있다")
+    void canSeeFollowersThatSpecifyMemberOnPrivateAccount() throws Exception {
+        // given
+        Member publicAccountMember = Member.builder().publicAccount(false).build();
+        em.persist(publicAccountMember);
+
+        Member anotherMember = saveMember();
+        saveFollow(anotherMember, publicAccountMember, FollowStatus.SUCCESS);
+
+        // when & then
+        assertThatCode(() -> followService.getFollowers(anotherMember.getId(), publicAccountMember.getId()))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("비공개 계정은 자신을 팔로우하지 않은 사용자에게 팔로워 목록을 보여주지 않는다")
+    void cantSeeFollowersThatDoesNotFollowOnPrivateAccount() throws Exception {
+        // given
+        Member publicAccountMember = Member.builder().publicAccount(false).build();
+        em.persist(publicAccountMember);
+
+        Member anotherMember = saveMember();
+        saveFollow(publicAccountMember, anotherMember, FollowStatus.PENDING);
+
+        // when & then
+        assertThatThrownBy(() -> followService.getFollowers(anotherMember.getId(), publicAccountMember.getId()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("권한없음");
+    }
+
+    private List<Follow> saveTargetFollowings(FollowStatus followStatus, Member target, List<Member> members, int start,
         int repeatCnt) {
         List<Follow> follows = new ArrayList<>();
         for (int i = start; i < start + repeatCnt; i++) {
             follows.add(saveFollow(target, members.get(i), followStatus));
+        }
+        return follows;
+    }
+
+    private List<Follow> saveTargetFollowers(FollowStatus followStatus, Member target, List<Member> members, int start,
+        int repeatCnt) {
+        List<Follow> follows = new ArrayList<>();
+        for (int i = start; i < start + repeatCnt; i++) {
+            follows.add(saveFollow(members.get(i), target, followStatus));
         }
         return follows;
     }

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -296,10 +296,10 @@ class FollowServiceTest {
         Member target = saveMember();
         int successCnt = 10;
         List<Member> members = saveMembers(successCnt);
-        List<Follow> targetFollows = saveFollows(FollowStatus.SUCCESS, target, members, 0, successCnt);
+        List<Follow> targetFollows = saveTargetFollowings(FollowStatus.SUCCESS, target, members, 0, successCnt);
 
         List<FollowInfo> targetFollowInfos = targetFollows.stream()
-            .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
+            .map(follow -> FollowInfo.of(follow.getTo(), follow.getId()))
             .toList();
 
         // when
@@ -308,6 +308,7 @@ class FollowServiceTest {
         // then
         assertThat(infos).hasSize(successCnt)
             .containsAnyElementsOf(targetFollowInfos);
+        assertThat(infos.get(0).id()).isNotEqualTo(target.getId());
     }
 
     @Test

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -1,0 +1,152 @@
+package com.example.temp.follow.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.temp.follow.domain.Follow;
+import com.example.temp.follow.domain.FollowStatus;
+import com.example.temp.follow.response.FollowResponse;
+import com.example.temp.member.domain.Member;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class FollowServiceTest {
+
+    @Autowired
+    FollowService followService;
+
+    @Autowired
+    EntityManager em;
+
+    long notExistMemberId = 999_999_999L;
+
+    @Test
+    @DisplayName("from 사용자가 to 사용자를 팔로우한다.")
+    void followSuccess() throws Exception {
+        // given
+        Member fromMember = saveMember();
+        Member toMember = saveMember();
+
+        // when
+        FollowResponse response = followService.follow(fromMember.getId(), toMember.getId());
+
+        // then
+        assertThat(response.status()).isEqualTo(FollowStatus.SUCCESS);
+        validateFollowResponse(response, fromMember, toMember);
+    }
+
+    @Test
+    @DisplayName("이미 팔로우가 되어있는 사용자에게 팔로우 요청을 보낼 수 없다")
+    void followFailAlreadyFollowSuccess() throws Exception {
+        // given
+        Member fromMember = saveMember();
+        Member toMember = saveMember();
+        saveFollow(fromMember, toMember, FollowStatus.SUCCESS);
+
+        // when & then
+        assertThatThrownBy(() -> followService.follow(fromMember.getId(), toMember.getId()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이미 둘 사이에 관계가 존재합니다.");
+    }
+
+    @Test
+    @DisplayName("이미 팔로우 요청을 보내 둔 사용자에게 팔로우 요청을 보낼 수 없다")
+    void followFailAlreadyFollowPending() throws Exception {
+        // given
+        Member fromMember = saveMember();
+        Member toMember = saveMember();
+        saveFollow(fromMember, toMember, FollowStatus.PENDING);
+
+        // when
+        assertThatThrownBy(() -> followService.follow(fromMember.getId(), toMember.getId()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이미 둘 사이에 관계가 존재합니다.");
+    }
+
+    @Test
+    @DisplayName("기존에 fromMember가 toMember를 팔로우 취소한 상태에서, 새롭게 팔로우를 한다")
+    void followSuccessThatAlreadyUnfollow() throws Exception {
+        // given
+        Member fromMember = saveMember();
+        Member toMember = saveMember();
+        saveFollow(fromMember, toMember, FollowStatus.CANCELED);
+
+        // when
+        FollowResponse response = followService.follow(fromMember.getId(), toMember.getId());
+
+        // then
+        assertThat(response.status()).isEqualTo(FollowStatus.SUCCESS);
+        validateFollowResponse(response, fromMember, toMember);
+    }
+
+    @Test
+    @DisplayName("기존에 toMember가 fromMember의 팔로우를 거절한 상태에서, fromMember는 다시 팔로우를 한다")
+    void followSuccessThatAlreadyRejected() throws Exception {
+        // given
+        Member fromMember = saveMember();
+        Member toMember = saveMember();
+        saveFollow(fromMember, toMember, FollowStatus.REJECTED);
+
+        // when
+        FollowResponse response = followService.follow(fromMember.getId(), toMember.getId());
+
+        // then
+        assertThat(response.status()).isEqualTo(FollowStatus.SUCCESS);
+        validateFollowResponse(response, fromMember, toMember);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 toMember에게 팔로우 요청을 할 수 없다")
+    void followFailBecauseOfNotExistMember() throws Exception {
+        // given
+        Member fromMember = saveMember();
+
+        // when & then
+        assertThatThrownBy(() -> followService.follow(fromMember.getId(), notExistMemberId))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("찾을 수 없는 사용자");
+    }
+
+
+    @Test
+    @DisplayName("존재하지 않는 fromMember로는 팔로우 요청을 보낼 수 없다")
+    void followFailBecauseExecutorNotFound() throws Exception {
+        // given
+        Member toMember = saveMember();
+
+        // when & then
+        assertThatThrownBy(() -> followService.follow(notExistMemberId, toMember.getId()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("찾을 수 없는 사용자");
+    }
+
+    private void validateFollowResponse(FollowResponse response, Member fromMember, Member toMember) {
+        Follow result = em.find(Follow.class, response.id());
+        assertThat(result.getId()).isNotNull();
+        assertThat(result.getFrom()).isEqualTo(fromMember);
+        assertThat(result.getTo()).isEqualTo(toMember);
+    }
+
+    private Follow saveFollow(Member fromMember, Member toMember, FollowStatus status) {
+        Follow follow = Follow.builder()
+            .from(fromMember)
+            .to(toMember)
+            .status(status)
+            .build();
+        em.persist(follow);
+        return follow;
+    }
+
+    private Member saveMember() {
+        Member member = Member.builder().build();
+        em.persist(member);
+        return member;
+    }
+
+}

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -45,6 +45,18 @@ class FollowServiceTest {
     }
 
     @Test
+    @DisplayName("자기 자신은 팔로우할 수 없다.")
+    void followFailBecauseOfFollowersAndFollowingsIsSame() throws Exception {
+        // given
+        Member sameMember = saveMember();
+
+        // when
+        assertThatThrownBy(() -> followService.follow(sameMember.getId(), sameMember.getId()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("자기 자신을 팔로우할 수 없습니다.");
+    }
+
+    @Test
     @DisplayName("팔로우를 할 때, target의 전략이 EAGER면 SUCCESS 상태의 follow가 생성된다.")
     void validateCreateSuccessFollowThatTargetStrategyIsEager() throws Exception {
         // given

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -1,9 +1,17 @@
 package com.example.temp.follow.application;
 
+import static com.example.temp.exception.ErrorCode.AUTHENTICATED_FAIL;
+import static com.example.temp.exception.ErrorCode.AUTHORIZED_FAIL;
+import static com.example.temp.exception.ErrorCode.FOLLOW_ALREADY_RELATED;
+import static com.example.temp.exception.ErrorCode.FOLLOW_NOT_FOUND;
+import static com.example.temp.exception.ErrorCode.FOLLOW_NOT_PENDING;
+import static com.example.temp.exception.ErrorCode.FOLLOW_SELF_FAIL;
+import static com.example.temp.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.temp.exception.ApiException;
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowStatus;
 import com.example.temp.follow.dto.response.FollowInfo;
@@ -35,8 +43,7 @@ class FollowServiceTest {
 
 
     /**
-     * 닉네임을 만들 때 중복을 제거하기 위해 사용합니다.
-     * ex. 닉네임0, 닉네임1 .... 과 같은 방식으로 닉네임을 순차적으로 생성하도록 돕습니다.
+     * 닉네임을 만들 때 중복을 제거하기 위해 사용합니다. ex. 닉네임0, 닉네임1 .... 과 같은 방식으로 닉네임을 순차적으로 생성하도록 돕습니다.
      */
     int globalIdx = 0;
 
@@ -63,8 +70,8 @@ class FollowServiceTest {
 
         // when
         assertThatThrownBy(() -> followService.follow(sameMember.getId(), sameMember.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("자기 자신을 팔로우할 수 없습니다.");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_SELF_FAIL.getMessage());
     }
 
     @Test
@@ -105,8 +112,8 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.follow(fromMember.getId(), toMember.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("이미 둘 사이에 관계가 존재합니다.");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_ALREADY_RELATED.getMessage());
     }
 
     @Test
@@ -119,8 +126,8 @@ class FollowServiceTest {
 
         // when
         assertThatThrownBy(() -> followService.follow(fromMember.getId(), toMember.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("이미 둘 사이에 관계가 존재합니다.");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_ALREADY_RELATED.getMessage());
     }
 
     @Test
@@ -163,21 +170,21 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.follow(fromMember.getId(), notExistMemberId))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("찾을 수 없는 사용자");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
     }
 
 
     @Test
-    @DisplayName("존재하지 않는 회원은 팔로우 요청을 보낼 수 없다")
+    @DisplayName("로그인이 제대로 되지 않은 회원은 팔로우 요청을 보낼 수 없다")
     void followFailBecauseExecutorNotFound() throws Exception {
         // given
         Member toMember = saveMember();
 
         // when & then
         assertThatThrownBy(() -> followService.follow(notExistMemberId, toMember.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("찾을 수 없는 사용자");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(AUTHENTICATED_FAIL.getMessage());
     }
 
     @Test
@@ -204,8 +211,8 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.unfollow(fromMember.getId(), target.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("찾을 수 없는 관계");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -216,8 +223,8 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.unfollow(fromMember.getId(), notExistMemberId))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("찾을 수 없는 사용자");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -246,8 +253,8 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.acceptFollowRequest(anotherMember.getId(), follow.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("권한없음");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }
 
     @ParameterizedTest
@@ -261,8 +268,8 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.acceptFollowRequest(target.getId(), follow.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("잘못된 상태입니다.");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_NOT_PENDING.getMessage());
     }
 
     @ParameterizedTest
@@ -292,8 +299,8 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.rejectFollowRequest(anotherMember.getId(), follow.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("권한없음");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }
 
     @Test
@@ -387,8 +394,8 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.getFollowings(anotherMember.getId(), privateMember.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("권한없음");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }
 
 
@@ -483,8 +490,8 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.getFollowers(anotherMember.getId(), privateMember.getId()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("권한없음");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }
 
     private List<Follow> saveTargetFollowings(FollowStatus followStatus, Member target, List<Member> members, int start,

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -81,7 +81,7 @@ class FollowRepositoryTest {
         Follow follow = Follow.builder()
             .from(executor)
             .to(target)
-            .status(FollowStatus.SUCCESS)
+            .status(FollowStatus.APPROVED)
             .build();
         em.persist(follow);
 
@@ -125,7 +125,7 @@ class FollowRepositoryTest {
         Follow follow = Follow.builder()
             .from(executor)
             .to(anotherMember)
-            .status(FollowStatus.SUCCESS)
+            .status(FollowStatus.APPROVED)
             .build();
         em.persist(follow);
 
@@ -159,7 +159,7 @@ class FollowRepositoryTest {
     @DisplayName("fromId와 status가 일치하는 Follow가 없을 때 비어있는 리스트를 반환한다")
     void findAllByFromIdAndStatusEmptyResult() throws Exception {
         // when
-        List<Follow> result = followRepository.findAllByFromIdAndStatus(notExistId, FollowStatus.SUCCESS);
+        List<Follow> result = followRepository.findAllByFromIdAndStatus(notExistId, FollowStatus.APPROVED);
 
         // then
         assertThat(result).isEmpty();
@@ -188,7 +188,7 @@ class FollowRepositoryTest {
     @DisplayName("toId와 status가 일치하는 Follow가 없을 때 비어있는 리스트를 반환한다")
     void findAllByToIdAndStatusEmptyResult() throws Exception {
         // when
-        List<Follow> result = followRepository.findAllByToIdAndStatus(notExistId, FollowStatus.SUCCESS);
+        List<Follow> result = followRepository.findAllByToIdAndStatus(notExistId, FollowStatus.APPROVED);
 
         // then
         assertThat(result).isEmpty();
@@ -212,7 +212,7 @@ class FollowRepositoryTest {
             .followStrategy(FollowStrategy.EAGER)
             .publicAccount(true)
             .build();
-            em.persist(member);
+        em.persist(member);
         return member;
     }
 

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.example.temp.follow.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.member.domain.Member;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class FollowRepositoryTest {
+
+    @Autowired
+    FollowRepository followRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("fromId와 toId가 일치하는 Follow를 찾는다.")
+    void findByFromIdAndToIdSuccess() throws Exception {
+        // given
+        Member fromMember = createMember();
+        Member toMember = createMember();
+
+        Follow follow = Follow.builder()
+            .from(fromMember)
+            .to(toMember)
+            .build();
+        em.persist(follow);
+
+        // when
+        Follow result = followRepository.findByFromIdAndToId(fromMember.getId(), toMember.getId()).get();
+
+        // then
+        assertThat(result.getId()).isNotNull();
+        assertThat(result.getFrom().getId()).isEqualTo(fromMember.getId());
+        assertThat(result.getTo().getId()).isEqualTo(toMember.getId());
+    }
+
+    @Test
+    @DisplayName("fromId와 toId가 일치하는 Follow가 없을 땐 Optional.empty를 반환한다.")
+    void findByFromIdAndToIdNotFound() throws Exception {
+        // given
+        Member fromMember = createMember();
+        Member toMember = createMember();
+
+        Follow follow = Follow.builder()
+            .from(fromMember)
+            .to(toMember)
+            .build();
+        em.persist(follow);
+
+        // when
+        Optional<Follow> resultOpt = followRepository.findByFromIdAndToId(toMember.getId(), fromMember.getId());
+
+        // then
+        assertThat(resultOpt).isEmpty();
+    }
+
+
+    private Member createMember() {
+        Member fromMember = Member.builder().build();
+        em.persist(fromMember);
+        return fromMember;
+    }
+}

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,12 +24,14 @@ class FollowRepositoryTest {
     @Autowired
     EntityManager em;
 
+    long notExistId = 999_999_999L;
+
     @Test
     @DisplayName("fromId와 toId가 일치하는 Follow를 찾는다.")
     void findByFromIdAndToIdSuccess() throws Exception {
         // given
-        Member fromMember = createMember();
-        Member toMember = createMember();
+        Member fromMember = saveMember();
+        Member toMember = saveMember();
 
         Follow follow = Follow.builder()
             .from(fromMember)
@@ -49,8 +52,8 @@ class FollowRepositoryTest {
     @DisplayName("fromId와 toId가 일치하는 Follow가 없을 땐 Optional.empty를 반환한다.")
     void findByFromIdAndToIdNotFound() throws Exception {
         // given
-        Member fromMember = createMember();
-        Member toMember = createMember();
+        Member fromMember = saveMember();
+        Member toMember = saveMember();
 
         Follow follow = Follow.builder()
             .from(fromMember)
@@ -69,8 +72,8 @@ class FollowRepositoryTest {
     @DisplayName("executor가 target을 팔로우하면 true를 반환한다")
     void checkExecutorFollowTargetTrue() throws Exception {
         // given
-        Member executor = createMember();
-        Member target = createMember();
+        Member executor = saveMember();
+        Member target = saveMember();
 
         Follow follow = Follow.builder()
             .from(executor)
@@ -91,8 +94,8 @@ class FollowRepositoryTest {
     @ValueSource(strings = {"PENDING", "REJECTED", "CANCELED"})
     void checkExecutorFollowTargetFalse1(String statusStr) throws Exception {
         // given
-        Member executor = createMember();
-        Member target = createMember();
+        Member executor = saveMember();
+        Member target = saveMember();
 
         Follow follow = Follow.builder()
             .from(executor)
@@ -112,9 +115,9 @@ class FollowRepositoryTest {
     @DisplayName("executor가 target을 팔로우하고 있지 않으면 false를 반환한다")
     void checkExecutorFollowTargetFalse2() throws Exception {
         // given
-        Member executor = createMember();
-        Member target = createMember();
-        Member anotherMember = createMember();
+        Member executor = saveMember();
+        Member target = saveMember();
+        Member anotherMember = saveMember();
 
         Follow follow = Follow.builder()
             .from(executor)
@@ -130,7 +133,75 @@ class FollowRepositoryTest {
         assertThat(result).isFalse();
     }
 
-    private Member createMember() {
+    @Test
+    @DisplayName("fromId와 status가 일치하는 Follow의 목록을 조회한다")
+    void findAllByFromIdAndStatus() throws Exception {
+        // given
+        Member fromMember = saveMember();
+        Member toMember1 = saveMember();
+        Member toMember2 = saveMember();
+        FollowStatus targetStatus = FollowStatus.PENDING;
+        Follow follow1 = saveFollow(fromMember, toMember1, targetStatus);
+        Follow follow2 = saveFollow(fromMember, toMember2, targetStatus);
+
+        // when
+        List<Follow> result = followRepository.findAllByFromIdAndStatus(fromMember.getId(), targetStatus);
+
+        // then
+        assertThat(result).hasSize(2)
+            .contains(follow1, follow2);
+    }
+
+    @Test
+    @DisplayName("fromId와 status가 일치하는 Follow가 없을 때 비어있는 리스트를 반환한다")
+    void findAllByFromIdAndStatusEmptyResult() throws Exception {
+        // when
+        List<Follow> result = followRepository.findAllByFromIdAndStatus(notExistId, FollowStatus.SUCCESS);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toId와 status가 일치하는 Follow의 목록을 조회한다")
+    void findAllByToIdAndStatus() throws Exception {
+        // given
+        Member fromMember1 = saveMember();
+        Member fromMember2 = saveMember();
+        Member toMember = saveMember();
+        FollowStatus targetStatus = FollowStatus.PENDING;
+        Follow follow1 = saveFollow(fromMember1, toMember, targetStatus);
+        Follow follow2 = saveFollow(fromMember2, toMember, targetStatus);
+
+        // when
+        List<Follow> result = followRepository.findAllByToIdAndStatus(toMember.getId(), targetStatus);
+
+        // then
+        assertThat(result).hasSize(2)
+            .contains(follow1, follow2);
+    }
+
+    @Test
+    @DisplayName("toId와 status가 일치하는 Follow가 없을 때 비어있는 리스트를 반환한다")
+    void findAllByToIdAndStatusEmptyResult() throws Exception {
+        // when
+        List<Follow> result = followRepository.findAllByToIdAndStatus(notExistId, FollowStatus.SUCCESS);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    private Follow saveFollow(Member fromMember, Member toMember1, FollowStatus status) {
+        Follow follow = Follow.builder()
+            .from(fromMember)
+            .to(toMember1)
+            .status(status)
+            .build();
+        em.persist(follow);
+        return follow;
+    }
+
+    private Member saveMember() {
         Member fromMember = Member.builder().build();
         em.persist(fromMember);
         return fromMember;

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -65,7 +65,7 @@ class FollowRepositoryTest {
         em.persist(follow);
 
         // when
-        Optional<Follow> resultOpt = followRepository.findByFromIdAndToId(toMember.getId(), fromMember.getId());
+        Optional<Follow> resultOpt = followRepository.findByFromIdAndToId(fromMember.getId(), notExistId);
 
         // then
         assertThat(resultOpt).isEmpty();

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -2,6 +2,7 @@ package com.example.temp.follow.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -25,6 +26,8 @@ class FollowRepositoryTest {
     EntityManager em;
 
     long notExistId = 999_999_999L;
+
+    int globalIdx = 0;
 
     @Test
     @DisplayName("fromId와 toId가 일치하는 Follow를 찾는다.")
@@ -202,8 +205,15 @@ class FollowRepositoryTest {
     }
 
     private Member saveMember() {
-        Member fromMember = Member.builder().build();
-        em.persist(fromMember);
-        return fromMember;
+        Member member = Member.builder()
+            .email("이메일")
+            .profileUrl("프로필")
+            .nickname("nickname" + globalIdx++)
+            .followStrategy(FollowStrategy.EAGER)
+            .publicAccount(true)
+            .build();
+            em.persist(member);
+        return member;
     }
+
 }

--- a/src/test/java/com/example/temp/follow/domain/FollowStatusTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowStatusTest.java
@@ -9,7 +9,7 @@ class FollowStatusTest {
 
     @DisplayName("해당 FollowStatus가 활성화 상태라면 true를 반환한다")
     @ParameterizedTest
-    @ValueSource(strings = {"SUCCESS", "PENDING"})
+    @ValueSource(strings = {"APPROVED", "PENDING"})
     void isValidSuccess(String statusStr) throws Exception {
         // given
         FollowStatus status = FollowStatus.valueOf(statusStr);

--- a/src/test/java/com/example/temp/follow/domain/FollowStatusTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowStatusTest.java
@@ -1,0 +1,32 @@
+package com.example.temp.follow.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FollowStatusTest {
+
+    @DisplayName("해당 Follow 엔티티가 유효한 상태라면 true를 반환한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"SUCCESS", "PENDING"})
+    void isValidSuccess(String statusStr) throws Exception {
+        // given
+        FollowStatus status = FollowStatus.valueOf(statusStr);
+
+        // when & then
+        Assertions.assertThat(status.isValid()).isTrue();
+    }
+
+    @DisplayName("해당 Follow 엔티티가 유효한 상태가 아니라면 false를 반환한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"REJECTED", "CANCELED"})
+    void isValidFail(String statusStr) throws Exception {
+        // given
+        FollowStatus status = FollowStatus.valueOf(statusStr);
+
+        // when & then
+        Assertions.assertThat(status.isValid()).isFalse();
+    }
+
+}

--- a/src/test/java/com/example/temp/follow/domain/FollowStatusTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowStatusTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class FollowStatusTest {
 
-    @DisplayName("해당 Follow 엔티티가 유효한 상태라면 true를 반환한다")
+    @DisplayName("해당 FollowStatus가 활성화 상태라면 true를 반환한다")
     @ParameterizedTest
     @ValueSource(strings = {"SUCCESS", "PENDING"})
     void isValidSuccess(String statusStr) throws Exception {
@@ -15,10 +15,10 @@ class FollowStatusTest {
         FollowStatus status = FollowStatus.valueOf(statusStr);
 
         // when & then
-        Assertions.assertThat(status.isValid()).isTrue();
+        Assertions.assertThat(status.isActive()).isTrue();
     }
 
-    @DisplayName("해당 Follow 엔티티가 유효한 상태가 아니라면 false를 반환한다")
+    @DisplayName("해당 FollowStatus가 활성화 상태가 아니라면 false를 반환한다")
     @ParameterizedTest
     @ValueSource(strings = {"REJECTED", "CANCELED"})
     void isValidFail(String statusStr) throws Exception {
@@ -26,7 +26,7 @@ class FollowStatusTest {
         FollowStatus status = FollowStatus.valueOf(statusStr);
 
         // when & then
-        Assertions.assertThat(status.isValid()).isFalse();
+        Assertions.assertThat(status.isActive()).isFalse();
     }
 
 }

--- a/src/test/java/com/example/temp/follow/domain/FollowTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowTest.java
@@ -124,6 +124,42 @@ class FollowTest {
             .hasMessageContaining("이미 비활성화된 관계입니다.");
     }
 
+    @ParameterizedTest
+    @DisplayName("팔로우를 거절한다.")
+    @CsvSource({
+        "SUCCESS",
+        "PENDING"
+    })
+    void rejectSuccess(String statusStr) throws Exception {
+        // given
+        Follow follow = Follow.builder()
+            .status(FollowStatus.valueOf(statusStr))
+            .build();
+
+        // when
+        follow.reject();
+        // then
+        assertThat(follow.getStatus()).isEqualTo(FollowStatus.REJECTED);
+    }
+
+    @ParameterizedTest
+    @DisplayName("이미 비활성화된 팔로우에 대해서는 거절을 할 수 없다.")
+    @CsvSource({
+        "CANCELED",
+        "REJECTED"
+    })
+    void rejectFailAlreadyInactivate(String statusStr) throws Exception {
+        // given
+        Follow follow = Follow.builder()
+            .status(FollowStatus.valueOf(statusStr))
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> follow.reject())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이미 비활성화된 관계입니다.");
+    }
+
     @Test
     @DisplayName("pending 상태의 follow를 수락한다")
     void acceptSuccess() throws Exception {

--- a/src/test/java/com/example/temp/follow/domain/FollowTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowTest.java
@@ -123,4 +123,34 @@ class FollowTest {
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("이미 비활성화된 관계입니다.");
     }
+
+    @Test
+    @DisplayName("pending 상태의 follow를 수락한다")
+    void acceptSuccess() throws Exception {
+        // given
+        Follow follow = Follow.builder()
+            .status(FollowStatus.PENDING)
+            .build();
+
+        // when
+        follow.accept();
+
+        // then
+        assertThat(follow.getStatus()).isEqualTo(FollowStatus.SUCCESS);
+    }
+
+    @ParameterizedTest
+    @DisplayName("pending 상태의 follow에 대해서만 요청을 수락할 수 있다.")
+    @ValueSource(strings = {"SUCCESS", "REJECTED", "CANCELED"})
+    void acceptFailInvalidFollowType(String statusStr) throws Exception {
+        // given
+        Follow follow = Follow.builder()
+            .status(FollowStatus.valueOf(statusStr))
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> follow.accept())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("잘못된 상태입니다.");
+    }
 }

--- a/src/test/java/com/example/temp/follow/domain/FollowTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowTest.java
@@ -1,9 +1,12 @@
 package com.example.temp.follow.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class FollowTest {
@@ -31,6 +34,57 @@ class FollowTest {
             .build();
 
         // when & then
-        Assertions.assertThat(follow.isValid()).isFalse();
+        assertThat(follow.isActive()).isFalse();
+    }
+
+    @ParameterizedTest
+    @DisplayName("비활성 상태의 Follow를 활성화한다.")
+    @CsvSource({
+        "REJECTED, SUCCESS",
+        "CANCELED, PENDING"
+    })
+    void reactiveSuccess(String prevStatusStr, String changedStatusStr) throws Exception {
+        // given
+        FollowStatus changed = FollowStatus.valueOf(changedStatusStr);
+        Follow follow = Follow.builder().status(FollowStatus.valueOf(prevStatusStr)).build();
+
+        // when
+        Follow reactiveFollow = follow.reactive(changed);
+
+        // then
+        assertThat(reactiveFollow).isEqualTo(follow);
+        assertThat(reactiveFollow.getStatus()).isEqualTo(changed);
+    }
+
+    @ParameterizedTest
+    @DisplayName("활성 상태의 Follow는 활성화시킬 수 없다.")
+    @CsvSource({
+        "SUCCESS",
+        "PENDING"
+    })
+    void reactiveFailAlreadyActivate(String prevStatusStr) throws Exception {
+        // given
+        Follow follow = Follow.builder().status(FollowStatus.valueOf(prevStatusStr)).build();
+
+        // when & then
+        assertThatThrownBy(() -> follow.reactive(FollowStatus.SUCCESS))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이미 둘 사이에 관계가 존재합니다.");
+    }
+
+    @ParameterizedTest
+    @DisplayName("비활성 상태를 입력해 Follow를 활성화시키는 건 불가능하다")
+    @CsvSource({
+        "CANCELED",
+        "REJECTED"
+    })
+    void reactiveFailInputIsInactivate(String changed) throws Exception {
+        // given
+        Follow follow = Follow.builder().status(FollowStatus.CANCELED).build();
+
+        // when & then
+        assertThatThrownBy(() -> follow.reactive(FollowStatus.valueOf(changed)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("해당 상태로는 변경할 수 없습니다.");
     }
 }

--- a/src/test/java/com/example/temp/follow/domain/FollowTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowTest.java
@@ -18,7 +18,7 @@ class FollowTest {
 
     @DisplayName("해당 Follow 엔티티가 유효한 상태라면 true를 반환한다")
     @ParameterizedTest
-    @ValueSource(strings = {"SUCCESS", "PENDING"})
+    @ValueSource(strings = {"APPROVED", "PENDING"})
     void isValidSuccess(String statusStr) throws Exception {
         // given
         Follow follow = Follow.builder()
@@ -45,7 +45,7 @@ class FollowTest {
     @ParameterizedTest
     @DisplayName("비활성 상태의 Follow를 활성화한다.")
     @CsvSource({
-        "REJECTED, SUCCESS",
+        "REJECTED, APPROVED",
         "CANCELED, PENDING"
     })
     void reactiveSuccess(String prevStatusStr, String changedStatusStr) throws Exception {
@@ -64,7 +64,7 @@ class FollowTest {
     @ParameterizedTest
     @DisplayName("활성 상태의 Follow는 활성화시킬 수 없다.")
     @CsvSource({
-        "SUCCESS",
+        "APPROVED",
         "PENDING"
     })
     void reactiveFailAlreadyActivate(String prevStatusStr) throws Exception {
@@ -72,7 +72,7 @@ class FollowTest {
         Follow follow = Follow.builder().status(FollowStatus.valueOf(prevStatusStr)).build();
 
         // when & then
-        assertThatThrownBy(() -> follow.reactive(FollowStatus.SUCCESS))
+        assertThatThrownBy(() -> follow.reactive(FollowStatus.APPROVED))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(FOLLOW_ALREADY_RELATED.getMessage());
     }
@@ -96,7 +96,7 @@ class FollowTest {
     @ParameterizedTest
     @DisplayName("언팔로우한다.")
     @CsvSource({
-        "SUCCESS",
+        "APPROVED",
         "PENDING"
     })
     void unfollowSuccess(String statusStr) throws Exception {
@@ -132,7 +132,7 @@ class FollowTest {
     @ParameterizedTest
     @DisplayName("팔로우를 거절한다.")
     @CsvSource({
-        "SUCCESS",
+        "APPROVED",
         "PENDING"
     })
     void rejectSuccess(String statusStr) throws Exception {
@@ -177,12 +177,12 @@ class FollowTest {
         follow.accept();
 
         // then
-        assertThat(follow.getStatus()).isEqualTo(FollowStatus.SUCCESS);
+        assertThat(follow.getStatus()).isEqualTo(FollowStatus.APPROVED);
     }
 
     @ParameterizedTest
     @DisplayName("pending 상태의 follow에 대해서만 요청을 수락할 수 있다.")
-    @ValueSource(strings = {"SUCCESS", "REJECTED", "CANCELED"})
+    @ValueSource(strings = {"APPROVED", "REJECTED", "CANCELED"})
     void acceptFailInvalidFollowType(String statusStr) throws Exception {
         // given
         Follow follow = Follow.builder()

--- a/src/test/java/com/example/temp/follow/domain/FollowTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowTest.java
@@ -1,8 +1,13 @@
 package com.example.temp.follow.domain;
 
+import static com.example.temp.exception.ErrorCode.FOLLOW_ALREADY_RELATED;
+import static com.example.temp.exception.ErrorCode.FOLLOW_INACTIVE;
+import static com.example.temp.exception.ErrorCode.FOLLOW_NOT_PENDING;
+import static com.example.temp.exception.ErrorCode.FOLLOW_STATUS_CHANGE_NOT_ALLOWED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.temp.exception.ApiException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -68,8 +73,8 @@ class FollowTest {
 
         // when & then
         assertThatThrownBy(() -> follow.reactive(FollowStatus.SUCCESS))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("이미 둘 사이에 관계가 존재합니다.");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_ALREADY_RELATED.getMessage());
     }
 
     @ParameterizedTest
@@ -84,8 +89,8 @@ class FollowTest {
 
         // when & then
         assertThatThrownBy(() -> follow.reactive(FollowStatus.valueOf(changed)))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("해당 상태로는 변경할 수 없습니다.");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_STATUS_CHANGE_NOT_ALLOWED.getMessage());
     }
 
     @ParameterizedTest
@@ -120,8 +125,8 @@ class FollowTest {
 
         // when & then
         assertThatThrownBy(() -> follow.unfollow())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("이미 비활성화된 관계입니다.");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_INACTIVE.getMessage());
     }
 
     @ParameterizedTest
@@ -156,8 +161,8 @@ class FollowTest {
 
         // when & then
         assertThatThrownBy(() -> follow.reject())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("이미 비활성화된 관계입니다.");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_INACTIVE.getMessage());
     }
 
     @Test
@@ -186,7 +191,7 @@ class FollowTest {
 
         // when & then
         assertThatThrownBy(() -> follow.accept())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("잘못된 상태입니다.");
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(FOLLOW_NOT_PENDING.getMessage());
     }
 }

--- a/src/test/java/com/example/temp/follow/domain/FollowTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowTest.java
@@ -87,4 +87,40 @@ class FollowTest {
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("해당 상태로는 변경할 수 없습니다.");
     }
+
+    @ParameterizedTest
+    @DisplayName("언팔로우한다.")
+    @CsvSource({
+        "SUCCESS",
+        "PENDING"
+    })
+    void unfollowSuccess(String statusStr) throws Exception {
+        // given
+        Follow follow = Follow.builder()
+            .status(FollowStatus.valueOf(statusStr))
+            .build();
+
+        // when
+        follow.unfollow();
+        // then
+        assertThat(follow.getStatus()).isEqualTo(FollowStatus.CANCELED);
+    }
+
+    @ParameterizedTest
+    @DisplayName("이미 비활성화된 팔로우에 대해서는 언팔로우를 할 수 없다.")
+    @CsvSource({
+        "CANCELED",
+        "REJECTED"
+    })
+    void unfollowFailAlreadyInactivate(String statusStr) throws Exception {
+        // given
+        Follow follow = Follow.builder()
+            .status(FollowStatus.valueOf(statusStr))
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> follow.unfollow())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이미 비활성화된 관계입니다.");
+    }
 }

--- a/src/test/java/com/example/temp/follow/domain/FollowTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowTest.java
@@ -1,6 +1,7 @@
 package com.example.temp.follow.domain;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -17,7 +18,7 @@ class FollowTest {
             .build();
 
         // when & then
-        Assertions.assertThat(follow.isValid()).isTrue();
+        assertThat(follow.isActive()).isTrue();
     }
 
     @DisplayName("해당 Follow 엔티티가 유효한 상태가 아니라면 false를 반환한다")

--- a/src/test/java/com/example/temp/follow/domain/FollowTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowTest.java
@@ -1,0 +1,35 @@
+package com.example.temp.follow.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FollowTest {
+
+    @DisplayName("해당 Follow 엔티티가 유효한 상태라면 true를 반환한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"SUCCESS", "PENDING"})
+    void isValidSuccess(String statusStr) throws Exception {
+        // given
+        Follow follow = Follow.builder()
+            .status(FollowStatus.valueOf(statusStr))
+            .build();
+
+        // when & then
+        Assertions.assertThat(follow.isValid()).isTrue();
+    }
+
+    @DisplayName("해당 Follow 엔티티가 유효한 상태가 아니라면 false를 반환한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"REJECTED", "CANCELED"})
+    void isValidFail(String statusStr) throws Exception {
+        // given
+        Follow follow = Follow.builder()
+            .status(FollowStatus.valueOf(statusStr))
+            .build();
+
+        // when & then
+        Assertions.assertThat(follow.isValid()).isFalse();
+    }
+}

--- a/src/test/java/com/example/temp/follow/dto/response/FollowInfosTest.java
+++ b/src/test/java/com/example/temp/follow/dto/response/FollowInfosTest.java
@@ -1,0 +1,25 @@
+package com.example.temp.follow.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FollowInfosTest {
+
+    @Test
+    @DisplayName("FollowInfos를 생성한다")
+    void create() throws Exception {
+        // given
+        FollowInfo followInfo1 = new FollowInfo(1L, 1L, "url");
+        FollowInfo followInfo2 = new FollowInfo(2L, 2L, "url");
+        // when
+        FollowInfos result = FollowInfos.from(List.of(followInfo1, followInfo2));
+
+        // then
+        assertThat(result.follows()).hasSize(2)
+            .contains(followInfo1, followInfo2);
+    }
+
+}

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.exception.NicknameDuplicatedException;
 import com.example.temp.member.infrastructure.nickname.NicknameGenerator;
@@ -115,6 +116,8 @@ class MemberServiceTest {
             .nickname(nickname)
             .email("이메일")
             .profileUrl("프로필주소")
+            .followStrategy(FollowStrategy.EAGER)
+            .publicAccount(true)
             .build();
         em.persist(member);
         return member;

--- a/src/test/java/com/example/temp/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberRepositoryTest.java
@@ -45,6 +45,7 @@ class MemberRepositoryTest {
             .nickname(nickname)
             .email("이멜")
             .profileUrl("프로필")
+            .followStrategy(FollowStrategy.EAGER)
             .build();
         em.persist(member);
         return member;


### PR DESCRIPTION
오우 분량이 너무 많은거 같아서 미리 죄송합니다 🥲🥲
지금 할 수 있는 작업이 Follow밖에 없다고 생각해서 한 큐에 PR을 보냈는데 분량이 너무하네요,, sorry,,,

## 👊🏻 작업 내용

- [x] 팔로우 요청 보내기
- [x] 팔로우 취소(팔로우 요청을 취소하는 것 역시 같은 API를 사용합니다)
- [x] PENDING 상태의 팔로우 요청을 수락
- [x] 팔로우 거절
- [x] 팔로워 목록 받기
- [x] 팔로잉 목록 받기

## 🏌🏻 리뷰 포인트
우선 로직 전반에 걸쳐 최대한 책임을 분리하며 코드를 짜려고 노력했습니다.

**많아도 너무 많은 테스트**
테스트 역시 모든 비즈니스 요구사항을 커버할 수 있도록 작성했는데요. 작성을 하고 보니 너무 너무 많습니다.
FollowServiceTest를 보시면 569줄이 있는데요. 반복을 없애면서 테스트를 짰는데도 이러네요.

제 고민은 이렇게 테스트를 작성하는 게 맞는건가, 어쩌면 필요 이상으로 반복적인 테스트를 짰을까 의문이 들어요.
정우님은 이 부분에 대해 어떻게 생각하시는지 의견이 궁금합니다.
(이런 습관? 에 관련한 부분들은 혼자 고민을 통해 명확한 답을 내리기 어렵더라구요)

---
서비스 로직 같은 경우에는 최대한 이해하기 쉽게 작성하려 노력했고, JavaDoc도 함께 첨부해뒀습니다.
한 번 읽어보시고 모호한 부분은 말씀해주시면 감사할 거 같아요!

**Follow 엔티티**
Follow 엔티티는 "FollowStatus를 변경하는 책임"을 갖도록 만드려고 노력했습니다.

Follow 엔티티에는 FollowStatus라는 필드가 있어요.
해당 필드는 SUCCESS, PENDING, CANCELED, REJECTED라는 네 가지 상태가 있는데요.
```
SUCCESS : 현재 팔로우중인 상태
PENDING : 팔로우 요청을 보낸 상태
CANCELED: 팔로우를 취소했을 때
REJECTED: 나를 팔로우하는 특정 사람을 끊어버리거나, 요청을 거절한 상태
```
Follow 엔티티를 보시면 각종 메서드를 사용해서 FollowStatus의 값을 바꾸는데요, 
setFollowStatus 메서드를 통해 외부에서 변경해도 되지만, Follow 엔티티 내부에서 값을 변경하는 게 더 무결성을 지키기 쉽겠다는 생각이 들어서 unfollow, cancel 등 여러 메서드를 만들어줬어요.
`ex. CANCELED 상태는 기존 상태가 SUCCESS나 PENDING였을 때만 변경 가능`

**Member 엔티티**
전략패턴을 적용했는데요, 아무래도 설계에 관련한 부분은 언급 없이는 이해가 쉽지 않다고 생각해서 적어봤습니다.

```java
public class Member {
    ... 생략 ...
    @Enumerated(EnumType.STRING)
    private FollowStrategy followStrategy;

    public FollowStatus getStatusBasedOnStrategy() {
        return followStrategy.getFollowStatus();
    }
    ... 생략 ...
}
```
```java
@Getter
public enum FollowStrategy {
    EAGER("팔로우 요청 즉시 팔로우가 되는 전략", FollowStatus.SUCCESS),
    LAZY("팔로우 요청이 들어오면 사용자가 확인 후 허가하는 전략", FollowStatus.PENDING);
    ... 생략 ...
}
```
각 Member는 FollowStrategy를 갖도록 만들었어요.
이를 통해 Member가 어떤 Follow 전략을 가지고 있냐에 따라서 -> Follow가 들어왔을 때 다른 상태(SUCCESS, PENDING)를 갖도록 만들어줬어요.

FollowService에서 어떻게 사용하는지 함께 보시면 이해하실 수 있을 거에요.
```java
// FollowService

    private Follow saveFollow(Member fromMember, Member target) {
        Follow follow = Follow.builder()
            .from(fromMember)
            .to(target)
            .status(target.getStatusBasedOnStrategy()) // 여기!
            .build();
        return followRepository.save(follow);
    }
```

## 🧘🏻 기타 사항
2/5 새벽 기준 팔로우 목록 보기 / 팔로워 목록 보기 기능 최적화가 아직 되지 않았습니다.
-> 1:N 문제가 발생하는데요. 내일 해결해 두겠습니다.

close #13
close #18 
close #19 
close #20 
close #26 