### PR TITLE
[#23] Kakao OAuth2 로그인 구현

### DIFF
--- a/src/main/java/com/example/temp/common/config/WebClientConfiguration.java
+++ b/src/main/java/com/example/temp/common/config/WebClientConfiguration.java
@@ -13,17 +13,16 @@ public class WebClientConfiguration {
 
     @Bean
     public GoogleOAuthClient googleOAuthClient() {
-        return createHttpInterface(GoogleOAuthClient.class, "https://www.googleapis.com");
+        return createHttpInterface(GoogleOAuthClient.class);
     }
 
     @Bean
     public KakaoOAuthClient kakaoOauthClient() {
-        return createHttpInterface(KakaoOAuthClient.class, "https://kauth.kakao.com");
+        return createHttpInterface(KakaoOAuthClient.class);
     }
 
-    private <T> T createHttpInterface(Class<T> clazz, String baseUrl) {
+    private <T> T createHttpInterface(Class<T> clazz) {
         WebClient webClient = WebClient.builder()
-            .baseUrl(baseUrl)
             .build();
 
         HttpServiceProxyFactory factory = HttpServiceProxyFactory

--- a/src/main/java/com/example/temp/common/config/WebClientConfiguration.java
+++ b/src/main/java/com/example/temp/common/config/WebClientConfiguration.java
@@ -1,6 +1,7 @@
 package com.example.temp.common.config;
 
 import com.example.temp.oauth.impl.google.GoogleOAuthClient;
+import com.example.temp.oauth.impl.kakao.KakaoOauthClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -13,6 +14,11 @@ public class WebClientConfiguration {
     @Bean
     public GoogleOAuthClient googleOAuthClient() {
         return createHttpInterface(GoogleOAuthClient.class, "https://www.googleapis.com");
+    }
+
+    @Bean
+    public KakaoOauthClient kakaoOauthClient() {
+        return createHttpInterface(KakaoOauthClient.class, "https://kauth.kakao.com");
     }
 
     private <T> T createHttpInterface(Class<T> clazz, String baseUrl) {

--- a/src/main/java/com/example/temp/common/config/WebClientConfiguration.java
+++ b/src/main/java/com/example/temp/common/config/WebClientConfiguration.java
@@ -1,7 +1,7 @@
 package com.example.temp.common.config;
 
 import com.example.temp.oauth.impl.google.GoogleOAuthClient;
-import com.example.temp.oauth.impl.kakao.KakaoOauthClient;
+import com.example.temp.oauth.impl.kakao.KakaoOAuthClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -17,8 +17,8 @@ public class WebClientConfiguration {
     }
 
     @Bean
-    public KakaoOauthClient kakaoOauthClient() {
-        return createHttpInterface(KakaoOauthClient.class, "https://kauth.kakao.com");
+    public KakaoOAuthClient kakaoOauthClient() {
+        return createHttpInterface(KakaoOAuthClient.class, "https://kauth.kakao.com");
     }
 
     private <T> T createHttpInterface(Class<T> clazz, String baseUrl) {

--- a/src/main/java/com/example/temp/oauth/impl/google/GoogleOAuthClient.java
+++ b/src/main/java/com/example/temp/oauth/impl/google/GoogleOAuthClient.java
@@ -11,10 +11,10 @@ import org.springframework.web.service.annotation.PostExchange;
 
 public interface GoogleOAuthClient {
 
-    @PostExchange(url = "/oauth2/v4/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
+    @PostExchange(url = "https://www.googleapis.com/oauth2/v4/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
     GoogleToken fetchToken(@RequestBody MultiValueMap<String, String> params);
 
-    @GetExchange(url = "/oauth2/v3/userinfo")
+    @GetExchange(url = "https://www.googleapis.com/oauth2/v3/userinfo")
     GoogleUserInfo fetchUserInfo(@RequestHeader(name = HttpHeaders.AUTHORIZATION) String authorizationValue);
 
 }

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthClient.java
@@ -1,6 +1,19 @@
 package com.example.temp.oauth.impl.kakao;
 
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
 public interface KakaoOAuthClient {
 
+    @PostExchange(url = "https://kauth.kakao.com/oauth/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
+    KakaoToken fetchToken(@RequestBody MultiValueMap<String, String> params);
 
+    @GetExchange(url = "https://kapi.kakao.com/v2/user/me")
+    KakaoUserInfo fetchUserInfo(@RequestHeader(name = HttpHeaders.AUTHORIZATION) String authorizationValue);
 }

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthClient.java
@@ -1,6 +1,6 @@
 package com.example.temp.oauth.impl.kakao;
 
-public interface KakaoOauthClient {
+public interface KakaoOAuthClient {
 
 
 }

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProperties.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProperties.java
@@ -1,0 +1,45 @@
+package com.example.temp.oauth.impl.kakao;
+
+import java.util.Arrays;
+import java.util.Objects;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoOAuthProperties(
+    String clientId,
+    String clientSecret,
+    String redirectUri,
+    String[] scope
+) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KakaoOAuthProperties that = (KakaoOAuthProperties) o;
+        return Objects.equals(clientId, that.clientId) && Objects.equals(clientSecret,
+            that.clientSecret) && Objects.equals(redirectUri, that.redirectUri) && Arrays.equals(scope,
+            that.scope);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(clientId, clientSecret, redirectUri);
+        result = 31 * result + Arrays.hashCode(scope);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "KakaoOAuthProperties{" +
+            "clientId='" + clientId + '\'' +
+            ", clientSecret='" + clientSecret + '\'' +
+            ", redirectUri='" + redirectUri + '\'' +
+            ", scope=" + Arrays.toString(scope) +
+            '}';
+    }
+}

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProvider.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProvider.java
@@ -34,7 +34,7 @@ public class KakaoOAuthProvider implements OAuthProvider {
             return kakaoOAuthClient.fetchUserInfo(kakaoToken.getValueUsingAuthorizationHeader());
         } catch (WebClientResponseException e) {
             if (e.getStatusCode().is5xxServerError()) {
-                throw new IllegalArgumentException("Google 서버에서 문제가 발생했습니다.");
+                throw new IllegalArgumentException("Kakao 서버에서 문제가 발생했습니다.");
             }
             throw e;
         }

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProvider.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProvider.java
@@ -1,0 +1,65 @@
+package com.example.temp.oauth.impl.kakao;
+
+import com.example.temp.oauth.OAuthProvider;
+import com.example.temp.oauth.OAuthProviderType;
+import com.example.temp.oauth.OAuthResponse;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthProvider implements OAuthProvider {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final KakaoOAuthProperties properties;
+
+    @Override
+    public boolean support(OAuthProviderType providerType) {
+        return Objects.equals(OAuthProviderType.KAKAO, providerType);
+    }
+
+    @Override
+    public OAuthResponse fetch(String authCode) {
+        KakaoToken kakaoToken = fetchToken(authCode);
+        KakaoUserInfo kakaoUserInfo = fetchUserInfo(kakaoToken);
+        return OAuthResponse.of(OAuthProviderType.KAKAO, kakaoUserInfo);
+    }
+
+    private KakaoUserInfo fetchUserInfo(KakaoToken kakaoToken) {
+        try {
+            return kakaoOAuthClient.fetchUserInfo(kakaoToken.getValueUsingAuthorizationHeader());
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().is5xxServerError()) {
+                throw new IllegalArgumentException("Google 서버에서 문제가 발생했습니다.");
+            }
+            throw e;
+        }
+    }
+
+    private KakaoToken fetchToken(String authCode) {
+        try {
+            return kakaoOAuthClient.fetchToken(getFetchTokenParams(authCode));
+        } catch (WebClientResponseException.BadRequest e) {
+            throw new IllegalArgumentException("적절하지 않은 Auth Code 입니다.");
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().is5xxServerError()) {
+                throw new IllegalArgumentException("Kakao 서버에서 문제가 발생했습니다.");
+            }
+            throw e;
+        }
+    }
+
+    private MultiValueMap<String, String> getFetchTokenParams(String authCode) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", properties.clientId());
+        params.add("client_secret", properties.clientSecret());
+        params.add("code", authCode);
+        params.add("redirect_uri", properties.redirectUri());
+        params.add("grant_type", "authorization_code");
+        return params;
+    }
+}

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOauthClient.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOauthClient.java
@@ -1,0 +1,6 @@
+package com.example.temp.oauth.impl.kakao;
+
+public interface KakaoOauthClient {
+
+
+}

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoToken.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoToken.java
@@ -1,0 +1,15 @@
+package com.example.temp.oauth.impl.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoToken(
+    @JsonProperty("access_token")
+    String accessToken,
+    @JsonProperty("token_type")
+    String tokenType
+) {
+
+    public String getValueUsingAuthorizationHeader() {
+        return String.format("%s %s", tokenType, accessToken);
+    }
+}

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoUserInfo.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoUserInfo.java
@@ -1,0 +1,59 @@
+package com.example.temp.oauth.impl.kakao;
+
+import com.example.temp.oauth.OAuthUserInfo;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+public class KakaoUserInfo implements OAuthUserInfo {
+    @JsonProperty("id")
+    private String idUsingResourceServer;
+
+    @JsonProperty("properties")
+    private Properties properties;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    static class Properties {
+        @JsonProperty("nickname")
+        private String name;
+
+    }
+
+    static class KakaoAccount {
+        @JsonProperty("profile")
+        private Profile profile;
+
+        @Getter
+        @JsonProperty("email")
+        private String email;
+
+        @Getter
+        static class Profile {
+            @JsonProperty("profile_image_url")
+            private String profileUrl;
+        }
+    }
+
+    @Override
+    public String getProfileUrl() {
+        return kakaoAccount.profile.getProfileUrl();
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.getEmail();
+    }
+
+    @Override
+    public String getIdUsingResourceServer() {
+        return idUsingResourceServer;
+    }
+
+    @Override
+    public String getName() {
+        return properties.getName();
+    }
+}
+

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoUserInfo.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoUserInfo.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 public class KakaoUserInfo implements OAuthUserInfo {
+
     @JsonProperty("id")
     private String idUsingResourceServer;
 
@@ -16,21 +17,23 @@ public class KakaoUserInfo implements OAuthUserInfo {
 
     @Getter
     static class Properties {
+
         @JsonProperty("nickname")
         private String name;
-
     }
 
+    @Getter
     static class KakaoAccount {
+
         @JsonProperty("profile")
         private Profile profile;
 
-        @Getter
         @JsonProperty("email")
         private String email;
 
         @Getter
         static class Profile {
+
             @JsonProperty("profile_image_url")
             private String profileUrl;
         }
@@ -38,7 +41,7 @@ public class KakaoUserInfo implements OAuthUserInfo {
 
     @Override
     public String getProfileUrl() {
-        return kakaoAccount.profile.getProfileUrl();
+        return kakaoAccount.getProfile().getProfileUrl();
     }
 
     @Override
@@ -56,4 +59,3 @@ public class KakaoUserInfo implements OAuthUserInfo {
         return properties.getName();
     }
 }
-

--- a/src/test/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProviderTest.java
+++ b/src/test/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProviderTest.java
@@ -1,0 +1,158 @@
+package com.example.temp.oauth.impl.kakao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.example.temp.oauth.OAuthProviderType;
+import com.example.temp.oauth.OAuthResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoOAuthProviderTest {
+
+    KakaoOAuthProvider provider;
+
+    @Mock
+    KakaoOAuthClient client;
+
+    @Mock
+    KakaoOAuthProperties properties;
+
+    KakaoToken kakaoToken;
+
+    KakaoUserInfo kakaoUserInfo;
+
+    @BeforeEach
+    void setUp() {
+        provider = new KakaoOAuthProvider(client, properties);
+        kakaoToken = new KakaoToken("test_access_token", "Bearer");
+        kakaoUserInfo = generateKakaoUserInfo();
+    }
+
+    @DisplayName("KakaoOAuthProvider 객체는 Kakao 타입을 지원한다.")
+    @Test
+    void supportTest() {
+        assertThat(provider.support(OAuthProviderType.KAKAO)).isTrue();
+    }
+
+    @DisplayName("KakaoOAuthProvider 객체는 Kakao 이외의 타입을 지원하지 않는다.")
+    @Test
+    void notSupportTest() {
+        assertThat(provider.support(OAuthProviderType.GOOGLE)).isFalse();
+    }
+
+    @DisplayName("KakaoOAuthProvider 객체는 null값을 허용하지 않는다.")
+    @Test
+    void notSupportNull() {
+        assertThat(provider.support(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Kakao에서 발급한 AuthCode를 사용하여 OauthResponse를 받아 올 수 있다.")
+    void fetch() throws Exception {
+        // given
+        when(client.fetchToken(any(MultiValueMap.class)))
+            .thenReturn(kakaoToken);
+        when(client.fetchUserInfo(anyString()))
+            .thenReturn(kakaoUserInfo);
+
+        // when
+        OAuthResponse result = provider.fetch("authCode");
+
+        // then
+        assertThat(result.type()).isEqualTo(OAuthProviderType.KAKAO);
+        assertThat(result.email()).isEqualTo(kakaoUserInfo.getEmail());
+        assertThat(result.name()).isEqualTo(kakaoUserInfo.getName());
+        assertThat(result.idUsingResourceServer()).isEqualTo(kakaoUserInfo.getIdUsingResourceServer());
+        assertThat(result.profileUrl()).isEqualTo(kakaoUserInfo.getProfileUrl());
+    }
+
+    @DisplayName("잘못된 AuthCode가 들어오면 '적절하지 않은 Auth Code 입니다.' 예외 메시지를 던진다.")
+    @Test
+    void fetchWithInvalidAuthCodeTest() {
+        //given
+        String invalidAuthCode = "invalidAuthCode";
+        String errorMessage = "적절하지 않은 Auth Code 입니다.";
+        WebClientResponseException exception = WebClientResponseException.create(
+            HttpStatus.BAD_REQUEST.value(), errorMessage, HttpHeaders.EMPTY, null, null);
+
+        when(client.fetchToken(any(MultiValueMap.class)))
+            .thenThrow(exception);
+
+        //when & then
+        assertThatThrownBy(() -> {
+            provider.fetch(invalidAuthCode);
+        }).isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(errorMessage);
+    }
+
+    @DisplayName("fetchToken 메소드 호출 시 Kakao 서버에서 문제 발생 시 'Kakao 서버에서 문제가 발생했습니다.' 메시지와 함께 예외를 발생시킨다.")
+    @Test
+    void fetchTokenWithServerErrorTest() {
+        // given
+        String authCode = "authCode";
+        String errorMessage = "Kakao 서버에서 문제가 발생했습니다.";
+        WebClientResponseException exception = WebClientResponseException.create(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(), errorMessage, HttpHeaders.EMPTY, null, null);
+
+        when(client.fetchToken(any(MultiValueMap.class))).thenThrow(exception);
+
+        // when & then
+        assertThatThrownBy(() -> {
+            provider.fetch(authCode);
+        }).isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(errorMessage);
+    }
+
+    @Test
+    @DisplayName("fetchUserInfo 메소드 호출 시 Kakao 서버에서 문제 발생 시 'Kakao 서버에서 문제가 발생했습니다.' 메시지와 함께 예외를 발생시킨다.")
+    void fetchUserInfoWithServerErrorTest() {
+        // given
+        String authCode = "authCode";
+        String errorMessage = "Kakao 서버에서 문제가 발생했습니다.";
+
+        WebClientResponseException exception = WebClientResponseException.create(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(), errorMessage, HttpHeaders.EMPTY, null, null);
+
+        when(client.fetchToken(any(MultiValueMap.class))).thenReturn(kakaoToken);
+        when(client.fetchUserInfo(anyString())).thenThrow(exception);
+
+        // when & then
+        assertThatThrownBy(() -> {
+            provider.fetch(authCode);
+        }).isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(errorMessage);
+    }
+
+    private KakaoUserInfo generateKakaoUserInfo() {
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo();
+        ReflectionTestUtils.setField(kakaoUserInfo, "idUsingResourceServer", "testId");
+
+        KakaoUserInfo.Properties properties = new KakaoUserInfo.Properties();
+        ReflectionTestUtils.setField(properties, "name", "testName");
+
+        KakaoUserInfo.KakaoAccount kakaoAccount = new KakaoUserInfo.KakaoAccount();
+        ReflectionTestUtils.setField(kakaoAccount, "email", "testEmail");
+
+        KakaoUserInfo.KakaoAccount.Profile profile = new KakaoUserInfo.KakaoAccount.Profile();
+        ReflectionTestUtils.setField(profile, "profileUrl", "testProfileUrl");
+        ReflectionTestUtils.setField(kakaoAccount, "profile", profile);
+        ReflectionTestUtils.setField(kakaoUserInfo, "kakaoAccount", kakaoAccount);
+        ReflectionTestUtils.setField(kakaoUserInfo, "properties", properties);
+
+        return kakaoUserInfo;
+    }
+}

--- a/src/test/java/com/example/temp/oauth/impl/kakao/KakaoTokenTest.java
+++ b/src/test/java/com/example/temp/oauth/impl/kakao/KakaoTokenTest.java
@@ -1,0 +1,23 @@
+package com.example.temp.oauth.impl.kakao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KakaoTokenTest {
+
+    @DisplayName("카카오 인증헤더에 'Bearer value' 형식으로 출력한다.")
+    @Test
+    void getAuthorizationValue() throws Exception {
+        // given
+        KakaoToken token = new KakaoToken("test_access_token", "Bearer");
+
+        // when
+        String result = token.getValueUsingAuthorizationHeader();
+
+        // then
+        assertThat(result).isEqualTo("Bearer test_access_token");
+    }
+
+}


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] Kakao의 Access Token을 발급받는다.
- [X] Kakao의 Access Token을 사용하여 Nickname, Profile URL, Email을 받아온다.
- [X] 최초 로그인한 사용자는 DB에 데이터를 저장한다.

## 🏌🏻 리뷰 포인트
기본적인 구현방식은 Google Oauth2 구현 방식과 동일하게 진행했습니다. 
테스트 코드는 메소드에 한해서 유닛테스트를 작성했습니다. 
해당 기능은 단순히 DTO의 역할을 하는 클래스가 많기 때문에 그 부분에 대해서는 테스트 코드를 작성하지 않았습니다.

- KakaoUserInfo 같은 경우 카카오에서는 응답 json 형태가 계층형으로 되어 있기 때문에 내부 클래스를 구현해서 받아오도록 구현했습니다. 현재 테스트 결과 로그인 후 닉네임은 카카오에서 동의 후 받아오는 닉네임이 아닌 Faker 라이브러리에서 랜덤으로 만들어진 닉네임이 나오는 데 이 부분은 의도 된 부분일까요!? 그렇다면 nickname 값을 받아오지 않아도 상관이 없을 지 질문드립니다.

- KakaoOAuthProviderTest 같은 경우에도 구글과 비슷한 방식으로 테스트 코드를 작성했습니다. 이 부분에 대해 리뷰 부탁드립니다. 


## 🧘🏻 기타 사항
- 테스트 코드를 작성하는 범위에 대해 궁금합니다. 저는 record 클래스 같은 경우는 따로 메소드를 만들지 않는 경우에는 단순 DTO의 역할만 하기 때문에 테스트 코드를 작성하지 않는 방향으로 가는게 좋다고 생각되어 지는데 태훈님의 의견이 궁금합니다.

close #23 