### PR TITLE
[#32] OAuth 로그인이 가능한 URL 제공

### DIFF
--- a/src/main/java/com/example/temp/auth/dto/response/AuthorizedUrl.java
+++ b/src/main/java/com/example/temp/auth/dto/response/AuthorizedUrl.java
@@ -1,0 +1,10 @@
+package com.example.temp.auth.dto.response;
+
+public record AuthorizedUrl(
+    String authorizedUrl
+) {
+
+    public static AuthorizedUrl createInstance(String authorizedUrl) {
+        return new AuthorizedUrl(authorizedUrl);
+    }
+}

--- a/src/main/java/com/example/temp/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/temp/auth/presentation/AuthController.java
@@ -3,6 +3,9 @@ package com.example.temp.auth.presentation;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 import com.example.temp.auth.dto.request.OAuthLoginRequest;
+import com.example.temp.auth.dto.response.AccessToken;
+import com.example.temp.auth.dto.response.AuthorizedUrl;
+import com.example.temp.auth.dto.response.LoginInfoResponse;
 import com.example.temp.auth.dto.response.LoginMemberResponse;
 import com.example.temp.auth.dto.response.LoginResponse;
 import com.example.temp.auth.dto.response.TokenInfo;
@@ -42,9 +45,9 @@ public class AuthController {
     }
 
     @GetMapping("/oauth/{provider}/authorized_url")
-    public ResponseEntity<Void> getAuthorizedUrl(@PathVariable String provider) {
+    public ResponseEntity<AuthorizedUrl> getAuthorizedUrl(@PathVariable String provider) {
         String authorizedUrl = oAuthService.getAuthorizedUrl(provider);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(AuthorizedUrl.createInstance(authorizedUrl));
     }
 
     @PostMapping("/auth/refresh")

--- a/src/main/java/com/example/temp/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/temp/auth/presentation/AuthController.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,6 +39,12 @@ public class AuthController {
 
         createRefreshCookie(tokenInfo.refreshToken(), response);
         return ResponseEntity.ok(LoginResponse.of(tokenInfo, memberResponse));
+    }
+
+    @GetMapping("/oauth/{provider}/authorized_url")
+    public ResponseEntity<Void> getAuthorizedUrl(@PathVariable String provider) {
+        String authorizedUrl = oAuthService.getAuthorizedUrl(provider);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/auth/refresh")

--- a/src/main/java/com/example/temp/oauth/OAuthProvider.java
+++ b/src/main/java/com/example/temp/oauth/OAuthProvider.java
@@ -5,4 +5,6 @@ public interface OAuthProvider {
     boolean support(OAuthProviderType providerType);
 
     OAuthResponse fetch(String authCode);
+
+    String getAuthorizedUrl();
 }

--- a/src/main/java/com/example/temp/oauth/OAuthProviderResolver.java
+++ b/src/main/java/com/example/temp/oauth/OAuthProviderResolver.java
@@ -11,11 +11,20 @@ public class OAuthProviderResolver {
     private final Set<OAuthProvider> providers;
 
     public OAuthResponse fetch(OAuthProviderType providerType, String authCode) {
-        OAuthProvider oAuthProvider = providers.stream()
+        OAuthProvider oAuthProvider = findProvider(providerType);
+        return oAuthProvider.fetch(authCode);
+    }
+
+    private OAuthProvider findProvider(OAuthProviderType providerType) {
+        return providers.stream()
             .filter(provider -> provider.support(providerType))
             .findAny()
             .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 OAuth 타입입니다."));
-        return oAuthProvider.fetch(authCode);
+    }
+
+    public String getAuthorizedUrl(OAuthProviderType providerType) {
+        OAuthProvider oAuthProvider = findProvider(providerType);
+        return oAuthProvider.getAuthorizedUrl();
     }
 }
 

--- a/src/main/java/com/example/temp/oauth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/oauth/application/OAuthService.java
@@ -44,6 +44,7 @@ public class OAuthService {
     }
 
     public String getAuthorizedUrl(String provider) {
-        return null;
+        OAuthProviderType oAuthProviderType = OAuthProviderType.find(provider);
+        return oAuthProviderResolver.getAuthorizedUrl(oAuthProviderType);
     }
 }

--- a/src/main/java/com/example/temp/oauth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/oauth/application/OAuthService.java
@@ -43,4 +43,7 @@ public class OAuthService {
         return savedMember;
     }
 
+    public String getAuthorizedUrl(String provider) {
+        return null;
+    }
 }

--- a/src/main/java/com/example/temp/oauth/impl/google/GoogleOAuthProperties.java
+++ b/src/main/java/com/example/temp/oauth/impl/google/GoogleOAuthProperties.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "oauth.google")
 public record GoogleOAuthProperties(
+    String fromUri,
     String clientId,
     String clientSecret,
     String redirectUri,
@@ -21,14 +22,14 @@ public record GoogleOAuthProperties(
             return false;
         }
         GoogleOAuthProperties that = (GoogleOAuthProperties) o;
-        return Objects.equals(clientId, that.clientId) && Objects.equals(clientSecret,
-            that.clientSecret) && Objects.equals(redirectUri, that.redirectUri) && Arrays.equals(scope,
-            that.scope);
+        return Objects.equals(fromUri, that.fromUri) && Objects.equals(clientId,
+            that.clientId) && Objects.equals(clientSecret, that.clientSecret) && Objects.equals(
+            redirectUri, that.redirectUri) && Arrays.equals(scope, that.scope);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(clientId, clientSecret, redirectUri);
+        int result = Objects.hash(fromUri, clientId, clientSecret, redirectUri);
         result = 31 * result + Arrays.hashCode(scope);
         return result;
     }
@@ -36,10 +37,12 @@ public record GoogleOAuthProperties(
     @Override
     public String toString() {
         return "GoogleOAuthProperties{" +
-            "clientId='" + clientId + '\'' +
+            "fromUri='" + fromUri + '\'' +
+            ", clientId='" + clientId + '\'' +
             ", clientSecret='" + clientSecret + '\'' +
             ", redirectUri='" + redirectUri + '\'' +
             ", scope=" + Arrays.toString(scope) +
             '}';
     }
+
 }

--- a/src/main/java/com/example/temp/oauth/impl/google/GoogleOAuthProvider.java
+++ b/src/main/java/com/example/temp/oauth/impl/google/GoogleOAuthProvider.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @RequiredArgsConstructor
@@ -31,7 +32,13 @@ public class GoogleOAuthProvider implements OAuthProvider {
 
     @Override
     public String getAuthorizedUrl() {
-        return null;
+        return UriComponentsBuilder
+            .fromUriString(properties.fromUri())
+            .queryParam("client_id", properties.clientId())
+            .queryParam("redirect_uri", properties.redirectUri())
+            .queryParam("response_type", "code")
+            .queryParam("scope", String.join(" ", properties.scope()))
+            .toUriString();
     }
 
     private GoogleUserInfo fetchUserInfo(GoogleToken googleToken) {

--- a/src/main/java/com/example/temp/oauth/impl/google/GoogleOAuthProvider.java
+++ b/src/main/java/com/example/temp/oauth/impl/google/GoogleOAuthProvider.java
@@ -29,6 +29,11 @@ public class GoogleOAuthProvider implements OAuthProvider {
         return OAuthResponse.of(OAuthProviderType.GOOGLE, googleUserInfo);
     }
 
+    @Override
+    public String getAuthorizedUrl() {
+        return null;
+    }
+
     private GoogleUserInfo fetchUserInfo(GoogleToken googleToken) {
         try {
             return googleOAuthClient.fetchUserInfo(googleToken.getValueUsingAuthorizationHeader());

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProperties.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProperties.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "oauth.kakao")
 public record KakaoOAuthProperties(
+    String fromUri,
     String clientId,
     String clientSecret,
     String redirectUri,
@@ -21,14 +22,14 @@ public record KakaoOAuthProperties(
             return false;
         }
         KakaoOAuthProperties that = (KakaoOAuthProperties) o;
-        return Objects.equals(clientId, that.clientId) && Objects.equals(clientSecret,
-            that.clientSecret) && Objects.equals(redirectUri, that.redirectUri) && Arrays.equals(scope,
-            that.scope);
+        return Objects.equals(fromUri, that.fromUri) && Objects.equals(clientId, that.clientId)
+            && Objects.equals(clientSecret, that.clientSecret) && Objects.equals(redirectUri,
+            that.redirectUri) && Arrays.equals(scope, that.scope);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(clientId, clientSecret, redirectUri);
+        int result = Objects.hash(fromUri, clientId, clientSecret, redirectUri);
         result = 31 * result + Arrays.hashCode(scope);
         return result;
     }
@@ -36,7 +37,8 @@ public record KakaoOAuthProperties(
     @Override
     public String toString() {
         return "KakaoOAuthProperties{" +
-            "clientId='" + clientId + '\'' +
+            "fromUri='" + fromUri + '\'' +
+            ", clientId='" + clientId + '\'' +
             ", clientSecret='" + clientSecret + '\'' +
             ", redirectUri='" + redirectUri + '\'' +
             ", scope=" + Arrays.toString(scope) +

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProvider.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProvider.java
@@ -29,6 +29,11 @@ public class KakaoOAuthProvider implements OAuthProvider {
         return OAuthResponse.of(OAuthProviderType.KAKAO, kakaoUserInfo);
     }
 
+    @Override
+    public String getAuthorizedUrl() {
+        return null;
+    }
+
     private KakaoUserInfo fetchUserInfo(KakaoToken kakaoToken) {
         try {
             return kakaoOAuthClient.fetchUserInfo(kakaoToken.getValueUsingAuthorizationHeader());

--- a/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProvider.java
+++ b/src/main/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProvider.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @RequiredArgsConstructor
@@ -31,8 +32,13 @@ public class KakaoOAuthProvider implements OAuthProvider {
 
     @Override
     public String getAuthorizedUrl() {
-        return null;
-    }
+        return UriComponentsBuilder
+            .fromUriString(properties.fromUri())
+            .queryParam("client_id", properties.clientId())
+            .queryParam("redirect_uri", properties.redirectUri())
+            .queryParam("response_type", "code")
+            .queryParam("scope", String.join(",", properties.scope()))
+            .toUriString();    }
 
     private KakaoUserInfo fetchUserInfo(KakaoToken kakaoToken) {
         try {

--- a/src/test/java/com/example/temp/oauth/OAuthProviderResolverUnitTest.java
+++ b/src/test/java/com/example/temp/oauth/OAuthProviderResolverUnitTest.java
@@ -69,4 +69,36 @@ class OAuthProviderResolverUnitTest {
         verify(oAuthProvider1, never()).fetch(anyString());
         verify(oAuthProvider2, never()).fetch(anyString());
     }
+
+    @Test
+    @DisplayName("입력된 OAuthProviderType에 해당되는 Provider의 Authorized URL을 받아온다.")
+    void getAuthorizedUrlSuccess() throws Exception {
+        // given
+        when(oAuthProvider1.support(any(OAuthProviderType.class)))
+            .thenReturn(true);
+
+        // when
+        resolver.getAuthorizedUrl(OAuthProviderType.KAKAO);
+
+        // then
+        verify(oAuthProvider1, times(1)).getAuthorizedUrl();
+        verify(oAuthProvider2, never()).getAuthorizedUrl();
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 OAuthProviderType을 입력받으면 예외를 반환한다")
+    void getAuthorizedUrlFailNotSupported() throws Exception {
+        // given
+        when(oAuthProvider1.support(any(OAuthProviderType.class)))
+            .thenReturn(false);
+        when(oAuthProvider2.support(any(OAuthProviderType.class)))
+            .thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> resolver.getAuthorizedUrl(OAuthProviderType.KAKAO))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("지원하지 않는 OAuth 타입입니다.");
+        verify(oAuthProvider1, never()).fetch(anyString());
+        verify(oAuthProvider2, never()).fetch(anyString());
+    }
 }

--- a/src/test/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProviderTest.java
+++ b/src/test/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProviderTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.temp.oauth.OAuthProviderType;
@@ -19,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @ExtendWith(MockitoExtension.class)
 class KakaoOAuthProviderTest {
@@ -154,5 +157,38 @@ class KakaoOAuthProviderTest {
         ReflectionTestUtils.setField(kakaoUserInfo, "properties", properties);
 
         return kakaoUserInfo;
+    }
+
+    @Test
+    @DisplayName("인증 URL을 받아온다.")
+    void getAuthorizedUrl() throws Exception {
+        // given
+        String fromUri = "fromUri";
+        String clientId = "clientId";
+        String redirectUri = "redirectUri";
+        String[] scope = new String[]{"first", "second"};
+        when(properties.fromUri()).thenReturn(fromUri);
+        when(properties.clientId()).thenReturn(clientId);
+        when(properties.redirectUri()).thenReturn(redirectUri);
+        when(properties.scope()).thenReturn(scope);
+        String expectedUrl = createUrl(fromUri, clientId, redirectUri, scope);
+
+        // when
+        String authorizedUrl = provider.getAuthorizedUrl();
+
+        // then
+        assertThat(authorizedUrl).isEqualTo(expectedUrl);
+        verify(properties, never()).clientSecret();
+    }
+
+    private static String createUrl(String fromUri, String clientId, String redirectUri, String[] scope) {
+        String kakaoScopeDelimiter = ",";
+        return UriComponentsBuilder
+            .fromUriString(fromUri)
+            .queryParam("client_id", clientId)
+            .queryParam("redirect_uri", redirectUri)
+            .queryParam("response_type", "code")
+            .queryParam("scope", String.join(kakaoScopeDelimiter, scope))
+            .toUriString();
     }
 }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 구글 OAuth 로그인 URL을 반환하는 기능 구현
- [x] 카카오 OAuth 로그인 URL을 반환하는 기능 구현

프론트엔드에서 OAuthProvider에 대한 정보를 모르도록 설계했습니다~~

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
**getAuthorizedUrl을 만드는 책임을 누가 가져가야 할까?**
현재 해당 책임은 OAuthProvider 구현체들에게 각각 있는데, 
구조 살짝만 바꾸면 하나의 지점에서 getAuthorizedUrl을 공통 처리할 수 있더라구요.

Google과 Kakao에서 getAuthorizedUrl의 내부 로직이 동일해요. 
```java
// 구글 예시
    @Override
    public String getAuthorizedUrl() {
        return UriComponentsBuilder
            .fromUriString(properties.fromUri())
            .queryParam("client_id", properties.clientId())
            .queryParam("redirect_uri", properties.redirectUri())
            .queryParam("response_type", "code")
            .queryParam("scope", String.join(" ", properties.scope()))
            .toUriString();
    }
```
여기에서 scope 부분의 String.join 구분자만 ","로 바꿔주면 카카오의 `getAUthorizedUrl`이 됩니다.
각 구현체가 들고 있는 properties 필드도 동일해서, 살짝만 건들면 깔끔한 구조가 나오겠다 싶은데...

일단 참았습니다. 지금 할게 많아서 나중으로 미루려구요.

close #32 