### PR TITLE
[#34] SonarCloud와 Jacoco 연동

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: CI
+on:
+  pull_request:
+    branches: [dev, main]
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: 'gradle'
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Build and analyze
+        run: ./gradlew build jacocoTestReport sonar --info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.8'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
+    id "org.sonarqube" version "4.4.1.3373"
 }
 
 group = 'com.example'
@@ -54,4 +56,21 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacocoTestReport {
+    reports {
+        xml.required.set(false)
+        html.required.set(false)
+    }
+}
+
+sonar {
+    properties {
+        property 'sonar.host.url', 'https://sonarcloud.io'
+        property 'sonar.organization', 'gymhubcommunity'
+        property 'sonar.projectKey', 'GymHubCommunity_GymHub-BE'
+        property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
+    }
 }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] SonarCloud와 Jacoco를 사용해 SonarCloud가 테스트 커버리지를 검사하도록 만들었습니다.

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
테스트용 레포지토리 파서 확인을 해봤어야 하는데 믿고 가보겠습니당

참고한 자료는 다음과 같습니다.
https://gong-check.github.io/dev-blog/BE/%EC%98%A4%EB%A6%AC/sonarcloud/sonarcloud/

https://velog.io/@chaerim1001/Springboot-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-SonarCloud%EB%A1%9C-%EC%A0%95%EC%A0%81-%EC%BD%94%EB%93%9C-%EB%B6%84%EC%84%9D%ED%95%98%EA%B8%B0-with-github-actions

close #34 