### PR TITLE
[#37] 사용자 인증, 인가

### DIFF
--- a/src/main/java/com/example/temp/auth/infrastructure/JwtTokenManager.java
+++ b/src/main/java/com/example/temp/auth/infrastructure/JwtTokenManager.java
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Transactional
 @RequiredArgsConstructor
-public class JwtTokenManager implements TokenManager {
+public class JwtTokenManager implements TokenManager, TokenParser {
 
     private static final String BEARER = "Bearer";
 
@@ -93,17 +93,24 @@ public class JwtTokenManager implements TokenManager {
      */
     @Override
     public TokenInfo reIssue(String refreshToken) {
-        Jws<Claims> claimsJws = parse(refreshToken);
+        Jws<Claims> claimsJws = parseToJwsClaims(refreshToken);
         Claims claims = claimsJws.getPayload();
         long id = Long.parseLong(claims.getSubject());
         return issue(id);
     }
 
-    private Jws<Claims> parse(String token) {
+    private Jws<Claims> parseToJwsClaims(String token) {
         try {
             return parser.parseSignedClaims(token);
         } catch (SignatureException e) {
             throw new TokenInvalidException(e);
         }
+    }
+
+    @Override
+    public long parse(String token) {
+        Jws<Claims> claimsJws = parseToJwsClaims(token);
+        Claims claims = claimsJws.getPayload();
+        return Long.parseLong(claims.getSubject());
     }
 }

--- a/src/main/java/com/example/temp/auth/infrastructure/TokenParser.java
+++ b/src/main/java/com/example/temp/auth/infrastructure/TokenParser.java
@@ -1,0 +1,6 @@
+package com.example.temp.auth.infrastructure;
+
+public interface TokenParser {
+
+    long parse(String token);
+}

--- a/src/main/java/com/example/temp/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/temp/auth/presentation/AuthController.java
@@ -3,9 +3,7 @@ package com.example.temp.auth.presentation;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 import com.example.temp.auth.dto.request.OAuthLoginRequest;
-import com.example.temp.auth.dto.response.AccessToken;
 import com.example.temp.auth.dto.response.AuthorizedUrl;
-import com.example.temp.auth.dto.response.LoginInfoResponse;
 import com.example.temp.auth.dto.response.LoginMemberResponse;
 import com.example.temp.auth.dto.response.LoginResponse;
 import com.example.temp.auth.dto.response.TokenInfo;

--- a/src/main/java/com/example/temp/common/config/WebConfig.java
+++ b/src/main/java/com/example/temp/common/config/WebConfig.java
@@ -1,9 +1,11 @@
 package com.example.temp.common.config;
 
+import com.example.temp.common.interceptor.AuthenticationInterceptor;
 import com.example.temp.common.properties.CorsProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -11,6 +13,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final CorsProperties corsProperties;
+
+    private final AuthenticationInterceptor authenticationInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -20,5 +24,12 @@ public class WebConfig implements WebMvcConfigurer {
             .allowedHeaders(corsProperties.allowedHeaders())
             .exposedHeaders(corsProperties.exposedHeaders())
             .allowCredentials(true);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authenticationInterceptor)
+            .excludePathPatterns("/oauth/**")
+            .excludePathPatterns("/auth/refresh");
     }
 }

--- a/src/main/java/com/example/temp/common/config/WebConfig.java
+++ b/src/main/java/com/example/temp/common/config/WebConfig.java
@@ -29,7 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
-            .excludePathPatterns("/oauth/**")
-            .excludePathPatterns("/auth/refresh");
+            .excludePathPatterns("/oauth/**", "/auth/refresh")
+            .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**");
     }
 }

--- a/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
@@ -6,9 +6,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @RequiredArgsConstructor
+@Component
 public class AuthenticationInterceptor implements HandlerInterceptor {
 
     public static final String BEARER = "Bearer ";

--- a/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,33 @@
+package com.example.temp.common.interceptor;
+
+import com.example.temp.auth.infrastructure.TokenParser;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    public static final String BEARER = "Bearer ";
+    public static final String EXECUTOR = "executor";
+
+    private final TokenParser tokenParser;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+        throws Exception {
+        String accessTokenBeforeProcessing = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (accessTokenBeforeProcessing == null || !accessTokenBeforeProcessing.startsWith(BEARER)) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+        String accessToken = accessTokenBeforeProcessing.substring(BEARER.length());
+        long memberId = tokenParser.parse(accessToken);
+        request.setAttribute(EXECUTOR, memberId);
+        return true;
+    }
+
+}

--- a/src/test/java/com/example/temp/auth/infrastructure/JwtTokenManagerTest.java
+++ b/src/test/java/com/example/temp/auth/infrastructure/JwtTokenManagerTest.java
@@ -129,6 +129,21 @@ class JwtTokenManagerTest {
             .isInstanceOf(TokenInvalidException.class);
     }
 
+    @Test
+    @DisplayName("토큰을 파싱해서 id를 얻는다")
+    void parse() throws Exception {
+        // given
+        long memberId = 1L;
+        Date future = Date.from(fixedMachineTime.plusSeconds(100000L));
+        String token = createToken(future, memberId);
+
+        // when
+        long result = jwtTokenManager.parse(token);
+
+        // then
+        assertThat(result).isEqualTo(memberId);
+    }
+
     private String createToken(Date expired, long subject) {
         return Jwts.builder()
             .subject(String.valueOf(subject))

--- a/src/test/java/com/example/temp/common/interceptor/AuthenticationInterceptorTest.java
+++ b/src/test/java/com/example/temp/common/interceptor/AuthenticationInterceptorTest.java
@@ -1,0 +1,98 @@
+package com.example.temp.common.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.temp.auth.infrastructure.TokenParser;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationInterceptorTest {
+
+    AuthenticationInterceptor authenticationInterceptor;
+
+    @Mock
+    TokenParser tokenParser;
+
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    HttpServletResponse response;
+
+    long executorId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        authenticationInterceptor = new AuthenticationInterceptor(tokenParser);
+    }
+
+    @Test
+    @DisplayName("사용자가 유효한 토큰을 사용하면 통과한다.")
+    void passSuccess() throws Exception {
+        // given
+        String token = "token";
+        when(tokenParser.parse(token))
+            .thenReturn(executorId);
+        when(request.getHeader(HttpHeaders.AUTHORIZATION))
+            .thenReturn("Bearer " + token);
+
+        // when
+        boolean result = authenticationInterceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isTrue();
+        verify(request, times(1)).setAttribute("executor", executorId);
+    }
+
+    @Test
+    @DisplayName("인증 헤더에 토큰이 없으면 통과할 수 없다.")
+    void passFailTokenNotFound() throws Exception {
+        // given
+        String token = "token";
+        when(request.getHeader(HttpHeaders.AUTHORIZATION))
+            .thenReturn(null);
+
+        // when
+        boolean result = authenticationInterceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isFalse();
+        verify(response, times(1)).setStatus(HttpStatus.UNAUTHORIZED.value());
+        verify(request, never()).setAttribute(anyString(), anyLong());
+        verify(tokenParser, never()).parse(anyString());
+    }
+
+    @Test
+    @DisplayName("인증 헤더에 토큰이 Bearer로 시작하지 않으면 통과할 수 없다.")
+    void passFailTokenNotStartBearer() throws Exception {
+        // given
+        String token = "token";
+        when(request.getHeader(HttpHeaders.AUTHORIZATION))
+            .thenReturn(token);
+
+        // when
+        boolean result = authenticationInterceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isFalse();
+        verify(response, times(1)).setStatus(HttpStatus.UNAUTHORIZED.value());
+        verify(request, never()).setAttribute(anyString(), anyLong());
+        verify(tokenParser, never()).parse(anyString());
+    }
+
+}


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] Interceptor에서 access token을 확인
- [x] JwtTokenManager에 토큰 파싱하는 기능 추가

## 🏌🏻 리뷰 포인트
**TokenParser 인터페이스 생성**
뭔가 딱 생각했을 때, 인터셉터에서 TokenManager의 모든 기능을 아는 건 위험하지 않을까?? 하는 생각이 자꾸 들어서요.
그냥 딱 토큰을 parse하는 책임만 가져가도록 인터페이스를 한 개 더 만들었습니다~

## 🧘🏻 기타 사항
적절한 Access Token를 보낸 요청은 컨트롤러에서 `@RequestAttribute(name="executor") Long executorId` 로 ID를 가져올 수 있습니다.
-> RequestAttribute는 외부에서 변수로 넣어줄 수 없어서 안전해요 예~

close #37 