### PR TITLE
[#36] 회원가입

### DIFF
--- a/src/main/java/com/example/temp/auth/dto/response/AccessToken.java
+++ b/src/main/java/com/example/temp/auth/dto/response/AccessToken.java
@@ -1,6 +1,0 @@
-package com.example.temp.auth.dto.response;
-
-@SuppressWarnings("java:S2094")
-public record AccessToken() {
-
-}

--- a/src/main/java/com/example/temp/auth/dto/response/LoginMemberResponse.java
+++ b/src/main/java/com/example/temp/auth/dto/response/LoginMemberResponse.java
@@ -1,15 +1,20 @@
 package com.example.temp.auth.dto.response;
 
 import com.example.temp.member.domain.Member;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public record LoginMemberResponse(
     Long id,
     String email,
     String profileUrl,
-    String nickname
+    String nickname,
+
+    @JsonIgnore
+    boolean init
 ) {
 
     public static LoginMemberResponse of(Member member) {
-        return new LoginMemberResponse(member.getId(), member.getEmail(), member.getProfileUrl(), member.getNickname());
+        return new LoginMemberResponse(member.getId(), member.getEmail(), member.getProfileUrl(),
+            member.getNickname(), member.isInit());
     }
 }

--- a/src/main/java/com/example/temp/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/temp/auth/dto/response/LoginResponse.java
@@ -3,10 +3,10 @@ package com.example.temp.auth.dto.response;
 public record LoginResponse(
     String accessToken,
     boolean requiredAdditionalInfo,
-    LoginMemberResponse userInfo
+    MemberInfo userInfo
 ) {
 
-    public static LoginResponse of(TokenInfo tokenInfo, LoginMemberResponse memberResponse) {
+    public static LoginResponse of(TokenInfo tokenInfo, MemberInfo memberResponse) {
         return new LoginResponse(tokenInfo.accessToken(), memberResponse.init(), memberResponse);
     }
 }

--- a/src/main/java/com/example/temp/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/temp/auth/dto/response/LoginResponse.java
@@ -7,6 +7,6 @@ public record LoginResponse(
 ) {
 
     public static LoginResponse of(TokenInfo tokenInfo, MemberInfo memberResponse) {
-        return new LoginResponse(tokenInfo.accessToken(), memberResponse.init(), memberResponse);
+        return new LoginResponse(tokenInfo.accessToken(), !memberResponse.registered(), memberResponse);
     }
 }

--- a/src/main/java/com/example/temp/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/temp/auth/dto/response/LoginResponse.java
@@ -2,10 +2,11 @@ package com.example.temp.auth.dto.response;
 
 public record LoginResponse(
     String accessToken,
+    boolean requiredAdditionalInfo,
     LoginMemberResponse userInfo
 ) {
 
     public static LoginResponse of(TokenInfo tokenInfo, LoginMemberResponse memberResponse) {
-        return new LoginResponse(tokenInfo.accessToken(), memberResponse);
+        return new LoginResponse(tokenInfo.accessToken(), memberResponse.init(), memberResponse);
     }
 }

--- a/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
+++ b/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
@@ -15,6 +15,6 @@ public record MemberInfo(
 
     public static MemberInfo of(Member member) {
         return new MemberInfo(member.getId(), member.getEmail(), member.getProfileUrl(),
-            member.getNickname(), member.isInit());
+            member.getNickname(), member.isRegistered());
     }
 }

--- a/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
+++ b/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
@@ -14,7 +14,7 @@ public record MemberInfo(
 ) {
 
     public static MemberInfo of(Member member) {
-        return new MemberInfo(member.getId(), member.getEmail(), member.getProfileUrl(),
+        return new MemberInfo(member.getId(), member.getEmailStr(), member.getProfileUrl(),
             member.getNicknameStr(), member.isRegistered());
     }
 }

--- a/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
+++ b/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
@@ -10,7 +10,7 @@ public record MemberInfo(
     String nickname,
 
     @JsonIgnore
-    boolean init
+    boolean registered
 ) {
 
     public static MemberInfo of(Member member) {

--- a/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
+++ b/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
@@ -3,7 +3,7 @@ package com.example.temp.auth.dto.response;
 import com.example.temp.member.domain.Member;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public record LoginMemberResponse(
+public record MemberInfo(
     Long id,
     String email,
     String profileUrl,
@@ -13,8 +13,8 @@ public record LoginMemberResponse(
     boolean init
 ) {
 
-    public static LoginMemberResponse of(Member member) {
-        return new LoginMemberResponse(member.getId(), member.getEmail(), member.getProfileUrl(),
+    public static MemberInfo of(Member member) {
+        return new MemberInfo(member.getId(), member.getEmail(), member.getProfileUrl(),
             member.getNickname(), member.isInit());
     }
 }

--- a/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
+++ b/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
@@ -14,7 +14,7 @@ public record MemberInfo(
 ) {
 
     public static MemberInfo of(Member member) {
-        return new MemberInfo(member.getId(), member.getEmailStr(), member.getProfileUrl(),
-            member.getNicknameStr(), member.isRegistered());
+        return new MemberInfo(member.getId(), member.getEmailValue(), member.getProfileUrl(),
+            member.getNicknameValue(), member.isRegistered());
     }
 }

--- a/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
+++ b/src/main/java/com/example/temp/auth/dto/response/MemberInfo.java
@@ -15,6 +15,6 @@ public record MemberInfo(
 
     public static MemberInfo of(Member member) {
         return new MemberInfo(member.getId(), member.getEmail(), member.getProfileUrl(),
-            member.getNickname(), member.isRegistered());
+            member.getNicknameStr(), member.isRegistered());
     }
 }

--- a/src/main/java/com/example/temp/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/temp/auth/presentation/AuthController.java
@@ -4,8 +4,8 @@ import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 import com.example.temp.auth.dto.request.OAuthLoginRequest;
 import com.example.temp.auth.dto.response.AuthorizedUrl;
-import com.example.temp.auth.dto.response.LoginMemberResponse;
 import com.example.temp.auth.dto.response.LoginResponse;
+import com.example.temp.auth.dto.response.MemberInfo;
 import com.example.temp.auth.dto.response.TokenInfo;
 import com.example.temp.auth.infrastructure.TokenManager;
 import com.example.temp.oauth.application.OAuthService;
@@ -35,7 +35,7 @@ public class AuthController {
     @PostMapping("/oauth/{provider}/login")
     public ResponseEntity<LoginResponse> oauthLogin(@PathVariable String provider,
         @RequestBody OAuthLoginRequest request, HttpServletResponse response) {
-        LoginMemberResponse memberResponse = oAuthService.login(provider, request.authCode());
+        MemberInfo memberResponse = oAuthService.login(provider, request.authCode());
         TokenInfo tokenInfo = tokenManager.issue(memberResponse.id());
 
         createRefreshCookie(tokenInfo.refreshToken(), response);

--- a/src/main/java/com/example/temp/common/entity/Email.java
+++ b/src/main/java/com/example/temp/common/entity/Email.java
@@ -1,0 +1,29 @@
+package com.example.temp.common.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode
+@SuppressWarnings("java:S1700")
+public class Email {
+
+    private String email;
+
+    @Builder
+    private Email(String email) {
+        this.email = email;
+    }
+
+    public static Email create(String email) {
+        return Email.builder()
+            .email(email)
+            .build();
+    }
+}

--- a/src/main/java/com/example/temp/common/entity/Email.java
+++ b/src/main/java/com/example/temp/common/entity/Email.java
@@ -1,5 +1,6 @@
 package com.example.temp.common.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,19 +12,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode
-@SuppressWarnings("java:S1700")
 public class Email {
 
-    private String email;
+    @Column(name = "email", nullable = false)
+    private String value;
 
     @Builder
-    private Email(String email) {
-        this.email = email;
+    private Email(String value) {
+        this.value = value;
     }
 
-    public static Email create(String email) {
+    public static Email create(String value) {
         return Email.builder()
-            .email(email)
+            .value(value)
             .build();
     }
 }

--- a/src/main/java/com/example/temp/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     AUTHENTICATED_FAIL(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     AUTHORIZED_FAIL(HttpStatus.FORBIDDEN, "인가 권한이 없는 사용자입니다."),
 
+
     // 회원
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당되는 회원을 찾을 수 없습니다."),
     MEMBER_ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "이미 가입이 완료된 회원입니다."),

--- a/src/main/java/com/example/temp/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/exception/ErrorCode.java
@@ -18,6 +18,11 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당되는 회원을 찾을 수 없습니다."),
     MEMBER_ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "이미 가입이 완료된 회원입니다."),
 
+    // 닉네임
+    NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "닉네임의 길이가 너무 깁니다."),
+    NICKNAME_TOO_SHORT(HttpStatus.BAD_REQUEST, "닉네임의 길이가 너무 짧습니다."),
+    NICKNAME_PATTERN_MISMATCH(HttpStatus.BAD_REQUEST, "닉네임에 허용되지 않는 문자가 포함되었습니다."),
+
     // 팔로우
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "두 회원 간에 팔로우 관계를 찾을 수 없습니다."),
     FOLLOW_SELF_FAIL(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),

--- a/src/main/java/com/example/temp/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 
     // 회원
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당되는 회원을 찾을 수 없습니다."),
+    MEMBER_ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "이미 가입이 완료된 회원입니다."),
 
     // 팔로우
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "두 회원 간에 팔로우 관계를 찾을 수 없습니다."),

--- a/src/main/java/com/example/temp/exception/ErrorResponse.java
+++ b/src/main/java/com/example/temp/exception/ErrorResponse.java
@@ -1,5 +1,30 @@
 package com.example.temp.exception;
 
-public record ErrorResponse(String message) {
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ErrorResponse {
+
+    public static final String SERVER_ERROR_MSG = "서버 에러가 발생했습니다. 관리자에게 문의하세요.";
+
+    private String message;
+
+    @Builder
+    private ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public static ErrorResponse create(String message) {
+        return ErrorResponse.builder()
+            .message(message)
+            .build();
+    }
+
+    public static ErrorResponse createServerError() {
+        return create(SERVER_ERROR_MSG);
+    }
 }

--- a/src/main/java/com/example/temp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/temp/exception/GlobalExceptionHandler.java
@@ -1,15 +1,32 @@
 package com.example.temp.exception;
 
+import com.example.temp.member.exception.NicknameDuplicatedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<ErrorResponse> handleApiException(ApiException exception) {
         return ResponseEntity.status(exception.getErrorCode().getHttpStatus())
-            .body(new ErrorResponse(exception.getMessage()));
+            .body(ErrorResponse.create(exception.getMessage()));
+    }
+
+    @ExceptionHandler({NicknameDuplicatedException.class})
+    public ResponseEntity<ErrorResponse> handleBadRequestStatus(RuntimeException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.create(exception.getMessage()));
+    }
+
+    @ExceptionHandler(Throwable.class)
+    public ResponseEntity<ErrorResponse> handleServerException(Exception exception) {
+        log.warn(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse.createServerError());
     }
 }

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -11,7 +11,7 @@ import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowRepository;
 import com.example.temp.follow.domain.FollowStatus;
 import com.example.temp.follow.dto.response.FollowInfo;
-import com.example.temp.follow.response.FollowResponse;
+import com.example.temp.follow.dto.response.FollowResponse;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
 import java.util.List;

--- a/src/main/java/com/example/temp/follow/dto/response/FollowResponse.java
+++ b/src/main/java/com/example/temp/follow/dto/response/FollowResponse.java
@@ -1,4 +1,4 @@
-package com.example.temp.follow.response;
+package com.example.temp.follow.dto.response;
 
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowStatus;

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -3,7 +3,7 @@ package com.example.temp.follow.presentation;
 import com.example.temp.follow.application.FollowService;
 import com.example.temp.follow.dto.response.FollowInfo;
 import com.example.temp.follow.dto.response.FollowInfos;
-import com.example.temp.follow.response.FollowResponse;
+import com.example.temp.follow.dto.response.FollowResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -1,7 +1,9 @@
 package com.example.temp.member.application;
 
+import com.example.temp.auth.dto.response.MemberInfo;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
+import com.example.temp.member.dto.request.MemberRegisterRequest;
 import com.example.temp.member.exception.NicknameDuplicatedException;
 import com.example.temp.member.infrastructure.nickname.NicknameGenerator;
 import com.example.temp.oauth.OAuthResponse;
@@ -46,4 +48,7 @@ public class MemberService {
         }
     }
 
+    public MemberInfo register(MemberRegisterRequest request) {
+        return null;
+    }
 }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -52,10 +52,10 @@ public class MemberService {
     }
 
     /**
-     * 초기화가 되어 있지 않던 Member를 사용 가능한 상태로 변경합니다.
+     * 가입 처리가 완료되지 않은 회원을 가입시킵니다.
      *
      * @param executorId 로그인한 사용자의 ID
-     * @param request
+     * @param request 회원 가입에 필요한 정보
      * @return 회원가입이 완료된 Member 객체의 정보를 반환합니다.
      */
     @Transactional

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -50,6 +50,13 @@ public class MemberService {
         }
     }
 
+    /**
+     * 초기화가 되어 있지 않던 Member를 사용 가능한 상태로 변경합니다.
+     *
+     * @param executorId 로그인한 사용자의 ID
+     * @param request
+     * @return 회원가입이 완료된 Member 객체의 정보를 반환합니다.
+     */
     @Transactional
     public MemberInfo register(long executorId, MemberRegisterRequest request) {
         Member member = memberRepository.findById(executorId)

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -48,7 +48,7 @@ public class MemberService {
         }
     }
 
-    public MemberInfo register(MemberRegisterRequest request) {
+    public MemberInfo register(long executorId, MemberRegisterRequest request) {
         return null;
     }
 }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -32,7 +32,7 @@ public class MemberService {
      */
     @Transactional
     @Retryable(retryFor = NicknameDuplicatedException.class, maxAttempts = LOOP_MAX_CNT, backoff = @Backoff(delay = 0))
-    public Member register(OAuthResponse oAuthResponse) {
+    public Member saveInitStatusMember(OAuthResponse oAuthResponse) {
         try {
             String nickname = nicknameGenerator.generate();
             if (memberRepository.existsByNickname(nickname)) {

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -7,6 +7,7 @@ import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
 import com.example.temp.member.dto.request.MemberRegisterRequest;
 import com.example.temp.member.exception.NicknameDuplicatedException;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import com.example.temp.member.infrastructure.nickname.NicknameGenerator;
 import com.example.temp.oauth.OAuthResponse;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +39,7 @@ public class MemberService {
     @Retryable(retryFor = NicknameDuplicatedException.class, maxAttempts = LOOP_MAX_CNT, backoff = @Backoff(delay = 0))
     public Member saveInitStatusMember(OAuthResponse oAuthResponse) {
         try {
-            String nickname = nicknameGenerator.generate();
+            Nickname nickname = nicknameGenerator.generate();
             if (memberRepository.existsByNickname(nickname)) {
                 throw new NicknameDuplicatedException();
             }
@@ -61,7 +62,7 @@ public class MemberService {
     public MemberInfo register(long executorId, MemberRegisterRequest request) {
         Member member = memberRepository.findById(executorId)
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
-        member.init(request.nickname(), request.profileUrl());
+        member.init(Nickname.create(request.nickname()), request.profileUrl());
         return MemberInfo.of(member);
     }
 }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
             if (memberRepository.existsByNickname(nickname)) {
                 throw new NicknameDuplicatedException();
             }
-            Member member = oAuthResponse.toMemberWithNickname(nickname);
+            Member member = oAuthResponse.toInitStatusMemberWith(nickname);
             memberRepository.save(member);
             return member;
         } catch (DataIntegrityViolationException e) {

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -1,6 +1,8 @@
 package com.example.temp.member.application;
 
 import com.example.temp.auth.dto.response.MemberInfo;
+import com.example.temp.exception.ApiException;
+import com.example.temp.exception.ErrorCode;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
 import com.example.temp.member.dto.request.MemberRegisterRequest;
@@ -48,7 +50,11 @@ public class MemberService {
         }
     }
 
+    @Transactional
     public MemberInfo register(long executorId, MemberRegisterRequest request) {
-        return null;
+        Member member = memberRepository.findById(executorId)
+            .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
+        member.init(request.nickname(), request.profileUrl());
+        return MemberInfo.of(member);
     }
 }

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -25,6 +25,8 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
+    private boolean init;
+
     @Column(nullable = false)
     private String email;
 
@@ -41,8 +43,9 @@ public class Member {
     private boolean publicAccount;
 
     @Builder
-    private Member(String email, String profileUrl, String nickname,
+    private Member(boolean init, String email, String profileUrl, String nickname,
         FollowStrategy followStrategy, boolean publicAccount) {
+        this.init = init;
         this.email = email;
         this.profileUrl = profileUrl;
         this.nickname = nickname;

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -27,7 +27,10 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
-    private boolean init;
+    /**
+     * 사용자에게 profileUrl과 nickname을 인증받았다면 true, 그렇지 않다면 false를 갖습니다.
+     */
+    private boolean registered;
 
     @Column(nullable = false)
     private String email;
@@ -45,10 +48,10 @@ public class Member {
     private boolean publicAccount;
 
     @Builder
-    private Member(boolean init, String email, String profileUrl, String nickname,
+    private Member(String email, boolean registered, String profileUrl, String nickname,
         FollowStrategy followStrategy, boolean publicAccount) {
-        this.init = init;
         this.email = email;
+        this.registered = registered;
         this.profileUrl = profileUrl;
         this.nickname = nickname;
         this.followStrategy = followStrategy;
@@ -62,7 +65,7 @@ public class Member {
     @Builder(builderMethodName = "buildInitStatus")
     private Member(String email, String profileUrl, String nickname,
         FollowStrategy followStrategy) {
-        this.init = false;
+        this.registered = false;
         this.publicAccount = false;
         this.email = email;
         this.profileUrl = profileUrl;
@@ -70,12 +73,11 @@ public class Member {
         this.followStrategy = followStrategy;
     }
 
-
     public void init(String nickname, String profileUrl) {
-        if (init) {
+        if (registered) {
             throw new ApiException(ErrorCode.MEMBER_ALREADY_REGISTER);
         }
-        this.init = true;
+        this.registered = true;
         this.nickname = nickname;
         this.profileUrl = profileUrl;
     }

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -36,11 +36,9 @@ public class Member {
     private boolean registered;
 
     @Embedded
-    @Column(nullable = false, unique = true)
     private Nickname nickname;
 
     @Embedded
-    @Column(nullable = false)
     private Email email;
 
     @Column(nullable = false)
@@ -107,11 +105,11 @@ public class Member {
     }
 
     public String getNicknameStr() {
-        return nickname.getNickname();
+        return nickname.getValue();
     }
 
     public String getEmailStr() {
-        return email.getEmail();
+        return email.getValue();
     }
 }
 

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.example.temp.member.domain;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.exception.ApiException;
 import com.example.temp.exception.ErrorCode;
 import com.example.temp.follow.domain.FollowStatus;
@@ -34,14 +35,15 @@ public class Member {
      */
     private boolean registered;
 
+    @Embedded
     @Column(nullable = false)
-    private String email;
+    private Email email;
 
     @Column(nullable = false)
     private String profileUrl;
 
-    @Column(nullable = false, unique = true)
     @Embedded
+    @Column(nullable = false, unique = true)
     private Nickname nickname;
 
     @Enumerated(EnumType.STRING)
@@ -51,7 +53,7 @@ public class Member {
     private boolean publicAccount;
 
     @Builder
-    private Member(String email, boolean registered, String profileUrl, Nickname nickname,
+    private Member(Email email, boolean registered, String profileUrl, Nickname nickname,
         FollowStrategy followStrategy, boolean publicAccount) {
         this.email = email;
         this.registered = registered;
@@ -65,7 +67,7 @@ public class Member {
         return followStrategy.getFollowStatus();
     }
 
-    public static Member createInitStatus(String email, String profileUrl, Nickname nickname) {
+    public static Member createInitStatus(Email email, String profileUrl, Nickname nickname) {
         return Member.builder()
             .registered(false)
             .publicAccount(false)
@@ -87,6 +89,10 @@ public class Member {
 
     public String getNicknameStr() {
         return nickname.getNickname();
+    }
+
+    public String getEmailStr() {
+        return email.getEmail();
     }
 }
 

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -36,15 +36,15 @@ public class Member {
     private boolean registered;
 
     @Embedded
+    @Column(nullable = false, unique = true)
+    private Nickname nickname;
+
+    @Embedded
     @Column(nullable = false)
     private Email email;
 
     @Column(nullable = false)
     private String profileUrl;
-
-    @Embedded
-    @Column(nullable = false, unique = true)
-    private Nickname nickname;
 
     private boolean publicAccount;
 
@@ -53,12 +53,12 @@ public class Member {
     private FollowStrategy followStrategy;
 
     @Builder
-    private Member(boolean registered, Email email, String profileUrl, Nickname nickname,
+    private Member(boolean registered, Nickname nickname, Email email, String profileUrl,
         boolean publicAccount, FollowStrategy followStrategy) {
         this.registered = registered;
+        this.nickname = nickname;
         this.email = email;
         this.profileUrl = profileUrl;
-        this.nickname = nickname;
         this.publicAccount = publicAccount;
         this.followStrategy = followStrategy;
     }

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -1,5 +1,7 @@
 package com.example.temp.member.domain;
 
+import com.example.temp.exception.ApiException;
+import com.example.temp.exception.ErrorCode;
 import com.example.temp.follow.domain.FollowStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -55,5 +57,14 @@ public class Member {
 
     public FollowStatus getStatusBasedOnStrategy() {
         return followStrategy.getFollowStatus();
+    }
+
+    public void init(String nickname, String profileUrl) {
+        if (init) {
+            throw new ApiException(ErrorCode.MEMBER_ALREADY_REGISTER);
+        }
+        this.init = true;
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
     }
 }

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -31,7 +31,7 @@ public class Member {
     private Long id;
 
     /**
-     * 사용자에게 profileUrl과 nickname을 인증받았다면 true, 그렇지 않다면 false를 갖습니다.
+     * 회원가입 처리가 끝난 이후 true 값을 갖습니다.
      */
     private boolean registered;
 
@@ -46,27 +46,31 @@ public class Member {
     @Column(nullable = false, unique = true)
     private Nickname nickname;
 
+    private boolean publicAccount;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private FollowStrategy followStrategy;
 
-    private boolean publicAccount;
-
     @Builder
-    private Member(Email email, boolean registered, String profileUrl, Nickname nickname,
-        FollowStrategy followStrategy, boolean publicAccount) {
-        this.email = email;
+    private Member(boolean registered, Email email, String profileUrl, Nickname nickname,
+        boolean publicAccount, FollowStrategy followStrategy) {
         this.registered = registered;
+        this.email = email;
         this.profileUrl = profileUrl;
         this.nickname = nickname;
-        this.followStrategy = followStrategy;
         this.publicAccount = publicAccount;
+        this.followStrategy = followStrategy;
     }
 
-    public FollowStatus getStatusBasedOnStrategy() {
-        return followStrategy.getFollowStatus();
-    }
-
+    /**
+     * 가입이 완료되지 않은 회원 엔티티를 생성합니다. 해당 회원은 현재 가입되지 않은 상태이고, 비공개 계정이며, LAZY한 팔로우 전략을 갖습니다.
+     *
+     * @param email
+     * @param profileUrl
+     * @param nickname
+     * @return 가입이 완료되지 않은 회원 엔티티를 반환합니다.
+     */
     public static Member createInitStatus(Email email, String profileUrl, Nickname nickname) {
         return Member.builder()
             .registered(false)
@@ -78,6 +82,13 @@ public class Member {
             .build();
     }
 
+    /**
+     * nickname과 profileUrl을 입력받아 회원가입 처리를 완료합니다.
+     *
+     * @param nickname
+     * @param profileUrl
+     * @throws ApiException MEMBER_ALREADY_REGISTER: 이미 가입이 완료된 회원이 해당 메서드를 호출했을 때 발생합니다.
+     */
     public void init(Nickname nickname, String profileUrl) {
         if (registered) {
             throw new ApiException(ErrorCode.MEMBER_ALREADY_REGISTER);
@@ -85,6 +96,14 @@ public class Member {
         this.registered = true;
         this.nickname = nickname;
         this.profileUrl = profileUrl;
+    }
+
+    /**
+     * 해당 회원을 팔로우했을 때, 생성될 팔로우 엔티티의 상태를 반환합니다. FollowStrategy의 text 컬럼을 통해 자세한 전략을 확인할 수 있습니다.
+     * @return 팔로우 엔티티의 상태값을 반환합니다. (ex. APPROVED, PENDING)
+     */
+    public FollowStatus getStatusBasedOnStrategy() {
+        return followStrategy.getFollowStatus();
     }
 
     public String getNicknameStr() {

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -59,6 +59,18 @@ public class Member {
         return followStrategy.getFollowStatus();
     }
 
+    @Builder(builderMethodName = "buildInitStatus")
+    private Member(String email, String profileUrl, String nickname,
+        FollowStrategy followStrategy) {
+        this.init = false;
+        this.publicAccount = false;
+        this.email = email;
+        this.profileUrl = profileUrl;
+        this.nickname = nickname;
+        this.followStrategy = followStrategy;
+    }
+
+
     public void init(String nickname, String profileUrl) {
         if (init) {
             throw new ApiException(ErrorCode.MEMBER_ALREADY_REGISTER);

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -104,11 +104,11 @@ public class Member {
         return followStrategy.getFollowStatus();
     }
 
-    public String getNicknameStr() {
+    public String getNicknameValue() {
         return nickname.getValue();
     }
 
-    public String getEmailStr() {
+    public String getEmailValue() {
         return email.getValue();
     }
 }

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -62,15 +62,15 @@ public class Member {
         return followStrategy.getFollowStatus();
     }
 
-    @Builder(builderMethodName = "buildInitStatus")
-    private Member(String email, String profileUrl, String nickname,
-        FollowStrategy followStrategy) {
-        this.registered = false;
-        this.publicAccount = false;
-        this.email = email;
-        this.profileUrl = profileUrl;
-        this.nickname = nickname;
-        this.followStrategy = followStrategy;
+    public static Member createInitStatus(String email, String profileUrl, String nickname) {
+        return Member.builder()
+            .registered(false)
+            .publicAccount(false)
+            .followStrategy(FollowStrategy.LAZY)
+            .email(email)
+            .profileUrl(profileUrl)
+            .nickname(nickname)
+            .build();
     }
 
     public void init(String nickname, String profileUrl) {

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -3,7 +3,9 @@ package com.example.temp.member.domain;
 import com.example.temp.exception.ApiException;
 import com.example.temp.exception.ErrorCode;
 import com.example.temp.follow.domain.FollowStatus;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -39,7 +41,8 @@ public class Member {
     private String profileUrl;
 
     @Column(nullable = false, unique = true)
-    private String nickname;
+    @Embedded
+    private Nickname nickname;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -48,7 +51,7 @@ public class Member {
     private boolean publicAccount;
 
     @Builder
-    private Member(String email, boolean registered, String profileUrl, String nickname,
+    private Member(String email, boolean registered, String profileUrl, Nickname nickname,
         FollowStrategy followStrategy, boolean publicAccount) {
         this.email = email;
         this.registered = registered;
@@ -62,7 +65,7 @@ public class Member {
         return followStrategy.getFollowStatus();
     }
 
-    public static Member createInitStatus(String email, String profileUrl, String nickname) {
+    public static Member createInitStatus(String email, String profileUrl, Nickname nickname) {
         return Member.builder()
             .registered(false)
             .publicAccount(false)
@@ -73,7 +76,7 @@ public class Member {
             .build();
     }
 
-    public void init(String nickname, String profileUrl) {
+    public void init(Nickname nickname, String profileUrl) {
         if (registered) {
             throw new ApiException(ErrorCode.MEMBER_ALREADY_REGISTER);
         }
@@ -81,4 +84,9 @@ public class Member {
         this.nickname = nickname;
         this.profileUrl = profileUrl;
     }
+
+    public String getNicknameStr() {
+        return nickname.getNickname();
+    }
 }
+

--- a/src/main/java/com/example/temp/member/domain/MemberRepository.java
+++ b/src/main/java/com/example/temp/member/domain/MemberRepository.java
@@ -1,10 +1,12 @@
 package com.example.temp.member.domain;
 
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNickname(Nickname nickname);
+
 }

--- a/src/main/java/com/example/temp/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/com/example/temp/member/dto/request/MemberRegisterRequest.java
@@ -1,5 +1,8 @@
 package com.example.temp.member.dto.request;
 
-public record MemberRegisterRequest() {
+public record MemberRegisterRequest(
+    String profileUrl,
+    String nickname
+) {
 
 }

--- a/src/main/java/com/example/temp/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/com/example/temp/member/dto/request/MemberRegisterRequest.java
@@ -1,0 +1,5 @@
+package com.example.temp.member.dto.request;
+
+public record MemberRegisterRequest() {
+
+}

--- a/src/main/java/com/example/temp/member/exception/NicknameDuplicatedException.java
+++ b/src/main/java/com/example/temp/member/exception/NicknameDuplicatedException.java
@@ -2,7 +2,7 @@ package com.example.temp.member.exception;
 
 public class NicknameDuplicatedException extends RuntimeException {
 
-    public static final String NICKNAME_DUPLICATED_MSG = "서버가 중복된 닉네임으로 회원 가입을 시도하고 있습니다.";
+    public static final String NICKNAME_DUPLICATED_MSG = "닉네임이 중복되었습니다.";
 
     public NicknameDuplicatedException(Throwable cause) {
         super(NICKNAME_DUPLICATED_MSG, cause);

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGenerator.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGenerator.java
@@ -1,9 +1,7 @@
 package com.example.temp.member.infrastructure.nickname;
 
 import com.github.javafaker.Faker;
-import org.springframework.stereotype.Component;
 
-@Component
 public class FakerNicknameGenerator implements NicknameGenerator {
 
     Faker faker = new Faker();

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGenerator.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGenerator.java
@@ -10,10 +10,7 @@ public class FakerNicknameGenerator implements NicknameGenerator {
 
     @Override
     public Nickname generate() {
-        String job = faker.job().position();
-        String color = faker.color().name();
-        String champ = faker.leagueOfLegends().champion();
-        String value = String.format("%s's %s %s", job, color, champ);
-        return Nickname.create(value);
+        String name = faker.number().digits(10);
+        return Nickname.create(name);
     }
 }

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGenerator.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGenerator.java
@@ -9,10 +9,11 @@ public class FakerNicknameGenerator implements NicknameGenerator {
     Faker faker = new Faker();
 
     @Override
-    public String generate() {
+    public Nickname generate() {
         String job = faker.job().position();
         String color = faker.color().name();
         String champ = faker.leagueOfLegends().champion();
-        return String.format("%s's %s %s", job, color, champ);
+        String value = String.format("%s's %s %s", job, color, champ);
+        return Nickname.create(value);
     }
 }

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/Nickname.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/Nickname.java
@@ -1,0 +1,29 @@
+package com.example.temp.member.infrastructure.nickname;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode
+@SuppressWarnings("java:S1700")
+public class Nickname {
+
+    private String nickname;
+
+    @Builder
+    private Nickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public static Nickname create(String nickname) {
+        return Nickname.builder()
+            .nickname(nickname)
+            .build();
+    }
+}

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/Nickname.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/Nickname.java
@@ -1,6 +1,9 @@
 package com.example.temp.member.infrastructure.nickname;
 
+import com.example.temp.exception.ApiException;
+import com.example.temp.exception.ErrorCode;
 import jakarta.persistence.Embeddable;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -14,11 +17,29 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("java:S1700")
 public class Nickname {
 
+    public static final int NICKNAME_MAX_LENGTH = 12;
+    public static final int NICKNAME_MIN_LENGTH = 2;
+    public static final String NICKNAME_PATTERN = "^[가-힣a-zA-Z0-9]*$";
+
     private String nickname;
 
     @Builder
     private Nickname(String nickname) {
+        validate(nickname);
         this.nickname = nickname;
+    }
+
+    public void validate(String nickname) {
+        Objects.requireNonNull(nickname);
+        if (nickname.length() < NICKNAME_MIN_LENGTH) {
+            throw new ApiException(ErrorCode.NICKNAME_TOO_SHORT);
+        }
+        if (nickname.length() > NICKNAME_MAX_LENGTH) {
+            throw new ApiException(ErrorCode.NICKNAME_TOO_LONG);
+        }
+        if (!nickname.matches(NICKNAME_PATTERN)) {
+            throw new ApiException(ErrorCode.NICKNAME_PATTERN_MISMATCH);
+        }
     }
 
     public static Nickname create(String nickname) {

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/Nickname.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/Nickname.java
@@ -2,6 +2,7 @@ package com.example.temp.member.infrastructure.nickname;
 
 import com.example.temp.exception.ApiException;
 import com.example.temp.exception.ErrorCode;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -14,37 +15,37 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode
-@SuppressWarnings("java:S1700")
 public class Nickname {
 
     public static final int NICKNAME_MAX_LENGTH = 12;
     public static final int NICKNAME_MIN_LENGTH = 2;
     public static final String NICKNAME_PATTERN = "^[가-힣a-zA-Z0-9]*$";
 
-    private String nickname;
+    @Column(name = "nickname", unique = true, nullable = false)
+    private String value;
 
     @Builder
-    private Nickname(String nickname) {
-        validate(nickname);
-        this.nickname = nickname;
+    private Nickname(String value) {
+        validate(value);
+        this.value = value;
     }
 
-    public void validate(String nickname) {
-        Objects.requireNonNull(nickname);
-        if (nickname.length() < NICKNAME_MIN_LENGTH) {
+    public void validate(String value) {
+        Objects.requireNonNull(value);
+        if (value.length() < NICKNAME_MIN_LENGTH) {
             throw new ApiException(ErrorCode.NICKNAME_TOO_SHORT);
         }
-        if (nickname.length() > NICKNAME_MAX_LENGTH) {
+        if (value.length() > NICKNAME_MAX_LENGTH) {
             throw new ApiException(ErrorCode.NICKNAME_TOO_LONG);
         }
-        if (!nickname.matches(NICKNAME_PATTERN)) {
+        if (!value.matches(NICKNAME_PATTERN)) {
             throw new ApiException(ErrorCode.NICKNAME_PATTERN_MISMATCH);
         }
     }
 
-    public static Nickname create(String nickname) {
+    public static Nickname create(String value) {
         return Nickname.builder()
-            .nickname(nickname)
+            .value(value)
             .build();
     }
 }

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/NicknameGenerator.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/NicknameGenerator.java
@@ -2,6 +2,6 @@ package com.example.temp.member.infrastructure.nickname;
 
 public interface NicknameGenerator {
 
-    String generate();
+    Nickname generate();
     
 }

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/RandomNicknameGenerator.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/RandomNicknameGenerator.java
@@ -1,0 +1,35 @@
+package com.example.temp.member.infrastructure.nickname;
+
+import static com.example.temp.member.infrastructure.nickname.Nickname.NICKNAME_MAX_LENGTH;
+
+import java.util.Random;
+import org.springframework.stereotype.Component;
+
+/**
+ * 알파벳 대소문자와 숫자를 포함하여 NICKNAME_MAX_LENGTH 길이만큼의 랜덤한 문자열을 생성하는 객체입니다.
+ */
+@Component
+public class RandomNicknameGenerator implements NicknameGenerator {
+
+    private static final String ALPHABETS_AND_NUM_STR = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
+    private static final char[] ALPHABETS_AND_NUM = createAlphabetsAndNums();
+
+    private static char[] createAlphabetsAndNums() {
+        return ALPHABETS_AND_NUM_STR.toCharArray();
+    }
+
+    private final Random random = new Random();
+
+    @Override
+    public Nickname generate() {
+        StringBuilder sb = new StringBuilder(NICKNAME_MAX_LENGTH);
+        for (int i = 0; i < NICKNAME_MAX_LENGTH; i++) {
+            sb.append(getRandomCharacter());
+        }
+        return Nickname.create(sb.toString());
+    }
+
+    private char getRandomCharacter() {
+        return ALPHABETS_AND_NUM[random.nextInt(ALPHABETS_AND_NUM.length)];
+    }
+}

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/RandomNicknameGenerator.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/RandomNicknameGenerator.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
  * 알파벳 대소문자와 숫자를 포함하여 NICKNAME_MAX_LENGTH 길이만큼의 랜덤한 문자열을 생성하는 객체입니다.
  */
 @Component
+@SuppressWarnings("java:S2245")
 public class RandomNicknameGenerator implements NicknameGenerator {
 
     private static final char[] ALPHABETS_AND_NUM = createAlphabetsAndNums();
@@ -17,6 +18,7 @@ public class RandomNicknameGenerator implements NicknameGenerator {
         String alphabetAndNumStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
         return alphabetAndNumStr.toCharArray();
     }
+
 
     private final Random random = new Random();
 

--- a/src/main/java/com/example/temp/member/infrastructure/nickname/RandomNicknameGenerator.java
+++ b/src/main/java/com/example/temp/member/infrastructure/nickname/RandomNicknameGenerator.java
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class RandomNicknameGenerator implements NicknameGenerator {
 
-    private static final String ALPHABETS_AND_NUM_STR = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
     private static final char[] ALPHABETS_AND_NUM = createAlphabetsAndNums();
 
     private static char[] createAlphabetsAndNums() {
-        return ALPHABETS_AND_NUM_STR.toCharArray();
+        String alphabetAndNumStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
+        return alphabetAndNumStr.toCharArray();
     }
 
     private final Random random = new Random();

--- a/src/main/java/com/example/temp/member/presentation/MemberController.java
+++ b/src/main/java/com/example/temp/member/presentation/MemberController.java
@@ -1,0 +1,28 @@
+package com.example.temp.member.presentation;
+
+import com.example.temp.auth.dto.response.MemberInfo;
+import com.example.temp.member.application.MemberService;
+import com.example.temp.member.dto.request.MemberRegisterRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/register")
+    public ResponseEntity<MemberInfo> register(@RequestAttribute(name = "executor") long executorId,
+        @RequestBody MemberRegisterRequest memberRegisterRequest) {
+        MemberInfo response = memberService.register(memberRegisterRequest);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/example/temp/member/presentation/MemberController.java
+++ b/src/main/java/com/example/temp/member/presentation/MemberController.java
@@ -21,7 +21,7 @@ public class MemberController {
     @PostMapping("/register")
     public ResponseEntity<MemberInfo> register(@RequestAttribute(name = "executor") long executorId,
         @RequestBody MemberRegisterRequest memberRegisterRequest) {
-        MemberInfo response = memberService.register(memberRegisterRequest);
+        MemberInfo response = memberService.register(executorId, memberRegisterRequest);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/temp/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/oauth/OAuthResponse.java
@@ -1,6 +1,7 @@
 package com.example.temp.oauth;
 
 import com.example.temp.member.domain.Member;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 
 public record OAuthResponse(
     OAuthProviderType type,
@@ -15,7 +16,7 @@ public record OAuthResponse(
             oAuthUserInfo.getIdUsingResourceServer(), oAuthUserInfo.getProfileUrl());
     }
 
-    public Member toInitStatusMemberWith(String nickname) {
+    public Member toInitStatusMemberWith(Nickname nickname) {
         return Member.createInitStatus(this.email(), this.profileUrl(), nickname);
     }
 }

--- a/src/main/java/com/example/temp/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/oauth/OAuthResponse.java
@@ -1,6 +1,5 @@
 package com.example.temp.oauth;
 
-import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 
 public record OAuthResponse(
@@ -17,13 +16,6 @@ public record OAuthResponse(
     }
 
     public Member toInitStatusMemberWith(String nickname) {
-        return Member.builder()
-            .registered(false)
-            .email(this.email())
-            .profileUrl(this.profileUrl())
-            .nickname(nickname)
-            .followStrategy(FollowStrategy.EAGER)
-            .publicAccount(true)
-            .build();
+        return Member.createInitStatus(this.email(), this.profileUrl(), nickname);
     }
 }

--- a/src/main/java/com/example/temp/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/oauth/OAuthResponse.java
@@ -21,6 +21,7 @@ public record OAuthResponse(
             .email(this.email())
             .profileUrl(this.profileUrl())
             .nickname(nickname)
+            .init(false)
             .followStrategy(FollowStrategy.EAGER)
             .publicAccount(true)
             .build();

--- a/src/main/java/com/example/temp/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/oauth/OAuthResponse.java
@@ -1,18 +1,19 @@
 package com.example.temp.oauth;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.infrastructure.nickname.Nickname;
 
 public record OAuthResponse(
     OAuthProviderType type,
-    String email,
+    Email email,
     String name,
     String idUsingResourceServer,
     String profileUrl
 ) {
 
     public static OAuthResponse of(OAuthProviderType type, OAuthUserInfo oAuthUserInfo) {
-        return new OAuthResponse(type, oAuthUserInfo.getEmail(), oAuthUserInfo.getName(),
+        return new OAuthResponse(type, Email.create(oAuthUserInfo.getEmail()), oAuthUserInfo.getName(),
             oAuthUserInfo.getIdUsingResourceServer(), oAuthUserInfo.getProfileUrl());
     }
 

--- a/src/main/java/com/example/temp/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/oauth/OAuthResponse.java
@@ -16,12 +16,11 @@ public record OAuthResponse(
             oAuthUserInfo.getIdUsingResourceServer(), oAuthUserInfo.getProfileUrl());
     }
 
-    public Member toMemberWithNickname(String nickname) {
-        return Member.builder()
+    public Member toInitStatusMemberWith(String nickname) {
+        return Member.buildInitStatus()
             .email(this.email())
             .profileUrl(this.profileUrl())
             .nickname(nickname)
-            .init(false)
             .followStrategy(FollowStrategy.EAGER)
             .publicAccount(true)
             .build();

--- a/src/main/java/com/example/temp/oauth/OAuthResponse.java
+++ b/src/main/java/com/example/temp/oauth/OAuthResponse.java
@@ -17,7 +17,8 @@ public record OAuthResponse(
     }
 
     public Member toInitStatusMemberWith(String nickname) {
-        return Member.buildInitStatus()
+        return Member.builder()
+            .registered(false)
             .email(this.email())
             .profileUrl(this.profileUrl())
             .nickname(nickname)

--- a/src/main/java/com/example/temp/oauth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/oauth/application/OAuthService.java
@@ -1,6 +1,6 @@
 package com.example.temp.oauth.application;
 
-import com.example.temp.auth.dto.response.LoginMemberResponse;
+import com.example.temp.auth.dto.response.MemberInfo;
 import com.example.temp.member.application.MemberService;
 import com.example.temp.member.domain.Member;
 import com.example.temp.oauth.OAuthProviderResolver;
@@ -22,11 +22,11 @@ public class OAuthService {
     private final MemberService memberService;
 
     @Transactional
-    public LoginMemberResponse login(String provider, String authCode) {
+    public MemberInfo login(String provider, String authCode) {
         OAuthProviderType oAuthProviderType = OAuthProviderType.find(provider);
         OAuthResponse oAuthResponse = oAuthProviderResolver.fetch(oAuthProviderType, authCode);
         Member member = findMemberOrElseCreate(oAuthResponse);
-        return LoginMemberResponse.of(member);
+        return MemberInfo.of(member);
     }
 
     private Member findMemberOrElseCreate(OAuthResponse oAuthResponse) {

--- a/src/main/java/com/example/temp/oauth/application/OAuthService.java
+++ b/src/main/java/com/example/temp/oauth/application/OAuthService.java
@@ -37,7 +37,7 @@ public class OAuthService {
     }
 
     private Member saveMemberAndOAuthInfo(OAuthProviderType oAuthProviderType, OAuthResponse oAuthResponse) {
-        Member savedMember = memberService.register(oAuthResponse);
+        Member savedMember = memberService.saveInitStatusMember(oAuthResponse);
         OAuthInfo oAuthInfo = OAuthInfo.of(oAuthResponse.idUsingResourceServer(), oAuthProviderType, savedMember);
         oAuthInfoRepository.save(oAuthInfo);
         return savedMember;

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -76,7 +76,7 @@ class OAuthServiceUnitTest {
 
         // then
         assertThat(response.id()).isEqualTo(member.getId());
-        assertThat(response.email()).isEqualTo(member.getEmailStr());
+        assertThat(response.email()).isEqualTo(member.getEmailValue());
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
     }
 
@@ -94,7 +94,7 @@ class OAuthServiceUnitTest {
 
         // then
         assertThat(response.id()).isEqualTo(member.getId());
-        assertThat(response.email()).isEqualTo(member.getEmailStr());
+        assertThat(response.email()).isEqualTo(member.getEmailValue());
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
     }
 

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import com.example.temp.auth.dto.response.MemberInfo;
 import com.example.temp.member.application.MemberService;
 import com.example.temp.member.domain.Member;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import com.example.temp.oauth.OAuthProviderResolver;
 import com.example.temp.oauth.OAuthProviderType;
 import com.example.temp.oauth.OAuthResponse;
@@ -49,7 +50,9 @@ class OAuthServiceUnitTest {
     void setUp() {
         oAuthService = new OAuthService(oAuthProviderResolver, oAuthInfoRepository, memberService);
         oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", "123", "프로필주소");
-        member = Member.builder().build();
+        member = Member.builder()
+            .nickname(Nickname.create("defaultNick"))
+            .build();
         oAuthInfo = OAuthInfo.builder()
             .member(member)
             .build();

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.example.temp.auth.dto.response.LoginMemberResponse;
+import com.example.temp.auth.dto.response.MemberInfo;
 import com.example.temp.member.application.MemberService;
 import com.example.temp.member.domain.Member;
 import com.example.temp.oauth.OAuthProviderResolver;
@@ -67,7 +67,7 @@ class OAuthServiceUnitTest {
             .thenReturn(member);
 
         // when
-        LoginMemberResponse response = oAuthService.login("google", "1234");
+        MemberInfo response = oAuthService.login("google", "1234");
 
         // then
         assertThat(response.id()).isEqualTo(member.getId());
@@ -85,7 +85,7 @@ class OAuthServiceUnitTest {
             .thenReturn(Optional.of(oAuthInfo));
 
         // when
-        LoginMemberResponse response = oAuthService.login("google", "1234");
+        MemberInfo response = oAuthService.login("google", "1234");
 
         // then
         assertThat(response.id()).isEqualTo(member.getId());

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -63,7 +63,7 @@ class OAuthServiceUnitTest {
             .thenReturn(oAuthResponse);
         when(oAuthInfoRepository.findByIdUsingResourceServerAndType(anyString(), any(OAuthProviderType.class)))
             .thenReturn(Optional.empty());
-        when(memberService.register(any(OAuthResponse.class)))
+        when(memberService.saveInitStatusMember(any(OAuthResponse.class)))
             .thenReturn(member);
 
         // when
@@ -101,7 +101,7 @@ class OAuthServiceUnitTest {
             .thenReturn(oAuthResponse);
         when(oAuthInfoRepository.findByIdUsingResourceServerAndType(anyString(), any(OAuthProviderType.class)))
             .thenReturn(Optional.empty());
-        when(memberService.register(any(OAuthResponse.class)))
+        when(memberService.saveInitStatusMember(any(OAuthResponse.class)))
             .thenReturn(member);
 
         // when
@@ -109,7 +109,7 @@ class OAuthServiceUnitTest {
 
         // then
         verify(memberService, times(1))
-            .register(any(OAuthResponse.class));
+            .saveInitStatusMember(any(OAuthResponse.class));
         verify(oAuthInfoRepository, times(1))
             .save(any(OAuthInfo.class));
     }
@@ -128,7 +128,7 @@ class OAuthServiceUnitTest {
 
         // then
         verify(memberService, never())
-            .register(any(OAuthResponse.class));
+            .saveInitStatusMember(any(OAuthResponse.class));
     }
 
 }

--- a/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
+++ b/src/test/java/com/example/temp/auth/application/OAuthServiceUnitTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.temp.auth.dto.response.MemberInfo;
+import com.example.temp.common.entity.Email;
 import com.example.temp.member.application.MemberService;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.infrastructure.nickname.Nickname;
@@ -49,9 +50,10 @@ class OAuthServiceUnitTest {
     @BeforeEach
     void setUp() {
         oAuthService = new OAuthService(oAuthProviderResolver, oAuthInfoRepository, memberService);
-        oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, "이메일", "닉네임", "123", "프로필주소");
+        oAuthResponse = new OAuthResponse(OAuthProviderType.GOOGLE, Email.create("이메일"), "닉네임", "123", "프로필주소");
         member = Member.builder()
             .nickname(Nickname.create("defaultNick"))
+            .email(Email.create("default@email.com"))
             .build();
         oAuthInfo = OAuthInfo.builder()
             .member(member)
@@ -74,7 +76,7 @@ class OAuthServiceUnitTest {
 
         // then
         assertThat(response.id()).isEqualTo(member.getId());
-        assertThat(response.email()).isEqualTo(member.getEmail());
+        assertThat(response.email()).isEqualTo(member.getEmailStr());
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
     }
 
@@ -92,7 +94,7 @@ class OAuthServiceUnitTest {
 
         // then
         assertThat(response.id()).isEqualTo(member.getId());
-        assertThat(response.email()).isEqualTo(member.getEmail());
+        assertThat(response.email()).isEqualTo(member.getEmailStr());
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
     }
 

--- a/src/test/java/com/example/temp/auth/dto/request/OAuthLoginRequestTest.java
+++ b/src/test/java/com/example/temp/auth/dto/request/OAuthLoginRequestTest.java
@@ -1,0 +1,23 @@
+package com.example.temp.auth.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OAuthLoginRequestTest {
+
+    @Test
+    @DisplayName("생성자의 순서가 올바른지 테스트한다")
+    void create() throws Exception {
+        // given
+        String authCode = "authCode";
+
+        // when
+        OAuthLoginRequest result = new OAuthLoginRequest(authCode);
+
+        // then
+        assertThat(result.authCode()).isEqualTo(authCode);
+    }
+
+}

--- a/src/test/java/com/example/temp/auth/dto/response/AuthorizedUrlTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/AuthorizedUrlTest.java
@@ -1,0 +1,22 @@
+package com.example.temp.auth.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuthorizedUrlTest {
+
+    @Test
+    @DisplayName("생성자의 순서가 올바른지 테스트한다")
+    void create() throws Exception {
+        // given
+        String authorizedUrl = "authorizedUrl";
+
+        // when
+        AuthorizedUrl result = new AuthorizedUrl(authorizedUrl);
+
+        // then
+        assertThat(result.authorizedUrl()).isEqualTo(authorizedUrl);
+    }
+}

--- a/src/test/java/com/example/temp/auth/dto/response/LoginMemberResponseTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/LoginMemberResponseTest.java
@@ -27,6 +27,7 @@ class LoginMemberResponseTest {
             .profileUrl("프로필주소")
             .nickname("생성된 닉네임")
             .followStrategy(FollowStrategy.EAGER)
+            .init(true)
             .build();
         em.persist(member);
 
@@ -38,5 +39,6 @@ class LoginMemberResponseTest {
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
         assertThat(response.email()).isEqualTo(member.getEmail());
         assertThat(response.nickname()).isEqualTo(member.getNickname());
+        assertThat(response.init()).isEqualTo(member.isInit());
     }
 }

--- a/src/test/java/com/example/temp/auth/dto/response/LoginResponseTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/LoginResponseTest.java
@@ -9,6 +9,25 @@ import org.junit.jupiter.api.Test;
 class LoginResponseTest {
 
     @Test
+    @DisplayName("생성자의 순서가 올바른지 테스트한다")
+    void create() throws Exception {
+        // given
+        String accessToken = "엑세스토큰";
+        boolean requiredAdditionalInfo = true;
+        Member member = Member.builder()
+            .build();
+        MemberInfo memberInfo = MemberInfo.of(member);
+
+        // when
+        LoginResponse result = new LoginResponse(accessToken, requiredAdditionalInfo, memberInfo);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo(accessToken);
+        assertThat(result.requiredAdditionalInfo()).isEqualTo(requiredAdditionalInfo);
+        assertThat(result.userInfo()).isEqualTo(memberInfo);
+    }
+
+    @Test
     @DisplayName("of 메서드를 통해 LoginResponse를 생성한다.")
     void ofSuccess() throws Exception {
         // given

--- a/src/test/java/com/example/temp/auth/dto/response/LoginResponseTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/LoginResponseTest.java
@@ -3,6 +3,7 @@ package com.example.temp.auth.dto.response;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.temp.member.domain.Member;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +16,7 @@ class LoginResponseTest {
         String accessToken = "엑세스토큰";
         boolean requiredAdditionalInfo = true;
         Member member = Member.builder()
+            .nickname(Nickname.create("nickname"))
             .build();
         MemberInfo memberInfo = MemberInfo.of(member);
 
@@ -38,6 +40,7 @@ class LoginResponseTest {
             .refreshToken("리프레쉬")
             .build();
         Member member = Member.builder()
+            .nickname(Nickname.create("nickname"))
             .registered(registered)
             .build();
         MemberInfo memberInfo = MemberInfo.of(member);

--- a/src/test/java/com/example/temp/auth/dto/response/LoginResponseTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/LoginResponseTest.java
@@ -1,0 +1,34 @@
+package com.example.temp.auth.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LoginResponseTest {
+
+    @Test
+    @DisplayName("of 메서드를 통해 LoginResponse를 생성한다.")
+    void ofSuccess() throws Exception {
+        // given
+        String accessToken = "엑세스토큰";
+        boolean registered = true;
+        TokenInfo tokenInfo = TokenInfo.builder()
+            .accessToken(accessToken)
+            .refreshToken("리프레쉬")
+            .build();
+        Member member = Member.builder()
+            .registered(registered)
+            .build();
+        MemberInfo memberInfo = MemberInfo.of(member);
+
+        // when
+        LoginResponse result = LoginResponse.of(tokenInfo, memberInfo);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo(accessToken);
+        assertThat(result.requiredAdditionalInfo()).isEqualTo(!registered);
+        assertThat(result.userInfo()).isEqualTo(memberInfo);
+    }
+}

--- a/src/test/java/com/example/temp/auth/dto/response/LoginResponseTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/LoginResponseTest.java
@@ -2,6 +2,7 @@ package com.example.temp.auth.dto.response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.infrastructure.nickname.Nickname;
 import org.junit.jupiter.api.DisplayName;
@@ -15,9 +16,7 @@ class LoginResponseTest {
         // given
         String accessToken = "엑세스토큰";
         boolean requiredAdditionalInfo = true;
-        Member member = Member.builder()
-            .nickname(Nickname.create("nickname"))
-            .build();
+        Member member = saveMember();
         MemberInfo memberInfo = MemberInfo.of(member);
 
         // when
@@ -34,15 +33,11 @@ class LoginResponseTest {
     void ofSuccess() throws Exception {
         // given
         String accessToken = "엑세스토큰";
-        boolean registered = true;
         TokenInfo tokenInfo = TokenInfo.builder()
             .accessToken(accessToken)
             .refreshToken("리프레쉬")
             .build();
-        Member member = Member.builder()
-            .nickname(Nickname.create("nickname"))
-            .registered(registered)
-            .build();
+        Member member = saveMember();
         MemberInfo memberInfo = MemberInfo.of(member);
 
         // when
@@ -50,7 +45,16 @@ class LoginResponseTest {
 
         // then
         assertThat(result.accessToken()).isEqualTo(accessToken);
-        assertThat(result.requiredAdditionalInfo()).isEqualTo(!registered);
+        assertThat(result.requiredAdditionalInfo()).isEqualTo(!memberInfo.registered());
         assertThat(result.userInfo()).isEqualTo(memberInfo);
     }
+
+    private Member saveMember() {
+        return Member.builder()
+            .nickname(Nickname.create("nickname"))
+            .email(Email.create("email@naver.com"))
+            .registered(true)
+            .build();
+    }
+
 }

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
-class LoginMemberResponseTest {
+class MemberInfoTest {
 
     @Autowired
     EntityManager em;
@@ -32,7 +32,7 @@ class LoginMemberResponseTest {
         em.persist(member);
 
         // when
-        LoginMemberResponse response = LoginMemberResponse.of(member);
+        MemberInfo response = MemberInfo.of(member);
 
         // then
         assertThat(response.id()).isNotNull();

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -48,7 +48,7 @@ class MemberInfoTest {
         Member member = Member.builder()
             .email(Email.create("이멜"))
             .profileUrl("프로필주소")
-            .nickname(Nickname.create("생성된 닉네임"))
+            .nickname(Nickname.create("생성닉네임"))
             .registered(true)
             .followStrategy(FollowStrategy.EAGER)
             .build();

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -60,8 +60,8 @@ class MemberInfoTest {
         // then
         assertThat(response.id()).isNotNull();
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
-        assertThat(response.email()).isEqualTo(member.getEmailStr());
-        assertThat(response.nickname()).isEqualTo(member.getNicknameStr());
+        assertThat(response.email()).isEqualTo(member.getEmailValue());
+        assertThat(response.nickname()).isEqualTo(member.getNicknameValue());
         assertThat(response.registered()).isEqualTo(member.isRegistered());
     }
 }

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -48,7 +48,7 @@ class MemberInfoTest {
         Member member = Member.builder()
             .email(Email.create("이멜"))
             .profileUrl("프로필주소")
-            .nickname(Nickname.create("생성닉네임"))
+            .nickname(Nickname.create("생성된닉네임"))
             .registered(true)
             .followStrategy(FollowStrategy.EAGER)
             .build();

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ class MemberInfoTest {
         Member member = Member.builder()
             .email("이멜")
             .profileUrl("프로필주소")
-            .nickname("생성된 닉네임")
+            .nickname(Nickname.create("생성된 닉네임"))
             .registered(true)
             .followStrategy(FollowStrategy.EAGER)
             .build();
@@ -59,7 +60,7 @@ class MemberInfoTest {
         assertThat(response.id()).isNotNull();
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
         assertThat(response.email()).isEqualTo(member.getEmail());
-        assertThat(response.nickname()).isEqualTo(member.getNickname());
+        assertThat(response.nickname()).isEqualTo(member.getNicknameStr());
         assertThat(response.registered()).isEqualTo(member.isRegistered());
     }
 }

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -26,8 +26,8 @@ class MemberInfoTest {
             .email("이멜")
             .profileUrl("프로필주소")
             .nickname("생성된 닉네임")
+            .registered(true)
             .followStrategy(FollowStrategy.EAGER)
-            .init(true)
             .build();
         em.persist(member);
 
@@ -39,6 +39,6 @@ class MemberInfoTest {
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
         assertThat(response.email()).isEqualTo(member.getEmail());
         assertThat(response.nickname()).isEqualTo(member.getNickname());
-        assertThat(response.init()).isEqualTo(member.isInit());
+        assertThat(response.init()).isEqualTo(member.isRegistered());
     }
 }

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -19,8 +19,29 @@ class MemberInfoTest {
     EntityManager em;
 
     @Test
-    @DisplayName("LoginInfoResponse를 생성한다")
+    @DisplayName("생성자의 순서가 올바른지 테스트한다")
     void create() throws Exception {
+        // given
+        long id = 1L;
+        String email = "email";
+        String profileUrl = "profile";
+        String nickname = "nick";
+        boolean registered = true;
+
+        // when
+        MemberInfo result = new MemberInfo(id, email, profileUrl, nickname, registered);
+
+        // then
+        assertThat(result.id()).isEqualTo(id);
+        assertThat(result.email()).isEqualTo(email);
+        assertThat(result.profileUrl()).isEqualTo(profileUrl);
+        assertThat(result.nickname()).isEqualTo(nickname);
+        assertThat(result.registered()).isEqualTo(registered);
+    }
+
+    @Test
+    @DisplayName("LoginInfoResponse를 생성한다")
+    void ofSuccess() throws Exception {
         // given
         Member member = Member.builder()
             .email("이멜")

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -2,6 +2,7 @@ package com.example.temp.auth.dto.response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.infrastructure.nickname.Nickname;
@@ -45,7 +46,7 @@ class MemberInfoTest {
     void ofSuccess() throws Exception {
         // given
         Member member = Member.builder()
-            .email("이멜")
+            .email(Email.create("이멜"))
             .profileUrl("프로필주소")
             .nickname(Nickname.create("생성된 닉네임"))
             .registered(true)
@@ -59,7 +60,7 @@ class MemberInfoTest {
         // then
         assertThat(response.id()).isNotNull();
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
-        assertThat(response.email()).isEqualTo(member.getEmail());
+        assertThat(response.email()).isEqualTo(member.getEmailStr());
         assertThat(response.nickname()).isEqualTo(member.getNicknameStr());
         assertThat(response.registered()).isEqualTo(member.isRegistered());
     }

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -39,6 +39,6 @@ class MemberInfoTest {
         assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
         assertThat(response.email()).isEqualTo(member.getEmail());
         assertThat(response.nickname()).isEqualTo(member.getNickname());
-        assertThat(response.init()).isEqualTo(member.isRegistered());
+        assertThat(response.registered()).isEqualTo(member.isRegistered());
     }
 }

--- a/src/test/java/com/example/temp/common/entity/EmailTest.java
+++ b/src/test/java/com/example/temp/common/entity/EmailTest.java
@@ -1,0 +1,35 @@
+package com.example.temp.common.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EmailTest {
+
+    @Test
+    @DisplayName("email의 값이 일치하면 동등한 객체인지 확인한다.")
+    void equals() throws Exception {
+        // given
+        Email email1 = Email.create("email");
+        Email email2 = Email.create("email");
+
+        // when & then
+        assertThat(email1.equals(email2)).isTrue();
+    }
+
+    @Test
+    @DisplayName("email의 값이 일치하면 해시코드가 일치하는지 확인한다.")
+    void hashcode() throws Exception {
+        // given
+        Email email1 = Email.create("email");
+        Email email2 = Email.create("email");
+
+        // when
+        boolean result = email1.hashCode() == email2.hashCode();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+}

--- a/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
+++ b/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
@@ -2,9 +2,9 @@ package com.example.temp.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 class GlobalExceptionHandlerUnitTest {
@@ -12,7 +12,7 @@ class GlobalExceptionHandlerUnitTest {
     GlobalExceptionHandler handler = new GlobalExceptionHandler();
 
     @Test
-    @DisplayName("ApiException이 들어오면 ErrorCode가 들고 있는 status와 message를 반환한다.")
+    @DisplayName("handleApiException이 실행되면 ErrorCode가 들고 있는 status와 message를 반환한다.")
     void handleApiException() throws Exception {
         // given
         ErrorCode errorCode = ErrorCode.TEST;
@@ -25,6 +25,40 @@ class GlobalExceptionHandlerUnitTest {
         assertThat(response.getStatusCode()).isEqualTo(errorCode.getHttpStatus());
 
         ErrorResponse body = response.getBody();
-        assertThat(body.message()).isEqualTo(errorCode.getMessage());
+        assertThat(body.getMessage()).isEqualTo(errorCode.getMessage());
+    }
+
+    @Test
+    @DisplayName("handleServerException가 들어오면 INTERNAL_SERVER_ERROR와 함께 서버에서 에러가 발생했다는 메세지를 반환한다")
+    void handleException() throws Exception {
+        // given
+        Exception exception = new Exception("에러에러");
+
+        // when
+        ResponseEntity<ErrorResponse> response = handler.handleServerException(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        ErrorResponse body = response.getBody();
+        assertThat(body.getMessage()).isEqualTo(ErrorResponse.SERVER_ERROR_MSG);
+
+    }
+
+    @Test
+    @DisplayName("handleBadRequestStatus가 실행되면 BAD_REQUEST 상태를 반환한다")
+    void handleNicknameDup() throws Exception {
+        // given
+        RuntimeException exception = new RuntimeException("msg");
+
+        // when
+        ResponseEntity<ErrorResponse> response = handler.handleBadRequestStatus(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        ErrorResponse body = response.getBody();
+        assertThat(body.getMessage()).isEqualTo(exception.getMessage());
+
     }
 }

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -16,7 +16,7 @@ import com.example.temp.exception.ApiException;
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowStatus;
 import com.example.temp.follow.dto.response.FollowInfo;
-import com.example.temp.follow.response.FollowResponse;
+import com.example.temp.follow.dto.response.FollowResponse;
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.infrastructure.nickname.Nickname;

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.exception.ApiException;
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowStatus;
@@ -532,7 +533,7 @@ class FollowServiceTest {
 
     private Member saveMemberWithAccountPolicy(boolean isPublic) {
         Member member = Member.builder()
-            .email("이메일")
+            .email(Email.create("이메일"))
             .profileUrl("프로필")
             .nickname(Nickname.create("nick" + (globalIdx++)))
             .followStrategy(FollowStrategy.EAGER)
@@ -544,7 +545,7 @@ class FollowServiceTest {
 
     private Member saveMemberWithFollowStrategy(FollowStrategy followStrategy) {
         Member member = Member.builder()
-            .email("이메일")
+            .email(Email.create("이메일"))
             .profileUrl("프로필")
             .nickname(Nickname.create("nick" + (globalIdx++)))
             .followStrategy(followStrategy)

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -18,6 +18,7 @@ import com.example.temp.follow.dto.response.FollowInfo;
 import com.example.temp.follow.response.FollowResponse;
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.List;
@@ -533,7 +534,7 @@ class FollowServiceTest {
         Member member = Member.builder()
             .email("이메일")
             .profileUrl("프로필")
-            .nickname("nickname" + globalIdx++)
+            .nickname(Nickname.create("nick" + (globalIdx++)))
             .followStrategy(FollowStrategy.EAGER)
             .publicAccount(isPublic)
             .build();
@@ -545,7 +546,7 @@ class FollowServiceTest {
         Member member = Member.builder()
             .email("이메일")
             .profileUrl("프로필")
-            .nickname("nickname" + globalIdx++)
+            .nickname(Nickname.create("nick" + (globalIdx++)))
             .followStrategy(followStrategy)
             .publicAccount(true)
             .build();

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -2,6 +2,7 @@ package com.example.temp.follow.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.infrastructure.nickname.Nickname;
@@ -207,7 +208,7 @@ class FollowRepositoryTest {
 
     private Member saveMember() {
         Member member = Member.builder()
-            .email("이메일")
+            .email(Email.create("이메일"))
             .profileUrl("프로필")
             .nickname(Nickname.create("nick" + (globalIdx++)))
             .followStrategy(FollowStrategy.EAGER)

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
@@ -208,7 +209,7 @@ class FollowRepositoryTest {
         Member member = Member.builder()
             .email("이메일")
             .profileUrl("프로필")
-            .nickname("nickname" + globalIdx++)
+            .nickname(Nickname.create("nick" + (globalIdx++)))
             .followStrategy(FollowStrategy.EAGER)
             .publicAccount(true)
             .build();

--- a/src/test/java/com/example/temp/follow/dto/response/FollowResponseTest.java
+++ b/src/test/java/com/example/temp/follow/dto/response/FollowResponseTest.java
@@ -1,0 +1,25 @@
+package com.example.temp.follow.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.follow.domain.FollowStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FollowResponseTest {
+
+    @Test
+    @DisplayName("FollowResponse를 생성한다")
+    void create() throws Exception {
+        // given
+        long id = 1L;
+        FollowStatus status = FollowStatus.PENDING;
+
+        // when
+        FollowResponse followResponse = new FollowResponse(id, status);
+
+        // then
+        assertThat(followResponse.id()).isEqualTo(id);
+        assertThat(followResponse.status()).isEqualTo(status);
+    }
+}

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -167,8 +167,9 @@ class MemberServiceTest {
             .nickname(nickname)
             .email("이메일")
             .profileUrl("프로필주소")
-            .init(true)
+            .registered(true)
             .followStrategy(FollowStrategy.EAGER)
+            .publicAccount(true)
             .build();
         em.persist(member);
         return member;
@@ -179,9 +180,9 @@ class MemberServiceTest {
             .nickname(nickname)
             .email("이메일")
             .profileUrl("프로필주소")
+            .registered(false)
             .followStrategy(FollowStrategy.EAGER)
             .publicAccount(true)
-            .init(false)
             .build();
         em.persist(member);
         return member;

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -47,10 +47,33 @@ class MemberServiceTest {
 
     @BeforeEach
     void setUp() {
-        oAuthUserInfo = createOAuthUserInfo();
+        oAuthUserInfo = mockOAuthClientResponse();
         oAuthResponse = OAuthResponse.of(OAuthProviderType.GOOGLE, oAuthUserInfo);
     }
 
+    private OAuthUserInfo mockOAuthClientResponse() {
+        return new OAuthUserInfo() {
+            @Override
+            public String getProfileUrl() {
+                return "프로필주소";
+            }
+
+            @Override
+            public String getEmail() {
+                return "이메일";
+            }
+
+            @Override
+            public String getIdUsingResourceServer() {
+                return "id";
+            }
+
+            @Override
+            public String getName() {
+                return "이름";
+            }
+        };
+    }
 
     @Test
     @DisplayName("임시 멤버를 생성한다")
@@ -72,7 +95,7 @@ class MemberServiceTest {
     @DisplayName("중복된 닉네임으로는 임시 멤버를 생성할 수 없다.")
     void registerTempFailDuplicatedNickname() throws Exception {
         // given
-        Nickname createdNickname = Nickname.create("중복되지않은닉네임");
+        Nickname createdNickname = Nickname.create("중복닉네임");
         saveMember(createdNickname);
         when(nicknameGenerator.generate())
             .thenReturn(createdNickname);
@@ -86,7 +109,7 @@ class MemberServiceTest {
     @DisplayName("중복된 닉네임으로 임시 회원을 저장하려 할 때, 다섯 번까지 재시도한다.")
     void tryRegisterTempSeveralTimeIfDuplicatedNickname() throws Exception {
         // given
-        Nickname createdNickname = Nickname.create("중복되지않은닉네임");
+        Nickname createdNickname = Nickname.create("중복닉네임");
         saveMember(createdNickname);
         when(nicknameGenerator.generate())
             .thenReturn(createdNickname);
@@ -194,30 +217,6 @@ class MemberServiceTest {
         assertThat(result.getId()).isNotNull();
         assertThat(result.getEmail()).isEqualTo(oAuthResponse.email());
         assertThat(result.getProfileUrl()).isEqualTo(oAuthResponse.profileUrl());
-    }
-
-    private OAuthUserInfo createOAuthUserInfo() {
-        return new OAuthUserInfo() {
-            @Override
-            public String getProfileUrl() {
-                return "프로필주소";
-            }
-
-            @Override
-            public String getEmail() {
-                return "이메일";
-            }
-
-            @Override
-            public String getIdUsingResourceServer() {
-                return "id";
-            }
-
-            @Override
-            public String getName() {
-                return "이름";
-            }
-        };
     }
 
 }

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -55,7 +55,7 @@ class MemberServiceTest {
             .thenReturn(createdNickname);
 
         // when
-        Member result = memberService.register(oAuthResponse);
+        Member result = memberService.saveInitStatusMember(oAuthResponse);
 
         // then
         assertThat(result.getNickname()).isEqualTo(createdNickname);
@@ -72,7 +72,7 @@ class MemberServiceTest {
             .thenReturn(createdNickname);
 
         // when & then
-        assertThatThrownBy(() -> memberService.register(oAuthResponse))
+        assertThatThrownBy(() -> memberService.saveInitStatusMember(oAuthResponse))
             .isInstanceOf(NicknameDuplicatedException.class);
     }
 
@@ -86,7 +86,7 @@ class MemberServiceTest {
             .thenReturn(createdNickname);
 
         // when & then
-        assertThatThrownBy(() -> memberService.register(oAuthResponse))
+        assertThatThrownBy(() -> memberService.saveInitStatusMember(oAuthResponse))
             .isInstanceOf(NicknameDuplicatedException.class);
         verify(nicknameGenerator, times(5))
             .generate();
@@ -104,7 +104,7 @@ class MemberServiceTest {
                 duplicatedNickname, createdNickname);
 
         // when
-        Member result = memberService.register(oAuthResponse);
+        Member result = memberService.saveInitStatusMember(oAuthResponse);
 
         // then
         assertThat(result.getNickname()).isEqualTo(createdNickname);

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -56,7 +56,7 @@ class MemberServiceTest {
     @DisplayName("임시 멤버를 생성한다")
     void registerTempSuccess() throws Exception {
         // given
-        Nickname createdNickname = Nickname.create("중복되지않은_닉네임");
+        Nickname createdNickname = Nickname.create("중복되지않은닉네임");
         when(nicknameGenerator.generate())
             .thenReturn(createdNickname);
 
@@ -72,7 +72,7 @@ class MemberServiceTest {
     @DisplayName("중복된 닉네임으로는 임시 멤버를 생성할 수 없다.")
     void registerTempFailDuplicatedNickname() throws Exception {
         // given
-        Nickname createdNickname = Nickname.create("중복되지않은_닉네임");
+        Nickname createdNickname = Nickname.create("중복되지않은닉네임");
         saveMember(createdNickname);
         when(nicknameGenerator.generate())
             .thenReturn(createdNickname);
@@ -86,7 +86,7 @@ class MemberServiceTest {
     @DisplayName("중복된 닉네임으로 임시 회원을 저장하려 할 때, 다섯 번까지 재시도한다.")
     void tryRegisterTempSeveralTimeIfDuplicatedNickname() throws Exception {
         // given
-        Nickname createdNickname = Nickname.create("중복되지않은_닉네임");
+        Nickname createdNickname = Nickname.create("중복되지않은닉네임");
         saveMember(createdNickname);
         when(nicknameGenerator.generate())
             .thenReturn(createdNickname);
@@ -102,8 +102,8 @@ class MemberServiceTest {
     @DisplayName("닉네임 중복으로 임시 회원 저장을 실패한 뒤 다시 시도했을 때, 다섯 번 안에 중복되지 않은 닉네임이 만들어지면 임시 회원을 저장할 수 있다.")
     void tryRegisterTempSuccessRecovery() throws Exception {
         // given
-        Nickname duplicatedNickname = Nickname.create("중복된_닉네임");
-        Nickname createdNickname = Nickname.create("중복되지않은_닉네임");
+        Nickname duplicatedNickname = Nickname.create("중복된닉네임");
+        Nickname createdNickname = Nickname.create("중복되지않은닉네임");
         saveMember(duplicatedNickname);
         when(nicknameGenerator.generate())
             .thenReturn(duplicatedNickname, duplicatedNickname, duplicatedNickname,
@@ -122,8 +122,8 @@ class MemberServiceTest {
     void registerSuccess() throws Exception {
         // given
         Member member = saveMember(Nickname.create("닉넴"));
-        String changedProfileUrl = "변경하는 프로필 주소";
-        String changedNickname = "변경할 닉네임";
+        String changedProfileUrl = "변경할프로필";
+        String changedNickname = "변경할닉네임";
 
         // when
         MemberInfo result = memberService.register(member.getId(),
@@ -141,8 +141,8 @@ class MemberServiceTest {
     void registerFailAlreadyRegistered() throws Exception {
         // given
         Member member = saveRegisterMember(Nickname.create("닉넴"));
-        String changedProfileUrl = "변경하는 프로필 주소";
-        String changedNickname = "변경할 닉네임";
+        String changedProfileUrl = "변경하는프로필주소";
+        String changedNickname = "변경할닉네임";
 
         // when & then
         assertThatThrownBy(() -> memberService.register(member.getId(),

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.temp.auth.dto.response.MemberInfo;
+import com.example.temp.common.entity.Email;
 import com.example.temp.exception.ApiException;
 import com.example.temp.exception.ErrorCode;
 import com.example.temp.member.domain.FollowStrategy;
@@ -166,7 +167,7 @@ class MemberServiceTest {
     private Member saveRegisterMember(Nickname nickname) {
         Member member = Member.builder()
             .nickname(nickname)
-            .email("이메일")
+            .email(Email.create("이메일"))
             .profileUrl("프로필주소")
             .registered(true)
             .followStrategy(FollowStrategy.EAGER)
@@ -179,7 +180,7 @@ class MemberServiceTest {
     private Member saveMember(Nickname nickname) {
         Member member = Member.builder()
             .nickname(nickname)
-            .email("이메일")
+            .email(Email.create("이메일"))
             .profileUrl("프로필주소")
             .registered(false)
             .followStrategy(FollowStrategy.EAGER)

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -128,7 +128,7 @@ class MemberServiceTest {
             new MemberRegisterRequest(changedProfileUrl, changedNickname));
 
         // then
-        assertThat(result.init()).isTrue();
+        assertThat(result.registered()).isTrue();
         assertThat(result.id()).isEqualTo(member.getId());
         assertThat(result.profileUrl()).isEqualTo(changedProfileUrl);
         assertThat(result.nickname()).isEqualTo(changedNickname);

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -47,8 +47,8 @@ class MemberServiceTest {
 
 
     @Test
-    @DisplayName("회원을 가입시킨다")
-    void registerSuccess() throws Exception {
+    @DisplayName("임시 멤버를 생성한다")
+    void registerTempSuccess() throws Exception {
         // given
         String createdNickname = "중복되지않은_닉네임";
         when(nicknameGenerator.generate())
@@ -63,8 +63,8 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("중복된 닉네임으로는 회원가입이 불가능하다")
-    void registerFailDuplicatedNickname() throws Exception {
+    @DisplayName("중복된 닉네임으로는 임시 멤버를 생성할 수 없다.")
+    void registerTempFailDuplicatedNickname() throws Exception {
         // given
         String createdNickname = "중복된_닉네임";
         saveMember(createdNickname);
@@ -77,8 +77,8 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("중복된 닉네임으로 회원가입 요청 시, 다섯 번까지 재시도한다.")
-    void trySeveralTimeIfDuplicatedNickname() throws Exception {
+    @DisplayName("중복된 닉네임으로 임시 회원을 저장하려 할 때, 다섯 번까지 재시도한다.")
+    void tryRegisterTempSeveralTimeIfDuplicatedNickname() throws Exception {
         // given
         String createdNickname = "중복된_닉네임";
         saveMember(createdNickname);
@@ -93,8 +93,8 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("닉네임 중복으로 회원가입 실패 후 다시 시도했을 때, 다섯 번 안에 중복되지 않은 닉네임이 만들어지면 회원가입이 가능하다")
-    void trySuccessRecovery() throws Exception {
+    @DisplayName("닉네임 중복으로 임시 회원 저장을 실패한 뒤 다시 시도했을 때, 다섯 번 안에 중복되지 않은 닉네임이 만들어지면 임시 회원을 저장할 수 있다.")
+    void tryRegisterTempSuccessRecovery() throws Exception {
         // given
         String duplicatedNickname = "중복된_닉네임";
         String createdNickname = "중복되지_않은_닉네임";

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -13,6 +13,7 @@ import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.dto.request.MemberRegisterRequest;
 import com.example.temp.member.exception.NicknameDuplicatedException;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import com.example.temp.member.infrastructure.nickname.NicknameGenerator;
 import com.example.temp.oauth.OAuthProviderType;
 import com.example.temp.oauth.OAuthResponse;
@@ -54,7 +55,7 @@ class MemberServiceTest {
     @DisplayName("임시 멤버를 생성한다")
     void registerTempSuccess() throws Exception {
         // given
-        String createdNickname = "중복되지않은_닉네임";
+        Nickname createdNickname = Nickname.create("중복되지않은_닉네임");
         when(nicknameGenerator.generate())
             .thenReturn(createdNickname);
 
@@ -70,7 +71,7 @@ class MemberServiceTest {
     @DisplayName("중복된 닉네임으로는 임시 멤버를 생성할 수 없다.")
     void registerTempFailDuplicatedNickname() throws Exception {
         // given
-        String createdNickname = "중복된_닉네임";
+        Nickname createdNickname = Nickname.create("중복되지않은_닉네임");
         saveMember(createdNickname);
         when(nicknameGenerator.generate())
             .thenReturn(createdNickname);
@@ -84,7 +85,7 @@ class MemberServiceTest {
     @DisplayName("중복된 닉네임으로 임시 회원을 저장하려 할 때, 다섯 번까지 재시도한다.")
     void tryRegisterTempSeveralTimeIfDuplicatedNickname() throws Exception {
         // given
-        String createdNickname = "중복된_닉네임";
+        Nickname createdNickname = Nickname.create("중복되지않은_닉네임");
         saveMember(createdNickname);
         when(nicknameGenerator.generate())
             .thenReturn(createdNickname);
@@ -100,8 +101,8 @@ class MemberServiceTest {
     @DisplayName("닉네임 중복으로 임시 회원 저장을 실패한 뒤 다시 시도했을 때, 다섯 번 안에 중복되지 않은 닉네임이 만들어지면 임시 회원을 저장할 수 있다.")
     void tryRegisterTempSuccessRecovery() throws Exception {
         // given
-        String duplicatedNickname = "중복된_닉네임";
-        String createdNickname = "중복되지_않은_닉네임";
+        Nickname duplicatedNickname = Nickname.create("중복된_닉네임");
+        Nickname createdNickname = Nickname.create("중복되지않은_닉네임");
         saveMember(duplicatedNickname);
         when(nicknameGenerator.generate())
             .thenReturn(duplicatedNickname, duplicatedNickname, duplicatedNickname,
@@ -119,7 +120,7 @@ class MemberServiceTest {
     @DisplayName("회원을 저장한다")
     void registerSuccess() throws Exception {
         // given
-        Member member = saveMember("닉넴");
+        Member member = saveMember(Nickname.create("닉넴"));
         String changedProfileUrl = "변경하는 프로필 주소";
         String changedNickname = "변경할 닉네임";
 
@@ -138,7 +139,7 @@ class MemberServiceTest {
     @DisplayName("이미 회원가입된 사용자 계정으로 회원가입을 할 수 없다.")
     void registerFailAlreadyRegistered() throws Exception {
         // given
-        Member member = saveRegisterMember("닉넴");
+        Member member = saveRegisterMember(Nickname.create("닉넴"));
         String changedProfileUrl = "변경하는 프로필 주소";
         String changedNickname = "변경할 닉네임";
 
@@ -162,7 +163,7 @@ class MemberServiceTest {
             .hasMessageContaining(ErrorCode.AUTHENTICATED_FAIL.getMessage());
     }
 
-    private Member saveRegisterMember(String nickname) {
+    private Member saveRegisterMember(Nickname nickname) {
         Member member = Member.builder()
             .nickname(nickname)
             .email("이메일")
@@ -175,7 +176,7 @@ class MemberServiceTest {
         return member;
     }
 
-    private Member saveMember(String nickname) {
+    private Member saveMember(Nickname nickname) {
         Member member = Member.builder()
             .nickname(nickname)
             .email("이메일")

--- a/src/test/java/com/example/temp/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package com.example.temp.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.member.infrastructure.nickname.Nickname;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -43,7 +44,7 @@ class MemberRepositoryTest {
     private Member createMember(Nickname nickname) {
         Member member = Member.builder()
             .nickname(nickname)
-            .email("이멜")
+            .email(Email.create("이메일"))
             .profileUrl("프로필")
             .followStrategy(FollowStrategy.EAGER)
             .build();

--- a/src/test/java/com/example/temp/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package com.example.temp.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,16 +23,15 @@ class MemberRepositoryTest {
     @Test
     @DisplayName("해당 닉네임이 DB에 존재하면 true를 반환한다.")
     void existsByNicknameSuccess() throws Exception {
-        String nickname = "firstNick";
+        Nickname nickname = Nickname.create("firstNick");
         assertThat(memberRepository.existsByNickname(nickname)).isFalse();
-
     }
 
     @Test
     @DisplayName("해당 닉네임이 DB에 존재하지 않으면 false를 반환한다.")
     void existsByNicknameFailDuplicated() throws Exception {
         // given
-        String nickname = "duplicated";
+        Nickname nickname = Nickname.create("duplicated");
         Member member = createMember(nickname);
         em.persist(member);
 
@@ -40,7 +40,7 @@ class MemberRepositoryTest {
 
     }
 
-    private Member createMember(String nickname) {
+    private Member createMember(Nickname nickname) {
         Member member = Member.builder()
             .nickname(nickname)
             .email("이멜")

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -3,6 +3,7 @@ package com.example.temp.member.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.exception.ApiException;
 import com.example.temp.exception.ErrorCode;
 import com.example.temp.member.infrastructure.nickname.Nickname;
@@ -50,7 +51,7 @@ class MemberTest {
     @DisplayName("초기화가 되지 않은 멤버를 생성한다.")
     void buildInitStatus() throws Exception {
         // given
-        String email = "email";
+        Email email = Email.create("email");
         String profileUrl = "profileUrl";
         Nickname nickname = Nickname.create("nickname");
 

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -1,0 +1,49 @@
+package com.example.temp.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.example.temp.exception.ApiException;
+import com.example.temp.exception.ErrorCode;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("회원을_초기화한다")
+    void init() throws Exception {
+        // given
+        String changedNickname = "변경할닉넴";
+        String changedProfileUrl = "변경할프로필주소";
+        Member member = Member.builder()
+            .init(false)
+            .build();
+
+        // when
+        member.init(changedNickname, changedProfileUrl);
+
+        // then
+        assertThat(member.isInit()).isTrue();
+        assertThat(member.getNickname()).isEqualTo(changedNickname);
+        assertThat(member.getProfileUrl()).isEqualTo(changedProfileUrl);
+    }
+
+    @Test
+    @DisplayName("초기화되어있던 회원은 초기화할 수 없다")
+    void initFailAlreadyInit() throws Exception {
+        // given
+        String changedNickname = "변경할닉넴";
+        String changedProfileUrl = "변경할프로필주소";
+        Member member = Member.builder()
+            .init(true)
+            .build();
+
+        // when & then
+        assertThatThrownBy(() -> member.init(changedNickname, changedProfileUrl))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.MEMBER_ALREADY_REGISTER.getMessage());
+    }
+}

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.temp.exception.ApiException;
 import com.example.temp.exception.ErrorCode;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +15,7 @@ class MemberTest {
     @DisplayName("회원을 초기화한다")
     void init() throws Exception {
         // given
-        String changedNickname = "변경할닉넴";
+        Nickname changedNickname = Nickname.create("변경할닉넴");
         String changedProfileUrl = "변경할프로필주소";
         Member member = Member.builder()
             .registered(false)
@@ -33,7 +34,7 @@ class MemberTest {
     @DisplayName("초기화되어있던 회원은 초기화할 수 없다")
     void initFailAlreadyInit() throws Exception {
         // given
-        String changedNickname = "변경할닉넴";
+        Nickname changedNickname = Nickname.create("변경할닉넴");
         String changedProfileUrl = "변경할프로필주소";
         Member member = Member.builder()
             .registered(true)
@@ -51,7 +52,7 @@ class MemberTest {
         // given
         String email = "email";
         String profileUrl = "profileUrl";
-        String nickname = "nickname";
+        Nickname nickname = Nickname.create("nickname");
 
         // when
         Member member = Member.createInitStatus(email, profileUrl, nickname);

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -44,4 +44,15 @@ class MemberTest {
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.MEMBER_ALREADY_REGISTER.getMessage());
     }
+
+    @Test
+    @DisplayName("초기화가 되지 않은 멤버를 생성한다.")
+    void buildInitStatus() throws Exception {
+
+        // when
+        Member member = Member.buildInitStatus().build();
+
+        // then
+        assertThat(member.isRegistered()).isFalse();
+    }
 }

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -11,20 +11,20 @@ import org.junit.jupiter.api.Test;
 class MemberTest {
 
     @Test
-    @DisplayName("회원을_초기화한다")
+    @DisplayName("회원을 초기화한다")
     void init() throws Exception {
         // given
         String changedNickname = "변경할닉넴";
         String changedProfileUrl = "변경할프로필주소";
         Member member = Member.builder()
-            .init(false)
+            .registered(false)
             .build();
 
         // when
         member.init(changedNickname, changedProfileUrl);
 
         // then
-        assertThat(member.isInit()).isTrue();
+        assertThat(member.isRegistered()).isTrue();
         assertThat(member.getNickname()).isEqualTo(changedNickname);
         assertThat(member.getProfileUrl()).isEqualTo(changedProfileUrl);
     }
@@ -36,7 +36,7 @@ class MemberTest {
         String changedNickname = "변경할닉넴";
         String changedProfileUrl = "변경할프로필주소";
         Member member = Member.builder()
-            .init(true)
+            .registered(true)
             .build();
 
         // when & then

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -48,11 +48,20 @@ class MemberTest {
     @Test
     @DisplayName("초기화가 되지 않은 멤버를 생성한다.")
     void buildInitStatus() throws Exception {
+        // given
+        String email = "email";
+        String profileUrl = "profileUrl";
+        String nickname = "nickname";
 
         // when
-        Member member = Member.buildInitStatus().build();
+        Member member = Member.createInitStatus(email, profileUrl, nickname);
 
         // then
         assertThat(member.isRegistered()).isFalse();
+        assertThat(member.getEmail()).isEqualTo(email);
+        assertThat(member.getProfileUrl()).isEqualTo(profileUrl);
+        assertThat(member.getNickname()).isEqualTo(nickname);
+
+
     }
 }

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -2,11 +2,9 @@ package com.example.temp.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.example.temp.exception.ApiException;
 import com.example.temp.exception.ErrorCode;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/example/temp/member/dto/request/MemberRegisterRequestTest.java
+++ b/src/test/java/com/example/temp/member/dto/request/MemberRegisterRequestTest.java
@@ -1,0 +1,25 @@
+package com.example.temp.member.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberRegisterRequestTest {
+
+    @Test
+    @DisplayName("생성자의 순서가 올바른지 테스트한다")
+    void create() throws Exception {
+        // given
+        String profileUrl = "profileUrl";
+        String nickname = "nickname";
+
+        // when
+        MemberRegisterRequest result = new MemberRegisterRequest(profileUrl, nickname);
+
+        // then
+        assertThat(result.profileUrl()).isEqualTo(profileUrl);
+        assertThat(result.nickname()).isEqualTo(nickname);
+    }
+
+}

--- a/src/test/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGeneratorTest.java
+++ b/src/test/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGeneratorTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,10 +22,35 @@ class FakerNicknameGeneratorTest {
     void createNickname() throws Exception {
         Set<String> nicknames = new HashSet<>();
         for (int i = 0; i < 1000; i++) {
-            String nickname = nicknameGenerator.generate();
-            Assertions.assertThat(nickname).isNotNull();
-            nicknames.add(nickname);
+            Nickname nickname = nicknameGenerator.generate();
+            assertThat(nickname).isNotNull();
+            nicknames.add(nickname.getNickname());
         }
         assertThat(nicknames.size()).isBetween(2, 1000);
+    }
+
+    @Test
+    @DisplayName("Nickname의 값이 일치하면 동등한 객체인지 확인한다.")
+    void equals() throws Exception {
+        // given
+        Nickname nickname1 = Nickname.create("nic");
+        Nickname nickname2 = Nickname.create("nic");
+
+        // when & then
+        assertThat(nickname1.equals(nickname2)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Nickname의 값이 일치하면 해시코드가 일치하는지 확인한다.")
+    void hashcode() throws Exception {
+        // given
+        Nickname nickname1 = Nickname.create("nic");
+        Nickname nickname2 = Nickname.create("nic");
+
+        // when
+        boolean result = nickname1.hashCode() == nickname2.hashCode();
+
+        // then
+        assertThat(result).isTrue();
     }
 }

--- a/src/test/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGeneratorTest.java
+++ b/src/test/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGeneratorTest.java
@@ -20,11 +20,11 @@ class FakerNicknameGeneratorTest {
     @Test
     @DisplayName("랜덤한 닉네임을 생성한다")
     void createNickname() throws Exception {
-        Set<String> nicknames = new HashSet<>();
+        Set<Nickname> nicknames = new HashSet<>();
         for (int i = 0; i < 1000; i++) {
             Nickname nickname = nicknameGenerator.generate();
             assertThat(nickname).isNotNull();
-            nicknames.add(nickname.getNickname());
+            nicknames.add(nickname);
         }
         assertThat(nicknames.size()).isBetween(2, 1000);
     }

--- a/src/test/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGeneratorTest.java
+++ b/src/test/java/com/example/temp/member/infrastructure/nickname/FakerNicknameGeneratorTest.java
@@ -29,28 +29,4 @@ class FakerNicknameGeneratorTest {
         assertThat(nicknames.size()).isBetween(2, 1000);
     }
 
-    @Test
-    @DisplayName("Nickname의 값이 일치하면 동등한 객체인지 확인한다.")
-    void equals() throws Exception {
-        // given
-        Nickname nickname1 = Nickname.create("nic");
-        Nickname nickname2 = Nickname.create("nic");
-
-        // when & then
-        assertThat(nickname1.equals(nickname2)).isTrue();
-    }
-
-    @Test
-    @DisplayName("Nickname의 값이 일치하면 해시코드가 일치하는지 확인한다.")
-    void hashcode() throws Exception {
-        // given
-        Nickname nickname1 = Nickname.create("nic");
-        Nickname nickname2 = Nickname.create("nic");
-
-        // when
-        boolean result = nickname1.hashCode() == nickname2.hashCode();
-
-        // then
-        assertThat(result).isTrue();
-    }
 }

--- a/src/test/java/com/example/temp/member/infrastructure/nickname/NicknameTest.java
+++ b/src/test/java/com/example/temp/member/infrastructure/nickname/NicknameTest.java
@@ -2,6 +2,7 @@ package com.example.temp.member.infrastructure.nickname;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.example.temp.exception.ApiException;
 import com.example.temp.exception.ErrorCode;
@@ -16,8 +17,8 @@ class NicknameTest {
     @DisplayName("Nickname의 값이 일치하면 동등한 객체인지 확인한다.")
     void equals() throws Exception {
         // given
-        Nickname nickname1 = Nickname.create("닉넴NickNAME12");
-        Nickname nickname2 = Nickname.create("닉넴NickNAME12");
+        Nickname nickname1 = Nickname.create("닉넴");
+        Nickname nickname2 = Nickname.create("닉넴");
 
         // when & then
         assertThat(nickname1.equals(nickname2)).isTrue();
@@ -36,6 +37,15 @@ class NicknameTest {
         // then
         assertThat(result).isTrue();
     }
+
+    @ParameterizedTest
+    @DisplayName("Nickname을 생성한다.")
+    @ValueSource(strings = {"닉넴NickNAME12", "닉넴", "ab", "12", "123456789012", "NiCKNAM2"})
+    void createNickname(String str) throws Exception {
+        // when & then
+        assertDoesNotThrow(() -> Nickname.create(str));
+    }
+
 
     @Test
     @DisplayName("Nickname의 길이는 12글자를 초과할 수 없다.")

--- a/src/test/java/com/example/temp/member/infrastructure/nickname/NicknameTest.java
+++ b/src/test/java/com/example/temp/member/infrastructure/nickname/NicknameTest.java
@@ -1,9 +1,14 @@
 package com.example.temp.member.infrastructure.nickname;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.temp.exception.ApiException;
+import com.example.temp.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class NicknameTest {
 
@@ -11,8 +16,8 @@ class NicknameTest {
     @DisplayName("Nickname의 값이 일치하면 동등한 객체인지 확인한다.")
     void equals() throws Exception {
         // given
-        Nickname nickname1 = Nickname.create("nic");
-        Nickname nickname2 = Nickname.create("nic");
+        Nickname nickname1 = Nickname.create("닉넴NickNAME12");
+        Nickname nickname2 = Nickname.create("닉넴NickNAME12");
 
         // when & then
         assertThat(nickname1.equals(nickname2)).isTrue();
@@ -30,6 +35,35 @@ class NicknameTest {
 
         // then
         assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("Nickname의 길이는 12글자를 초과할 수 없다.")
+    void nicknameTooLong() throws Exception {
+        // when & then
+        assertThatThrownBy(() -> Nickname.create("닉넴NickNAME123"))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.NICKNAME_TOO_LONG.getMessage());
+    }
+
+    @Test
+    @DisplayName("Nickname의 길이는 2글자 이상이어야 합니다.")
+    void nicknameTooShort() throws Exception {
+        // when & then
+        assertThatThrownBy(() -> Nickname.create("닉"))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.NICKNAME_TOO_SHORT.getMessage());
+    }
+
+    @ParameterizedTest
+    @DisplayName("Nickname에는 모든 종류의 특수문자를 포함할 수 없다")
+    @ValueSource(strings = {"!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "-", "_", "+", "=", "{", "}", "[", "]",
+        ":", ";", "'", "<", ">", "?", "/", ",", ".", "~", "`", "|", "\\", "\""})
+    void nicknameTooLong(String specialChar) throws Exception {
+        // when & then
+        assertThatThrownBy(() -> Nickname.create("닉넴Nick1" + specialChar))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.NICKNAME_PATTERN_MISMATCH.getMessage());
     }
 
 }

--- a/src/test/java/com/example/temp/member/infrastructure/nickname/NicknameTest.java
+++ b/src/test/java/com/example/temp/member/infrastructure/nickname/NicknameTest.java
@@ -1,0 +1,35 @@
+package com.example.temp.member.infrastructure.nickname;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NicknameTest {
+
+    @Test
+    @DisplayName("Nickname의 값이 일치하면 동등한 객체인지 확인한다.")
+    void equals() throws Exception {
+        // given
+        Nickname nickname1 = Nickname.create("nic");
+        Nickname nickname2 = Nickname.create("nic");
+
+        // when & then
+        assertThat(nickname1.equals(nickname2)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Nickname의 값이 일치하면 해시코드가 일치하는지 확인한다.")
+    void hashcode() throws Exception {
+        // given
+        Nickname nickname1 = Nickname.create("nic");
+        Nickname nickname2 = Nickname.create("nic");
+
+        // when
+        boolean result = nickname1.hashCode() == nickname2.hashCode();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+}

--- a/src/test/java/com/example/temp/member/infrastructure/nickname/NicknameTest.java
+++ b/src/test/java/com/example/temp/member/infrastructure/nickname/NicknameTest.java
@@ -57,7 +57,7 @@ class NicknameTest {
     }
 
     @Test
-    @DisplayName("Nickname의 길이는 2글자 이상이어야 합니다.")
+    @DisplayName("Nickname의 길이는 2글자 이상이어야 한다.")
     void nicknameTooShort() throws Exception {
         // when & then
         assertThatThrownBy(() -> Nickname.create("닉"))

--- a/src/test/java/com/example/temp/member/infrastructure/nickname/RandomNicknameGeneratorTest.java
+++ b/src/test/java/com/example/temp/member/infrastructure/nickname/RandomNicknameGeneratorTest.java
@@ -1,0 +1,31 @@
+package com.example.temp.member.infrastructure.nickname;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RandomNicknameGeneratorTest {
+
+    RandomNicknameGenerator nicknameGenerator;
+
+    @BeforeEach
+    void setUp() {
+        nicknameGenerator = new RandomNicknameGenerator();
+    }
+
+    @Test
+    @DisplayName("랜덤한 닉네임을 생성한다")
+    void createNickname() throws Exception {
+        Set<Nickname> nicknames = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            Nickname nickname = nicknameGenerator.generate();
+            assertThat(nickname).isNotNull();
+            nicknames.add(nickname);
+        }
+        assertThat(nicknames.size()).isBetween(2, 1000);
+    }
+}

--- a/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
+++ b/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
@@ -2,6 +2,7 @@ package com.example.temp.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.infrastructure.nickname.Nickname;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +49,7 @@ class OAuthResponseTest {
 
         // then
         assertThat(result.type()).isEqualTo(type);
-        assertThat(result.email()).isEqualTo(oAuthUserInfo.getEmail());
+        assertThat(result.email()).isEqualTo(Email.create(oAuthUserInfo.getEmail()));
         assertThat(result.name()).isEqualTo(oAuthUserInfo.getName());
         assertThat(result.idUsingResourceServer()).isEqualTo(oAuthUserInfo.getIdUsingResourceServer());
         assertThat(result.profileUrl()).isEqualTo(oAuthUserInfo.getProfileUrl());

--- a/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
+++ b/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
@@ -3,6 +3,7 @@ package com.example.temp.oauth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.temp.member.domain.Member;
+import com.example.temp.member.infrastructure.nickname.Nickname;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,7 +58,7 @@ class OAuthResponseTest {
     @DisplayName("OAuthResponse와 nickname을 사용해 초기화되지 않은 멤버를 만든다.")
     void createMemberUsingOAuthResponse() throws Exception {
         // given
-        String nickname = "닉네임";
+        Nickname nickname = Nickname.create("닉네임");
         OAuthResponse oAuthResponse = OAuthResponse.of(OAuthProviderType.GOOGLE, oAuthUserInfo);
 
         // when

--- a/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
+++ b/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
@@ -64,7 +64,7 @@ class OAuthResponseTest {
         Member result = oAuthResponse.toInitStatusMemberWith(nickname);
 
         // then
-        assertThat(result.isInit()).isFalse();
+        assertThat(result.isRegistered()).isFalse();
         assertThat(result.getNickname()).isEqualTo(nickname);
         assertThat(result.getEmail()).isEqualTo(oAuthResponse.email());
         assertThat(result.getProfileUrl()).isEqualTo(oAuthResponse.profileUrl());

--- a/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
+++ b/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
@@ -61,7 +61,7 @@ class OAuthResponseTest {
         OAuthResponse oAuthResponse = OAuthResponse.of(OAuthProviderType.GOOGLE, oAuthUserInfo);
 
         // when
-        Member result = oAuthResponse.toMemberWithNickname(nickname);
+        Member result = oAuthResponse.toInitStatusMemberWith(nickname);
 
         // then
         assertThat(result.isInit()).isFalse();

--- a/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
+++ b/src/test/java/com/example/temp/oauth/OAuthResponseTest.java
@@ -54,7 +54,7 @@ class OAuthResponseTest {
     }
 
     @Test
-    @DisplayName("OAuthResponse와 nickname을 사용해 Member 객체를 만든다.")
+    @DisplayName("OAuthResponse와 nickname을 사용해 초기화되지 않은 멤버를 만든다.")
     void createMemberUsingOAuthResponse() throws Exception {
         // given
         String nickname = "닉네임";
@@ -64,6 +64,7 @@ class OAuthResponseTest {
         Member result = oAuthResponse.toMemberWithNickname(nickname);
 
         // then
+        assertThat(result.isInit()).isFalse();
         assertThat(result.getNickname()).isEqualTo(nickname);
         assertThat(result.getEmail()).isEqualTo(oAuthResponse.email());
         assertThat(result.getProfileUrl()).isEqualTo(oAuthResponse.profileUrl());

--- a/src/test/java/com/example/temp/oauth/impl/google/GoogleOAuthProviderTest.java
+++ b/src/test/java/com/example/temp/oauth/impl/google/GoogleOAuthProviderTest.java
@@ -8,19 +8,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.oauth.OAuthProviderType;
 import com.example.temp.oauth.OAuthResponse;
-import com.example.temp.oauth.impl.google.GoogleOAuthClient;
-import com.example.temp.oauth.impl.google.GoogleOAuthProperties;
-import com.example.temp.oauth.impl.google.GoogleOAuthProvider;
-import com.example.temp.oauth.impl.google.GoogleToken;
-import com.example.temp.oauth.impl.google.GoogleUserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -80,7 +75,7 @@ class GoogleOAuthProviderTest {
 
         // then
         assertThat(result.type()).isEqualTo(OAuthProviderType.GOOGLE);
-        assertThat(result.email()).isEqualTo(googleUserInfo.getEmail());
+        assertThat(result.email()).isEqualTo(Email.create(googleUserInfo.getEmail()));
         assertThat(result.name()).isEqualTo(googleUserInfo.getName());
         assertThat(result.idUsingResourceServer()).isEqualTo(googleUserInfo.getIdUsingResourceServer());
         assertThat(result.profileUrl()).isEqualTo(googleUserInfo.getProfileUrl());

--- a/src/test/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProviderTest.java
+++ b/src/test/java/com/example/temp/oauth/impl/kakao/KakaoOAuthProviderTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.example.temp.common.entity.Email;
 import com.example.temp.oauth.OAuthProviderType;
 import com.example.temp.oauth.OAuthResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,7 +78,7 @@ class KakaoOAuthProviderTest {
 
         // then
         assertThat(result.type()).isEqualTo(OAuthProviderType.KAKAO);
-        assertThat(result.email()).isEqualTo(kakaoUserInfo.getEmail());
+        assertThat(result.email()).isEqualTo(Email.create(kakaoUserInfo.getEmail()));
         assertThat(result.name()).isEqualTo(kakaoUserInfo.getName());
         assertThat(result.idUsingResourceServer()).isEqualTo(kakaoUserInfo.getIdUsingResourceServer());
         assertThat(result.profileUrl()).isEqualTo(kakaoUserInfo.getProfileUrl());


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] Login API response 변경
- [x] 회원가입 API
- [x] Member 엔티티에 registered 필드 추가(boolean)
(2/7 추가)
- [x] Nickname, Email 값 객체 추가
- [x] RandomNicknameGenerator 생성

## 🏌🏻 리뷰 포인트
~~**Member 엔티티에 빌더가 두개에요**~~
-> 빌더가 두 개일 때, 더 상위에 선언한 빌더만 사용 가능합니다. 
그래서 해당 변경은 폐기하고 비즈니스 로직에서는 정적 팩토리 메서드를 사용하게 되었습니다.
이 변화로 인해 값 객체를 도입하게 되었어요.(정우님이 추천해주신 방법 중 의미적으로 가장 적절하다고 생각했어요.)

**값객체 생성**
Member의 Email, Nickname을 값 객체로 변경해줬습니다.
이를 통해 String 대신 더욱 의미를 갖고 사용할 수 있게 되었습니다.
다만 클라이언트에게 반환할 때는 값 객체를 그대로 반환할 수 없습니다. 그러면 API 명세가 깨져요.
그래서 Member 엔티티에 `getEmailStr`, `getNicknameStr` 메서드를 만들어뒀어요.
사용자에게 반환하는 목적이라면 비즈니스 로직이 끝난 뒤 `getXXXStr`을 호출해서 String으로 변환해주었습니다.

**레코드 타입에 빌더를 만드는 게 좋을까?**
저희는 객체를 생성할 때 생성자를 사용하지 말자고 규칙을 정했잖아요.
그래서 모든 객체들은 @Builder 생성자를 하나씩 가지고 있는데...

저는 레코드 타입에 이 규칙을 적용해야 할까 의문이 들었어요.
레코드 타입은 public 생성자 하나를 무조건 포함해야 하기 때문이에요.(아마 그럴거에요..? 레코드를 처음쓰다보니 불안하네요)
생성자를 private으로 강제하지 못하는데 Builder를 만들 필요 있을까? 의문이 들어서요.
굳이 만들 필요 없지 않을까 생각을 했습니다.

- 다만 아래와 같은 변경사항이 생길 때, 프로그램 차원에서 검증이 안되니까 테스트를 짜줄 필요는 있겠네요.
`레코드(String 변수1, String 변수2) -> 레코드(String 변수2, String 변수1)` -> 타입은 그대로라 컴파일 에러는 발생하지 않음


## 🧘🏻 기타 사항
**레코드를 언제 쓰는 게 맞을까?**
저희가 DTO에 레코드를 쓰기로 했었잖아요.
아무래도 저나 정우님 둘 다 레코드를 처음 쓰다보니까 긴가민가한 부분들이 있는거같아요.
개발하다가 보니까 레코드 타입에 정적 메서드를 선언하는 경우들이 생기는데요, 뭔가 물음표가 생겨요.
그런데 설명을 못하겠어요 ㅋㅋ 그냥 느낌적인 느낌이라 근거가 없어서 말을 못하겠는데 혹시 정우님도 같은 걸 느끼시나 해서 적어봤습니당

사실 둘 다 근거가 없으면 그냥 사용하는 게 좋을 거 같아요. 
지금 미숙한 상태에서 고민하더라도 좋은 결과를 낼 거 같지는 않아서,,, 추후 리팩토링하는 방향이 낫지 않을까 싶습니다.

**Random 객체는 보안상 위험하다는데 왜 쓰셨나요?**
<img width="957" alt="스크린샷 2024-02-07 오후 7 01 32" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/167ccb0f-19d3-4385-80cb-5b67e7a61373">
<img width="1352" alt="스크린샷 2024-02-07 오후 7 00 23" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/bd56bd00-454f-4691-af2a-b6eb8f0acc10">

현재 Random 객체는 RandomNicknameGenerator에서 랜덤한 닉네임 값을 생성하기 위해 사용중입니다.
이 데이터는 그냥 db 닉네임 제약조건 때문에 넣는 더미데이터잖아요. 노출되어도 **보안상 아무 문제가 없기 때문에** 해당 이슈를 꺼줬습니다. 

> 혹시나 문제가 생길까 하여 동작 원리를 살펴봤는데요.
Random 객체는 나노초를 기준으로 랜덤값을 만들어낸대요.
우리 서버는 임의의 닉네임을 만들 때, 닉네임이 겹치면 최대 다섯 번까지 요청을 보내는데요.
다섯 번의 요청이 모두 나노초까지 같을 확률은 없다고 판단했습니다.
결론은 보안상 && 사용상 아무 문제가 없어서 보안 이슈를 꺼줬습니다.

참고 자료 : https://kemilbeltre.medium.com/why-do-not-use-math-random-a6f8b0ad38dd


close #36 