### PR TITLE
[#43, #49] 회원 삭제, 닉네임 중복 검사

### DIFF
--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "닉네임의 길이가 너무 깁니다."),
     NICKNAME_TOO_SHORT(HttpStatus.BAD_REQUEST, "닉네임의 길이가 너무 짧습니다."),
     NICKNAME_PATTERN_MISMATCH(HttpStatus.BAD_REQUEST, "닉네임에 허용되지 않는 문자가 포함되었습니다."),
+    NICKNAME_DUPLICATED(HttpStatus.BAD_REQUEST, "닉네임이 중복되었습니다."),
 
     // 팔로우
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "두 회원 간에 팔로우 관계를 찾을 수 없습니다."),

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -15,9 +15,11 @@ import com.example.temp.follow.dto.response.FollowInfo;
 import com.example.temp.follow.dto.response.FollowResponse;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
+import com.example.temp.member.event.MemberDeletedEvent;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -177,5 +179,13 @@ public class FollowService {
         follow.reject();
     }
 
-}
+    /**
+     * 회원이 삭제되었을 때, 해당 회원이 팔로우 중이거나, 해당 회원을 팔로우하고 있는 모든 팔로우를 삭제합니다.
+     */
+    @EventListener
+    public void handleMemberDeletedEvent(MemberDeletedEvent event) {
+        List<Follow> follows = followRepository.findAllRelatedByMemberId(event.getMemberId());
+        followRepository.deleteAllInBatch(follows);
+    }
 
+}

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -10,14 +10,16 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByFromIdAndToId(long fromId, Long toId);
 
-    @Query("SELECT f FROM Follow f join fetch f.to where f.from.id = :fromId and f.status = :status")
+    @Query("SELECT f FROM Follow f JOIN FETCH f.to WHERE f.from.id = :fromId AND f.status = :status")
     List<Follow> findAllByFromIdAndStatus(@Param("fromId") long fromId, @Param("status") FollowStatus status);
 
-    @Query("SELECT f FROM Follow f join fetch f.from where f.to.id = :toId and f.status = :status")
+    @Query("SELECT f FROM Follow f JOIN FETCH f.from WHERE f.to.id = :toId AND f.status = :status")
     List<Follow> findAllByToIdAndStatus(@Param("toId") long toId, @Param("status") FollowStatus status);
 
     @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END FROM Follow f"
-        + " WHERE f.from.id = :executorId AND f.to.id = :targetId and f.status = 'APPROVED'")
+        + " WHERE f.from.id = :executorId AND f.to.id = :targetId AND f.status = 'APPROVED'")
     boolean checkExecutorFollowsTarget(@Param("executorId") long executorId, @Param("targetId") long targetId);
 
+    @Query("SELECT f FROM Follow f WHERE f.from.id = :memberId OR f.to.id = :memberId")
+    List<Follow> findAllRelatedByMemberId(@Param("memberId") long memberId);
 }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -7,10 +7,10 @@ import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
 import com.example.temp.member.domain.PrivacyPolicy;
-import com.example.temp.member.dto.request.MemberRegisterRequest;
-import com.example.temp.member.exception.NicknameDuplicatedException;
 import com.example.temp.member.domain.nickname.Nickname;
 import com.example.temp.member.domain.nickname.NicknameGenerator;
+import com.example.temp.member.dto.request.MemberRegisterRequest;
+import com.example.temp.member.exception.NicknameDuplicatedException;
 import com.example.temp.oauth.OAuthResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -57,14 +57,18 @@ public class MemberService {
      * 가입 처리가 완료되지 않은 회원을 가입시킵니다.
      *
      * @param userContext 로그인한 사용자의 정보
-     * @param request    회원 가입에 필요한 정보
+     * @param request     회원 가입에 필요한 정보
      * @return 회원가입이 완료된 Member 객체의 정보를 반환합니다.
      */
     @Transactional
     public MemberInfo register(UserContext userContext, MemberRegisterRequest request) {
         Member member = memberRepository.findById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
-        member.init(Nickname.create(request.nickname()), request.profileUrl());
+        Nickname nickname = Nickname.create(request.nickname());
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new ApiException(ErrorCode.NICKNAME_DUPLICATED);
+        }
+        member.init(nickname, request.profileUrl());
         return MemberInfo.of(member);
     }
 

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -78,4 +78,8 @@ public class MemberService {
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
         member.changePrivacy(privacyPolicy);
     }
+
+    public void withdraw(UserContext userContext, long targetId) {
+
+    }
 }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -59,6 +59,8 @@ public class MemberService {
      * @param userContext 로그인한 사용자의 정보
      * @param request     회원 가입에 필요한 정보
      * @return 회원가입이 완료된 Member 객체의 정보를 반환합니다.
+     * @throws ApiException NICKNAME_DUPLICATED: 닉네임이 중복되었을 때 발생합니다.
+     * @throws ApiException MEMBER_ALREADY_REGISTER: 이미 가입이 완료된 멤버가 해당 요청을 호출할 때 발생합니다.
      */
     @Transactional
     public MemberInfo register(UserContext userContext, MemberRegisterRequest request) {
@@ -72,6 +74,23 @@ public class MemberService {
         return MemberInfo.of(member);
     }
 
+    /**
+     * 회원을 탈퇴시킵니다.
+     *
+     * @param userContext 로그인한 사용자의 정보
+     * @param targetId    탈퇴시킬 대상의 ID
+     * @throws ApiException AUTHORIZED_FAIL: 로그인한 사용자와 탈퇴를 원하는 대상의 ID가 일치하지 않을 때 발생합니다.
+     */
+    @Transactional
+    public void withdraw(UserContext userContext, long targetId) {
+        if (userContext.id() != targetId) {
+            throw new ApiException(ErrorCode.AUTHORIZED_FAIL);
+        }
+        Member member = memberRepository.findById(userContext.id())
+            .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
+        member.delete();
+    }
+
     @Transactional
     public void changePrivacy(UserContext userContext, PrivacyPolicy privacyPolicy) {
         Member member = memberRepository.findById(userContext.id())
@@ -79,7 +98,4 @@ public class MemberService {
         member.changePrivacy(privacyPolicy);
     }
 
-    public void withdraw(UserContext userContext, long targetId) {
-
-    }
 }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -64,7 +64,7 @@ public class MemberService {
      */
     @Transactional
     public MemberInfo register(UserContext userContext, MemberRegisterRequest request) {
-        Member member = memberRepository.findById(userContext.id())
+        Member member = memberRepository.findMemberIncludingUnregisteredById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
         Nickname nickname = Nickname.create(request.nickname());
         if (memberRepository.existsByNickname(nickname)) {

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -35,6 +35,11 @@ public class Member {
      */
     private boolean registered;
 
+    /**
+     * 탈퇴한 회원의 경우 true 값을 갖습니다.
+     */
+    private boolean deleted;
+
     @Embedded
     private Nickname nickname;
 
@@ -53,9 +58,10 @@ public class Member {
     private FollowStrategy followStrategy;
 
     @Builder
-    private Member(boolean registered, Nickname nickname, Email email, String profileUrl,
+    private Member(boolean registered, boolean deleted, Nickname nickname, Email email, String profileUrl,
         PrivacyPolicy privacyPolicy, FollowStrategy followStrategy) {
         this.registered = registered;
+        this.deleted = deleted;
         this.nickname = nickname;
         this.email = email;
         this.profileUrl = profileUrl;
@@ -74,6 +80,7 @@ public class Member {
     public static Member createInitStatus(Email email, String profileUrl, Nickname nickname) {
         return Member.builder()
             .registered(false)
+            .deleted(false)
             .privacyPolicy(PrivacyPolicy.PRIVATE)
             .followStrategy(FollowStrategy.LAZY)
             .email(email)
@@ -123,6 +130,10 @@ public class Member {
 
     public boolean isPublicAccount() {
         return privacyPolicy == PrivacyPolicy.PUBLIC;
+    }
+
+    public void delete() {
+        this.deleted = true;
     }
 }
 

--- a/src/main/java/com/example/temp/member/domain/MemberRepository.java
+++ b/src/main/java/com/example/temp/member/domain/MemberRepository.java
@@ -10,17 +10,20 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    /**
+     * 회원가입 처리가 완료되고, 삭제가 되지 않은 회원을 조회합니다.
+     */
+    @Query("SELECT m FROM Member m WHERE m.id = :memberId"
+        + " AND m.registered = true"
+        + " AND m.deleted = false")
+    Optional<Member> findById(@Param(value = "memberId") long memberId);
+
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m"
         + " WHERE m.nickname = :nickname"
         + " AND m.deleted = false")
     boolean existsByNickname(Nickname nickname);
 
     @Query("SELECT m FROM Member m WHERE m.id = :memberId AND m.deleted = false")
-    Optional<Member> findById(@Param(value = "memberId") long memberId);
-
-    @Query("SELECT m FROM Member m WHERE m.id = :memberId"
-        + " AND m.registered = true"
-        + " AND m.deleted = false")
-    Optional<Member> findRegisteredMemberById(@Param(value = "memberId") long memberId);
+    Optional<Member> findMemberIncludingUnregisteredById(@Param(value = "memberId") long memberId);
 
 }

--- a/src/main/java/com/example/temp/member/domain/MemberRepository.java
+++ b/src/main/java/com/example/temp/member/domain/MemberRepository.java
@@ -1,12 +1,26 @@
 package com.example.temp.member.domain;
 
 import com.example.temp.member.domain.nickname.Nickname;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m"
+        + " WHERE m.nickname = :nickname"
+        + " AND m.deleted = false")
     boolean existsByNickname(Nickname nickname);
+
+    @Query("SELECT m FROM Member m WHERE m.id = :memberId AND m.deleted = false")
+    Optional<Member> findById(@Param(value = "memberId") long memberId);
+
+    @Query("SELECT m FROM Member m WHERE m.id = :memberId"
+        + " AND m.registered = true"
+        + " AND m.deleted = false")
+    Optional<Member> findRegisteredMemberById(@Param(value = "memberId") long memberId);
 
 }

--- a/src/main/java/com/example/temp/member/event/MemberDeletedEvent.java
+++ b/src/main/java/com/example/temp/member/event/MemberDeletedEvent.java
@@ -1,0 +1,23 @@
+package com.example.temp.member.event;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class MemberDeletedEvent {
+
+    private final long memberId;
+
+    @Builder
+    private MemberDeletedEvent(long memberId) {
+        this.memberId = memberId;
+    }
+
+    public static MemberDeletedEvent create(long memberId) {
+        return MemberDeletedEvent.builder()
+            .memberId(memberId)
+            .build();
+    }
+}

--- a/src/main/java/com/example/temp/member/presentation/MemberController.java
+++ b/src/main/java/com/example/temp/member/presentation/MemberController.java
@@ -8,6 +8,8 @@ import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.dto.request.MemberRegisterRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +28,12 @@ public class MemberController {
         @RequestBody MemberRegisterRequest memberRegisterRequest) {
         MemberInfo response = memberService.register(userContext, memberRegisterRequest);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<Void> withdraw(@Login UserContext userContext, @PathVariable long memberId) {
+        memberService.withdraw(userContext, memberId);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/account/privacy")

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -547,6 +547,7 @@ class FollowServiceTest {
 
     private Member saveMemberHelper(FollowStrategy followStrategy, PrivacyPolicy privacyPolicy) {
         Member member = Member.builder()
+            .registered(true)
             .email(Email.create("이메일"))
             .profileUrl("프로필")
             .nickname(Nickname.create("nick" + (globalIdx++)))

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -197,6 +197,26 @@ class FollowRepositoryTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    @DisplayName("특정 멤버가 팔로우하고 있는, 그리고 팔로우를 받은 모든 팔로우를 가져온다.")
+    void finAllRelatedFollowers() throws Exception {
+        // given
+        Member target = saveMember();
+        Member member1 = saveMember();
+        Member member2 = saveMember();
+
+        Follow related1 = saveFollow(target, member1, FollowStatus.REJECTED);
+        Follow related2 = saveFollow(member2, target, FollowStatus.APPROVED);
+        Follow notRelatedFollow = saveFollow(member1, member2, FollowStatus.APPROVED);
+
+        // when
+        List<Follow> follows = followRepository.findAllRelatedByMemberId(target.getId());
+
+        // then
+        assertThat(follows).hasSize(2)
+            .contains(related1, related2);
+    }
+
     private Follow saveFollow(Member fromMember, Member toMember1, FollowStatus status) {
         Follow follow = Follow.builder()
             .from(fromMember)

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -212,6 +212,32 @@ class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("서비스를 탈퇴한다.")
+    void withdraw() throws Exception {
+        // given
+        Member member = saveRegisteredMember(Nickname.create("nick"));
+
+        // when
+        memberService.withdraw(UserContext.from(member), member.getId());
+
+        // then
+        assertThat(member.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("자신의 계정만 탈퇴할 수 있다.")
+    void withdrawFailNotAuthz() throws Exception {
+        // given
+        Member anotherMember = saveRegisteredMember(Nickname.create("nick"));
+        Member loginMember = saveRegisteredMember(Nickname.create("nick2"));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.withdraw(UserContext.from(loginMember), anotherMember.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.AUTHORIZED_FAIL.getMessage());
+    }
+
+    @Test
     @DisplayName("존재하지 않는 회원은 계정 Privacy 상태를 바꿀 수 없다.")
     void changeStatusFail() throws Exception {
         // given


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 회원 Soft Delete
- [x]  연관된 Follow 모두 삭제
- [x] 닉네임 중복 검사 기능 구현

## 🏌🏻 리뷰 포인트
**회원 삭제 이벤트**
드디어 제가 스프링에서 이벤트를 써봤습니다!!!
이벤트를 사용하니까 모듈간의 결합도가 낮아지는 게 확 느껴집니다.
되게 마음에 드는 친구라서 앞으로 애용할 거 같습니다. **`강력추천`**

만약 정우님도 스프링 이벤트를 사용해보신 적 없다면 흐름이 헷갈릴텐데요.
흐름을 적어둘테니 리뷰하실 때 도움이 되면 좋겠어요.

1. MemberService의 `withdraw` 메서드를 보시면, member 삭제 후 EventPublisher가 이벤트(MemberDeletedEvent)를 발행합니다.
2. 스프링이 해당 이벤트의 구독자들을 찾아냅니다.
`MemberDeletedEvent`는 FollowService가 구독중이에요.
3. FollowService는 연관된 모든 Follow 엔티티를 삭제합니다. `handleMemberDeletedEvent` 를 보시면 돼요!

추가로 말씀드리면, 디버깅은 안해봤는데 옵저버 패턴 방식으로 동작한다고 하네요. (플젝 끝나고 구조 뜯어볼듯?)

**findById 메서드 registered=true 필터링**
서비스 계층에서 findById를 사용할 때 registered=true인 데이터만 가져오도록 묵시적인 처리를 해줬습니다.

장점 : 개발자 편의성을 올리고, 모듈간 결합도를 낮췄습니다.
단점 : 예상하지 못한 방식으로 동작할 수 있습니다.
단점 보완 :
- findById에 JavaDoc을 통해 동작 방식을 명시해줬습니다.
- 등록되지 않은 회원도 조회할 수 있는 별도의 메서드를 만들었습니다.

상세하게 설명드리면! 원래는 아래와 같이 메서드를 만들었어요. https://github.com/GymHubCommunity/GymHub-BE/commit/c7f160a15e7c5c256e5aca1170e35cf2562cc9ba
```java
    @Query("SELECT m FROM Member m WHERE m.id = :memberId AND m.deleted = false")
    Optional<Member> findById(@Param(value = "memberId") long memberId);

    @Query("SELECT m FROM Member m WHERE m.id = :memberId"
        + " AND m.registered = true"
        + " AND m.deleted = false")
    Optional<Member> 회원가입이_완료된_멤버를_가져온다(@Param(value = "memberId") long memberId);
```

그런데 이 방식을 사용하니까 MemberRepository의 클라이언트(FollowService) 입장에서 불편했습니다.
FollowService, PostService 등 서비스 입장에서는 "아직 회원가입 절차가 진행중인 사용자"에 대한 정보가 전혀 안궁금해요.
그럼에도 `회원가입이_완료된_멤버를_가져온다` 메서드를 써야 하는게 마음에 들지 않았습니다.

그래서 findById 메서드는 "회원가입된 사용자"만 조회할 수 있도록 만들었습니다.
이 말은 "회원가입 절차가 진행중인 사용자"를 FindById로 조회하면 Optional.empty()를 반환한다는 말이에요.
그리고 회원가입 절차가 진행중인 사용자를 가져올 수 있는 `findMemberIncludingUnregisteredById` 별도의 메서드를 만들어서 사용하기로 결론을 내렸습니다.


## 🧘🏻 기타 사항
**이벤트는 흐름을 파악하기 어렵다.**
저는 원래 이벤트라는 건 명시적인 코드 흐름이 없어서 어떻게 동작이 일어나는지 어렵다는 선입견이 있었어요.
(기억이 가물가물한데 예전에 자바스크립트 사용할 때 분명 그랬던 거 같아요. vscode 문제였나..?)

그런데 인텔리제이와 스프링과 함께라면 그런 걱정 안해도 될 거 같아요.
인텔리제이가 해당 이벤트를 구독한 위치를 전부 보여주네요.
<img width="414" alt="스크린샷 2024-02-09 오후 2 15 03" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/ffbe46e8-2fd8-444a-a556-bc7f1a15c03e">

우리는 저거 보면서 흐름을 파악하고, @SpringBootTest만 잘 작성해두면 이벤트 기반으로 서비스 만드는 게 마냥 어렵지는 않겠네요.

**findById, existsByID JPQL로 재정의**
MemberRepository를 보시면 모든 메서드를 JPQL로 재정의했어요.
그 이유는 데이터를 가져올 때, 이미 삭제된(deleted=true)인 회원을 필터링해서 가져오기 위해서에요.

모든 메서드에 자동으로 deleted=true를 붙여주는 `@SQLDelete` 라는 친구가 있기는 한데요,,,
저는 해당 설정을 좋아하지 않아요.

저걸 쓰게 되면 deleted가 true인 메서드를 가져올 수 있는 방법이 없어집니다.
나중에 soft delete된 회원을 Batch를 돌리면서 직접 삭제하는 기능을 만들거 같아서 `@SQLDelete`는 사용하지 않았습니다.

> 제가 경험해보기도 했고, 영한님 피셜로 실무에서도 권장하지 않는다 합니다.
예전에 확인해 본 바로는 jpa, JPQL, QueryDSL 세 개 모두 SQLDelete 설정이 자동으로 적용되더라구요.
그 때 찾아보기로는 Hibernate 구현체를 사용하면 해당 설정을 뗄 수 없다고 봤던 거 같습니다.
JDBC를 직접 쓰면 deleted가 true인 메서드를 가져올 수 있겠지만 저는 그렇게 할 바에는 JPQL로 메서드 재정의를 할 거 같아요.

close #43 
close #49 
