### PR TITLE
[#57, #59] Swagger 설정, jacoco 테스트 대상 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,12 +66,12 @@ tasks.named('test') {
 }
 
 jacocoTestReport {
-    afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
-            fileTree(dir: it,
-                    exclude: ['**/common/config', "**/presentation/**"])
-        })
-    }    
+//    afterEvaluate {
+//        classDirectories = files(classDirectories.files.collect {
+//            fileTree(dir: it,
+//                    exclude: ['**/common/config', "**/presentation/**"])
+//        })
+//    }
     reports {
         xml.required.set(true)
         html.required.set(true)

--- a/src/main/java/com/example/temp/common/annotation/Login.java
+++ b/src/main/java/com/example/temp/common/annotation/Login.java
@@ -1,10 +1,12 @@
 package com.example.temp.common.annotation;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@Hidden
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Login {

--- a/src/main/java/com/example/temp/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/temp/common/config/SwaggerConfig.java
@@ -1,21 +1,40 @@
 package com.example.temp.common.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @OpenAPIDefinition
 @Configuration
-public class SwaggerConfig {
+@Profile("local")
+public class SwaggerConfig implements WebMvcConfigurer {
 
     @Bean
     public OpenAPI customOpenAPI() {
         Info info = new Info()
             .title("GymHub")
             .version("v1.0.0");
+
+        String securityRequirementName = "accessToken을 붙여넣으세요, Bearer는 필요 없습니다.";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(securityRequirementName);
+
+        Components components = new Components()
+            .addSecuritySchemes(securityRequirementName, new SecurityScheme()
+                .name(securityRequirementName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT"));
+
         return new OpenAPI()
-            .info(info);
+            .info(info)
+            .addSecurityItem(securityRequirement) // 인증 정보를 Global하게 사용할 수 있게 만듦
+            .components(components); // securityRequirementName이 어떤 방식으로 동작하는지 설정함
     }
 }

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -44,8 +44,8 @@ public class Member {
     @Column(nullable = false)
     private String profileUrl;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    @Enumerated
     private PrivacyPolicy privacyPolicy;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,3 @@
+INSERT INTO members(member_id, registered, nickname, email, profile_url, privacy_policy, follow_strategy)
+VALUES (1, true, '김태훈', 'first@test.com', 'https://avatars.githubusercontent.com/u/67636607?s=80&u=66f65ed6f693c3235b3ba0a4a1ed93b7eeae50cb&v=4', 'PUBLIC', 'EAGER'),
+       (2, true, '이정우', 'another@test.org', 'https://avatars.githubusercontent.com/u/49686619?v=4', 'PUBLIC', 'EAGER');

--- a/src/test/java/com/example/temp/common/config/SwaggerConfigTest.java
+++ b/src/test/java/com/example/temp/common/config/SwaggerConfigTest.java
@@ -1,0 +1,37 @@
+package com.example.temp.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SwaggerConfigTest {
+
+    SwaggerConfig swaggerConfig;
+
+    @BeforeEach
+    void setUp() {
+        swaggerConfig = new SwaggerConfig();
+    }
+
+    @Test
+    void testCustomOpenAPI() {
+        String securityRequirementName = "accessToken을 붙여넣으세요, Bearer는 필요 없습니다.";
+        OpenAPI openAPI = swaggerConfig.customOpenAPI();
+
+        assertThat(openAPI.getInfo().getTitle()).isEqualTo("GymHub");
+        assertThat(openAPI.getInfo().getVersion()).isNotNull();
+        Map<String, SecurityScheme> securitySchemes = openAPI.getComponents().getSecuritySchemes();
+        SecurityScheme securityScheme = securitySchemes.get(securityRequirementName);
+
+        assertThat(securityScheme.getName()).isEqualTo(securityRequirementName);
+        assertThat(securityScheme.getType()).isEqualTo(Type.HTTP);
+        assertThat(securityScheme.getScheme()).isEqualTo("bearer");
+        assertThat(securityScheme.getBearerFormat()).isEqualTo("JWT");
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,3 +1,8 @@
+spring:
+  sql:
+    init:
+      mode: never # 테스트를 돌릴 때 data.sql을 실행하지 않겠다.
+
 # Jwt 커스텀
 jwt:
   secret: ThisIsSecretThisIsSecretThisIsSecretThisIsSecretThisIsSecretThisIsSecretThisIsSecretThisIsSecret


### PR DESCRIPTION
## 👊🏻 작업 내용
- [x] Swagger에서 UserContext에 대한 정보가 노출되는 이슈 해결
- [x] Swagger Authorization 헤더 입력할 수 있도록 구현
- [x] init.sql 생성해 회원을 둘 저장
- [x] 오랜 기간 유효한 토큰 생성하기(테스트용 Key로 만들어 보안 이슈 없음)
- [x] common/config, presentation 테스트 커버리지 대상에서 제외

**이제 우측 상단을 통해 access token을 사용할 수 있게 되었습니다**
<img width="1045" alt="스크린샷 2024-02-10 오후 4 03 00" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/fbac6142-67c7-4ba9-a252-b0cb3a3c2463">

UserContext가 노출되어 프론트엔드 입장에서 혼란스럽겠더라구요. 
이 부분 `@Login` 어노테이션에 `@Hidden` 적용해서 안보이게 만들어줬습니다.

적용 전
<img width="333" alt="스크린샷 2024-02-10 오후 4 05 24" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/3266222a-f7d8-4741-b884-e2a4eb481f4e">

적용 후
<img width="241" alt="스크린샷 2024-02-10 오후 4 04 21" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/56145a3d-8aa5-44d4-a553-677068b467c4">


## 🏌🏻 리뷰 포인트
설정에 관련한 부분이라 특별하게 리뷰하실 내용은 없을 거에요!

## 🧘🏻 기타 사항
- application.yml 갱신
- 로컬 환경에서 20주 유효한 토큰 만들어서 함께 올려뒀어요.

close #57 
close #59  