### PR TITLE
[#56] Presigned URL 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ repositories {
 }
 
 dependencies {
+
+    // AWS S3 의존성
+    implementation 'software.amazon.awssdk:s3:2.23.19'
+
     // Swagger 의존성
     // https://springdoc.org/#migrating-from-springfox
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'

--- a/src/main/java/com/example/temp/common/config/S3Config.java
+++ b/src/main/java/com/example/temp/common/config/S3Config.java
@@ -1,0 +1,66 @@
+package com.example.temp.common.config;
+
+import com.example.temp.common.properties.S3Properties;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    private final S3Properties s3Properties;
+
+    @Bean
+    S3Presigner s3Presigner(AwsCredentialsProvider credentialsProvider, S3Configuration s3Configuration) {
+        return S3Presigner.builder()
+            .region(Region.of(s3Properties.region()))
+            .endpointOverride(URI.create(s3Properties.endpoint()))
+            .credentialsProvider(credentialsProvider)
+            .serviceConfiguration(s3Configuration)
+            .build();
+    }
+
+    /**
+     * 로컬 환경에서는 S3를 에뮬레이팅합니다. 해당 환경에서는 Credentials가 필요 없어 test, test라는 값을 넣어 사용합니다.
+     */
+    @Bean
+    @Profile("local")
+    @SuppressWarnings("java:S6437")
+    public AwsCredentialsProvider localAwsCredentialsProvider() {
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test"));
+    }
+
+    /**
+     * 로컬 환경에서 S3를 대신해서 LocalStack을 사용중입니다. LocalStack은 s3와 경로가 다르다는 문제가 있어 별도의 프로필로 관리합니다.
+     */
+    @Bean
+    @Profile("local")
+    public S3Configuration localS3Configuration() {
+        return S3Configuration.builder()
+            .pathStyleAccessEnabled(true)
+            .build();
+    }
+
+    @Bean
+    @Profile("!local")
+    public AwsCredentialsProvider prodAwsCredentialsProvider() {
+        return InstanceProfileCredentialsProvider.create();
+    }
+
+    @Bean
+    @Profile("!local")
+    public S3Configuration prodS3Configuration() {
+        return S3Configuration.builder()
+            .build();
+    }
+}

--- a/src/main/java/com/example/temp/common/entity/Extension.java
+++ b/src/main/java/com/example/temp/common/entity/Extension.java
@@ -1,0 +1,27 @@
+package com.example.temp.common.entity;
+
+import static com.example.temp.common.entity.Extension.Type.IMAGE;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public enum Extension {
+    JPEG(IMAGE),
+    JPG(IMAGE),
+    PNG(IMAGE);
+
+    private final Type type;
+
+    Extension(Type type) {
+        this.type = type;
+    }
+
+    public boolean isImageType() {
+        return Objects.equals(this.type, IMAGE);
+    }
+
+    enum Type {
+        IMAGE;
+    }
+}

--- a/src/main/java/com/example/temp/common/entity/Extension.java
+++ b/src/main/java/com/example/temp/common/entity/Extension.java
@@ -1,12 +1,14 @@
 package com.example.temp.common.entity;
 
 import static com.example.temp.common.entity.Extension.Type.IMAGE;
+import static com.example.temp.common.entity.Extension.Type.TEXT;
 
 import java.util.Objects;
 import lombok.Getter;
 
 @Getter
 public enum Extension {
+    TXT(TEXT),
     JPEG(IMAGE),
     JPG(IMAGE),
     PNG(IMAGE);
@@ -22,6 +24,7 @@ public enum Extension {
     }
 
     enum Type {
+        TEXT,
         IMAGE;
     }
 }

--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
 
     // 공통
     TEST(HttpStatus.BAD_REQUEST, "테스트용 예외 메시지입니다."),
+    EXTENSION_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "해당 확장자는 지원하지 않습니다"),
 
     // 인증
     AUTHENTICATED_FAIL(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
@@ -32,7 +33,10 @@ public enum ErrorCode {
     FOLLOW_INACTIVE(HttpStatus.BAD_REQUEST, "해당 Follow는 비활성화된 상태이기 때문에, 해당 요청을 수행할 수 없습니다."),
 
     //게시글
-    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "게시글은 최대 2,000자 까지 가능합니다.");
+    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "게시글은 최대 2,000자 까지 가능합니다."),
+
+    // 이미지
+    IMAGE_TOO_BIG(HttpStatus.BAD_REQUEST, "이미지의 크기가 너무 큽니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode {
     CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "게시글은 최대 2,000자 까지 가능합니다."),
 
     // 이미지
-    IMAGE_TOO_BIG(HttpStatus.BAD_REQUEST, "이미지의 크기가 너무 큽니다");
+    IMAGE_TOO_BIG(HttpStatus.BAD_REQUEST, "이미지의 크기가 너무 큽니다"),
+    IMAGE_NAME_DUPLICATED(HttpStatus.CONFLICT, "서버에서 생성한 이미지의 이름이 중복되었습니다. 다시 한 번 요청을 보내주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.example.temp.common.exception;
 
-import com.example.temp.common.exception.ApiException;
-import com.example.temp.common.exception.ErrorResponse;
 import com.example.temp.member.exception.NicknameDuplicatedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/temp/common/properties/S3Properties.java
+++ b/src/main/java/com/example/temp/common/properties/S3Properties.java
@@ -7,7 +7,8 @@ public record S3Properties(
     String region,
     String endpoint,
     String bucket,
-    long presignedExpires
+    long presignedExpires,
+    long imgMaxContentLength
 ) {
 
 }

--- a/src/main/java/com/example/temp/common/properties/S3Properties.java
+++ b/src/main/java/com/example/temp/common/properties/S3Properties.java
@@ -1,0 +1,11 @@
+package com.example.temp.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "s3")
+public record S3Properties(
+    String region,
+    String endpoint
+) {
+
+}

--- a/src/main/java/com/example/temp/common/properties/S3Properties.java
+++ b/src/main/java/com/example/temp/common/properties/S3Properties.java
@@ -5,7 +5,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "s3")
 public record S3Properties(
     String region,
-    String endpoint
+    String endpoint,
+    String bucket,
+    long presignedExpires
 ) {
 
 }

--- a/src/main/java/com/example/temp/common/utils/random/DefaultRandomGenerator.java
+++ b/src/main/java/com/example/temp/common/utils/random/DefaultRandomGenerator.java
@@ -3,41 +3,57 @@ package com.example.temp.common.utils.random;
 import java.util.Random;
 import org.springframework.stereotype.Component;
 
+/**
+ * 랜덤한 난수를 생성합니다. 생성되는 난수는 [알파벳 대소문자, 숫자] 로 구성되어 있습니다. 기본으로 생성되는 난수의 길이는 20입니다.
+ *
+ * @warning 보안에 관련한 용도로는 사용해서는 안됩니다. 해당 생성기로 만들어지는 난수는 예측이 가능합니다.
+ */
 @Component
+@SuppressWarnings("java:S2245")
 public class DefaultRandomGenerator implements RandomGenerator {
 
-    public static final int DEFAULT_SIZE = 10;
+    public static final int DEFAULT_SIZE = 20;
     private static final String DEFAULT_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
 
-    private final Random random = new Random(12312);
+    private final Random random = new Random("GymHub".hashCode());
 
+    /**
+     * @param length
+     * @return 길이가 length인 난수
+     */
     @Override
-    public String generate(int size) {
-        StringBuilder randomStr = new StringBuilder(size);
-        for (int i = 0; i < size; i++) {
-            int number = this.random.nextInt(DEFAULT_CHARSET.length());
-            char ch = DEFAULT_CHARSET.charAt(number);
-            randomStr.append(ch);
-        }
-        return randomStr.toString();
+    public String generate(int length) {
+        return generateHelper(length, this.random);
     }
 
+    /**
+     * 길이가 DEFAULT인 난수를 반환합니다.
+     */
     @Override
     public String generate() {
         return generate(DEFAULT_SIZE);
     }
 
+    /**
+     * 길이가 length인 고정된 난수를 반환합니다.
+     *
+     * @param seed
+     * @param length
+     */
     @Override
     public String generateWithSeed(String seed, int length) {
-        long seedLong = seed.hashCode();
-        Random randomGenerator = new Random(seedLong);
+        Random randomGenerator = new Random(seed.hashCode());
+        return generateHelper(length, randomGenerator);
+    }
+
+
+    private String generateHelper(int length, Random random) {
         StringBuilder randomStr = new StringBuilder();
         for (int i = 0; i < length; i++) {
-            int number = randomGenerator.nextInt(DEFAULT_CHARSET.length());
+            int number = random.nextInt(DEFAULT_CHARSET.length());
             char ch = DEFAULT_CHARSET.charAt(number);
             randomStr.append(ch);
         }
         return randomStr.toString();
     }
-
 }

--- a/src/main/java/com/example/temp/common/utils/random/DefaultRandomGenerator.java
+++ b/src/main/java/com/example/temp/common/utils/random/DefaultRandomGenerator.java
@@ -1,0 +1,43 @@
+package com.example.temp.common.utils.random;
+
+import java.util.Random;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultRandomGenerator implements RandomGenerator {
+
+    public static final int DEFAULT_SIZE = 10;
+    private static final String DEFAULT_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
+
+    private final Random random = new Random(12312);
+
+    @Override
+    public String generate(int size) {
+        StringBuilder randomStr = new StringBuilder(size);
+        for (int i = 0; i < size; i++) {
+            int number = this.random.nextInt(DEFAULT_CHARSET.length());
+            char ch = DEFAULT_CHARSET.charAt(number);
+            randomStr.append(ch);
+        }
+        return randomStr.toString();
+    }
+
+    @Override
+    public String generate() {
+        return generate(DEFAULT_SIZE);
+    }
+
+    @Override
+    public String generateWithSeed(String seed, int length) {
+        long seedLong = seed.hashCode();
+        Random randomGenerator = new Random(seedLong);
+        StringBuilder randomStr = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            int number = randomGenerator.nextInt(DEFAULT_CHARSET.length());
+            char ch = DEFAULT_CHARSET.charAt(number);
+            randomStr.append(ch);
+        }
+        return randomStr.toString();
+    }
+
+}

--- a/src/main/java/com/example/temp/common/utils/random/RandomGenerator.java
+++ b/src/main/java/com/example/temp/common/utils/random/RandomGenerator.java
@@ -1,0 +1,11 @@
+package com.example.temp.common.utils.random;
+
+public interface RandomGenerator {
+
+    String generate(int size);
+
+    String generate();
+
+    String generateWithSeed(String seed, int length);
+
+}

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -5,7 +5,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByFromIdAndToId(long fromId, Long toId);

--- a/src/main/java/com/example/temp/image/application/ImageService.java
+++ b/src/main/java/com/example/temp/image/application/ImageService.java
@@ -1,6 +1,10 @@
 package com.example.temp.image.application;
 
+import com.example.temp.common.entity.Extension;
+import com.example.temp.common.exception.ApiException;
+import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.common.properties.S3Properties;
+import com.example.temp.image.dto.request.PresignedUrlRequest;
 import java.net.URL;
 import java.time.Duration;
 import java.util.function.Consumer;
@@ -17,15 +21,34 @@ public class ImageService {
     private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
 
-    public URL createPresignedUrl() {
+    public URL createPresignedUrl(PresignedUrlRequest request) {
+        long contentLength = request.contentLength();
+        if (contentLength > s3Properties.imgMaxContentLength()) {
+            throw new ApiException(ErrorCode.IMAGE_TOO_BIG);
+        }
+        validateExtension(request.extension());
+
         PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(r ->
             r.signatureDuration(Duration.ofSeconds(s3Properties.presignedExpires()))
-                .putObjectRequest(createPutObjectRequest()));
+                .putObjectRequest(createPutObjectRequest(contentLength)));
 
         return presignedRequest.url();
     }
 
-    private Consumer<Builder> createPutObjectRequest() {
-        return objectRequest -> objectRequest.bucket(s3Properties.bucket()).key("test");
+    private void validateExtension(String extValue) {
+        try {
+            Extension ext = Extension.valueOf(extValue.toUpperCase());
+            if (!ext.isImageType()) {
+                throw new ApiException(ErrorCode.EXTENSION_NOT_SUPPORTED);
+            }
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(ErrorCode.EXTENSION_NOT_SUPPORTED);
+        }
+    }
+
+    private Consumer<Builder> createPutObjectRequest(long contentLength) {
+        return objectRequest -> objectRequest.bucket(s3Properties.bucket())
+            .contentLength(contentLength)
+            .key("test");
     }
 }

--- a/src/main/java/com/example/temp/image/application/ImageService.java
+++ b/src/main/java/com/example/temp/image/application/ImageService.java
@@ -1,0 +1,17 @@
+package com.example.temp.image.application;
+
+import com.example.temp.common.dto.UserContext;
+import com.example.temp.image.dto.response.PresignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ImageService {
+
+    public PresignedUrlResponse createPresignedUrl(UserContext userContext) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/temp/image/application/ImageService.java
+++ b/src/main/java/com/example/temp/image/application/ImageService.java
@@ -1,5 +1,6 @@
 package com.example.temp.image.application;
 
+import com.example.temp.common.properties.S3Properties;
 import java.net.URL;
 import java.time.Duration;
 import java.util.function.Consumer;
@@ -14,16 +15,17 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequ
 public class ImageService {
 
     private final S3Presigner s3Presigner;
+    private final S3Properties s3Properties;
 
     public URL createPresignedUrl() {
         PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(r ->
-            r.signatureDuration(Duration.ofSeconds(300))
+            r.signatureDuration(Duration.ofSeconds(s3Properties.presignedExpires()))
                 .putObjectRequest(createPutObjectRequest()));
 
         return presignedRequest.url();
     }
 
-    private static Consumer<Builder> createPutObjectRequest() {
-        return objectRequest -> objectRequest.bucket("test240209").key("test");
+    private Consumer<Builder> createPutObjectRequest() {
+        return objectRequest -> objectRequest.bucket(s3Properties.bucket()).key("test");
     }
 }

--- a/src/main/java/com/example/temp/image/application/ImageService.java
+++ b/src/main/java/com/example/temp/image/application/ImageService.java
@@ -1,9 +1,11 @@
 package com.example.temp.image.application;
 
+import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.entity.Extension;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.common.properties.S3Properties;
+import com.example.temp.common.utils.random.RandomGenerator;
 import com.example.temp.image.dto.request.PresignedUrlRequest;
 import java.net.URL;
 import java.time.Duration;
@@ -18,21 +20,33 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequ
 @RequiredArgsConstructor
 public class ImageService {
 
+    public static final int RANDOM_SIZE_ABOUT_ID = 10;
+    public static final String DELIMITER = ".";
+
     private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
+    private final RandomGenerator randomGenerator;
 
-    public URL createPresignedUrl(PresignedUrlRequest request) {
+    public URL createPresignedUrl(UserContext userContext, PresignedUrlRequest request) {
+        Long memberId = userContext.id();
         long contentLength = request.contentLength();
         if (contentLength > s3Properties.imgMaxContentLength()) {
             throw new ApiException(ErrorCode.IMAGE_TOO_BIG);
         }
         validateExtension(request.extension());
 
+        String fileName = generateFileName(memberId);
         PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(r ->
             r.signatureDuration(Duration.ofSeconds(s3Properties.presignedExpires()))
-                .putObjectRequest(createPutObjectRequest(contentLength)));
+                .putObjectRequest(createPutObjectRequest(contentLength, fileName)));
 
         return presignedRequest.url();
+    }
+
+    private String generateFileName(Long memberId) {
+        String randomId = randomGenerator.generateWithSeed(String.valueOf(memberId), RANDOM_SIZE_ABOUT_ID);
+        String uuid = randomGenerator.generate();
+        return randomId + DELIMITER + uuid;
     }
 
     private void validateExtension(String extValue) {
@@ -46,9 +60,9 @@ public class ImageService {
         }
     }
 
-    private Consumer<Builder> createPutObjectRequest(long contentLength) {
+    private Consumer<Builder> createPutObjectRequest(long contentLength, String fileName) {
         return objectRequest -> objectRequest.bucket(s3Properties.bucket())
             .contentLength(contentLength)
-            .key("test");
+            .key(fileName);
     }
 }

--- a/src/main/java/com/example/temp/image/application/ImageService.java
+++ b/src/main/java/com/example/temp/image/application/ImageService.java
@@ -1,17 +1,30 @@
 package com.example.temp.image.application;
 
 import com.example.temp.common.dto.UserContext;
-import com.example.temp.image.dto.response.PresignedUrlResponse;
+import java.net.URL;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ImageService {
 
-    public PresignedUrlResponse createPresignedUrl(UserContext userContext) {
-        return null;
+    private final S3Presigner s3Presigner;
+
+    public URL createPresignedUrl(UserContext userContext) {
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+            .bucket("test240209")
+            .key("test")
+            .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(r ->
+            r.signatureDuration(Duration.ofSeconds(300))
+                .putObjectRequest(objectRequest));
+
+        return presignedRequest.url();
     }
 }

--- a/src/main/java/com/example/temp/image/application/ImageService.java
+++ b/src/main/java/com/example/temp/image/application/ImageService.java
@@ -6,18 +6,23 @@ import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.common.properties.S3Properties;
 import com.example.temp.common.utils.random.RandomGenerator;
+import com.example.temp.image.domain.Image;
+import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.image.dto.request.PresignedUrlRequest;
 import java.net.URL;
 import java.time.Duration;
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest.Builder;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ImageService {
 
     public static final int RANDOM_SIZE_ABOUT_ID = 10;
@@ -26,27 +31,36 @@ public class ImageService {
     private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
     private final RandomGenerator randomGenerator;
+    private final ImageRepository imageRepository;
 
+    @Transactional
     public URL createPresignedUrl(UserContext userContext, PresignedUrlRequest request) {
-        Long memberId = userContext.id();
-        long contentLength = request.contentLength();
-        if (contentLength > s3Properties.imgMaxContentLength()) {
-            throw new ApiException(ErrorCode.IMAGE_TOO_BIG);
+        try {
+            Long memberId = userContext.id();
+            long contentLength = request.contentLength();
+            if (contentLength > s3Properties.imgMaxContentLength()) {
+                throw new ApiException(ErrorCode.IMAGE_TOO_BIG);
+            }
+            validateExtension(request.extension());
+
+            String fileName = generateFileName(memberId);
+            PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(r ->
+                r.signatureDuration(Duration.ofSeconds(s3Properties.presignedExpires()))
+                    .putObjectRequest(createPutObjectRequest(contentLength, fileName)));
+
+            return presignedRequest.url();
+        } catch (DataIntegrityViolationException e) {
+            throw new ApiException(ErrorCode.IMAGE_NAME_DUPLICATED);
         }
-        validateExtension(request.extension());
 
-        String fileName = generateFileName(memberId);
-        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(r ->
-            r.signatureDuration(Duration.ofSeconds(s3Properties.presignedExpires()))
-                .putObjectRequest(createPutObjectRequest(contentLength, fileName)));
-
-        return presignedRequest.url();
     }
 
     private String generateFileName(Long memberId) {
         String randomId = randomGenerator.generateWithSeed(String.valueOf(memberId), RANDOM_SIZE_ABOUT_ID);
         String uuid = randomGenerator.generate();
-        return randomId + DELIMITER + uuid;
+        String fileName = randomId + DELIMITER + uuid;
+        imageRepository.save(Image.create(fileName));
+        return fileName;
     }
 
     private void validateExtension(String extValue) {

--- a/src/main/java/com/example/temp/image/application/ImageService.java
+++ b/src/main/java/com/example/temp/image/application/ImageService.java
@@ -1,11 +1,11 @@
 package com.example.temp.image.application;
 
-import com.example.temp.common.dto.UserContext;
 import java.net.URL;
 import java.time.Duration;
+import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest.Builder;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
@@ -15,16 +15,15 @@ public class ImageService {
 
     private final S3Presigner s3Presigner;
 
-    public URL createPresignedUrl(UserContext userContext) {
-        PutObjectRequest objectRequest = PutObjectRequest.builder()
-            .bucket("test240209")
-            .key("test")
-            .build();
-
+    public URL createPresignedUrl() {
         PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(r ->
             r.signatureDuration(Duration.ofSeconds(300))
-                .putObjectRequest(objectRequest));
+                .putObjectRequest(createPutObjectRequest()));
 
         return presignedRequest.url();
+    }
+
+    private static Consumer<Builder> createPutObjectRequest() {
+        return objectRequest -> objectRequest.bucket("test240209").key("test");
     }
 }

--- a/src/main/java/com/example/temp/image/domain/Image.java
+++ b/src/main/java/com/example/temp/image/domain/Image.java
@@ -25,14 +25,26 @@ public class Image {
     @Column(unique = true, nullable = false)
     private String fileName;
 
+    /**
+     * 다른 엔티티(Post)에서 해당 이미지를 사용할 때 true 값을 갖습니다.
+     */
+    private boolean used;
+
     @Builder
-    private Image(String fileName) {
+    private Image(String fileName, boolean used) {
         this.fileName = fileName;
+        this.used = used;
     }
 
+    /**
+     * 초기 상태 이미지를 생성합니다.
+     *
+     * @param fileName
+     */
     public static Image create(String fileName) {
         return Image.builder()
             .fileName(fileName)
+            .used(false)
             .build();
     }
 }

--- a/src/main/java/com/example/temp/image/domain/Image.java
+++ b/src/main/java/com/example/temp/image/domain/Image.java
@@ -1,0 +1,38 @@
+package com.example.temp.image.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "images")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String fileName;
+
+    @Builder
+    private Image(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public static Image create(String fileName) {
+        return Image.builder()
+            .fileName(fileName)
+            .build();
+    }
+}

--- a/src/main/java/com/example/temp/image/domain/ImageRepository.java
+++ b/src/main/java/com/example/temp/image/domain/ImageRepository.java
@@ -1,0 +1,11 @@
+package com.example.temp.image.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    boolean existsByFileName(String fileName);
+
+}

--- a/src/main/java/com/example/temp/image/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/com/example/temp/image/dto/request/PresignedUrlRequest.java
@@ -1,0 +1,8 @@
+package com.example.temp.image.dto.request;
+
+public record PresignedUrlRequest(
+    long contentLength,
+    String extension
+) {
+
+}

--- a/src/main/java/com/example/temp/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/example/temp/image/dto/response/PresignedUrlResponse.java
@@ -1,5 +1,22 @@
 package com.example.temp.image.dto.response;
 
+import java.net.URL;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
 public class PresignedUrlResponse {
 
+    private final String presignedUrl;
+
+    @Builder
+    private PresignedUrlResponse(String presignedUrl) {
+        this.presignedUrl = presignedUrl;
+    }
+
+    public static PresignedUrlResponse create(URL presignedUrl) {
+        return PresignedUrlResponse.builder()
+            .presignedUrl(presignedUrl.toString())
+            .build();
+    }
 }

--- a/src/main/java/com/example/temp/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/example/temp/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,5 @@
+package com.example.temp.image.dto.response;
+
+public class PresignedUrlResponse {
+
+}

--- a/src/main/java/com/example/temp/image/presentation/ImageController.java
+++ b/src/main/java/com/example/temp/image/presentation/ImageController.java
@@ -1,11 +1,13 @@
 package com.example.temp.image.presentation;
 
 import com.example.temp.image.application.ImageService;
+import com.example.temp.image.dto.request.PresignedUrlRequest;
 import com.example.temp.image.dto.response.PresignedUrlResponse;
 import java.net.URL;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,8 +19,8 @@ public class ImageController {
     private final ImageService imageService;
 
     @PostMapping("/presigned_url")
-    public ResponseEntity<PresignedUrlResponse> providePresignedUrl() {
-        URL presignedUrl = imageService.createPresignedUrl();
+    public ResponseEntity<PresignedUrlResponse> providePresignedUrl(@RequestBody PresignedUrlRequest request) {
+        URL presignedUrl = imageService.createPresignedUrl(request);
         return ResponseEntity.ok(PresignedUrlResponse.create(presignedUrl));
     }
 }

--- a/src/main/java/com/example/temp/image/presentation/ImageController.java
+++ b/src/main/java/com/example/temp/image/presentation/ImageController.java
@@ -1,5 +1,7 @@
 package com.example.temp.image.presentation;
 
+import com.example.temp.common.annotation.Login;
+import com.example.temp.common.dto.UserContext;
 import com.example.temp.image.application.ImageService;
 import com.example.temp.image.dto.request.PresignedUrlRequest;
 import com.example.temp.image.dto.response.PresignedUrlResponse;
@@ -19,8 +21,9 @@ public class ImageController {
     private final ImageService imageService;
 
     @PostMapping("/presigned_url")
-    public ResponseEntity<PresignedUrlResponse> providePresignedUrl(@RequestBody PresignedUrlRequest request) {
-        URL presignedUrl = imageService.createPresignedUrl(request);
+    public ResponseEntity<PresignedUrlResponse> providePresignedUrl(@Login UserContext userContext,
+        @RequestBody PresignedUrlRequest request) {
+        URL presignedUrl = imageService.createPresignedUrl(userContext, request);
         return ResponseEntity.ok(PresignedUrlResponse.create(presignedUrl));
     }
 }

--- a/src/main/java/com/example/temp/image/presentation/ImageController.java
+++ b/src/main/java/com/example/temp/image/presentation/ImageController.java
@@ -4,6 +4,7 @@ import com.example.temp.common.annotation.Login;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.image.application.ImageService;
 import com.example.temp.image.dto.response.PresignedUrlResponse;
+import java.net.URL;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,7 +20,7 @@ public class ImageController {
 
     @PostMapping("/presigned_url")
     public ResponseEntity<PresignedUrlResponse> providePresignedUrl(@Login UserContext userContext) {
-        PresignedUrlResponse presignedUrlResponse = imageService.createPresignedUrl(userContext);
-        return ResponseEntity.ok(presignedUrlResponse);
+        URL presignedUrl = imageService.createPresignedUrl(userContext);
+        return ResponseEntity.ok(PresignedUrlResponse.create(presignedUrl));
     }
 }

--- a/src/main/java/com/example/temp/image/presentation/ImageController.java
+++ b/src/main/java/com/example/temp/image/presentation/ImageController.java
@@ -1,0 +1,25 @@
+package com.example.temp.image.presentation;
+
+import com.example.temp.common.annotation.Login;
+import com.example.temp.common.dto.UserContext;
+import com.example.temp.image.application.ImageService;
+import com.example.temp.image.dto.response.PresignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping("/presigned_url")
+    public ResponseEntity<PresignedUrlResponse> providePresignedUrl(@Login UserContext userContext) {
+        PresignedUrlResponse presignedUrlResponse = imageService.createPresignedUrl(userContext);
+        return ResponseEntity.ok(presignedUrlResponse);
+    }
+}

--- a/src/main/java/com/example/temp/image/presentation/ImageController.java
+++ b/src/main/java/com/example/temp/image/presentation/ImageController.java
@@ -1,7 +1,5 @@
 package com.example.temp.image.presentation;
 
-import com.example.temp.common.annotation.Login;
-import com.example.temp.common.dto.UserContext;
 import com.example.temp.image.application.ImageService;
 import com.example.temp.image.dto.response.PresignedUrlResponse;
 import java.net.URL;
@@ -19,8 +17,8 @@ public class ImageController {
     private final ImageService imageService;
 
     @PostMapping("/presigned_url")
-    public ResponseEntity<PresignedUrlResponse> providePresignedUrl(@Login UserContext userContext) {
-        URL presignedUrl = imageService.createPresignedUrl(userContext);
+    public ResponseEntity<PresignedUrlResponse> providePresignedUrl() {
+        URL presignedUrl = imageService.createPresignedUrl();
         return ResponseEntity.ok(PresignedUrlResponse.create(presignedUrl));
     }
 }

--- a/src/main/java/com/example/temp/member/domain/nickname/RandomNicknameGenerator.java
+++ b/src/main/java/com/example/temp/member/domain/nickname/RandomNicknameGenerator.java
@@ -1,37 +1,21 @@
 package com.example.temp.member.domain.nickname;
 
-import static com.example.temp.member.domain.nickname.Nickname.NICKNAME_MAX_LENGTH;
-
-import java.util.Random;
+import com.example.temp.common.utils.random.RandomGenerator;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 /**
- * 알파벳 대소문자와 숫자를 포함하여 NICKNAME_MAX_LENGTH 길이만큼의 랜덤한 문자열을 생성하는 객체입니다.
+ * NICKNAME_MAX_LENGTH 길이만큼의 랜덤한 문자열을 생성하는 객체입니다.
  */
 @Component
-@SuppressWarnings("java:S2245")
+@RequiredArgsConstructor
 public class RandomNicknameGenerator implements NicknameGenerator {
 
-    private static final char[] ALPHABETS_AND_NUM = createAlphabetsAndNums();
-
-    private static char[] createAlphabetsAndNums() {
-        String alphabetAndNumStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
-        return alphabetAndNumStr.toCharArray();
-    }
-
-
-    private final Random random = new Random();
+    private final RandomGenerator randomGenerator;
 
     @Override
     public Nickname generate() {
-        StringBuilder sb = new StringBuilder(NICKNAME_MAX_LENGTH);
-        for (int i = 0; i < NICKNAME_MAX_LENGTH; i++) {
-            sb.append(getRandomCharacter());
-        }
-        return Nickname.create(sb.toString());
-    }
-
-    private char getRandomCharacter() {
-        return ALPHABETS_AND_NUM[random.nextInt(ALPHABETS_AND_NUM.length)];
+        String randomValue = randomGenerator.generate(Nickname.NICKNAME_MAX_LENGTH);
+        return Nickname.create(randomValue);
     }
 }

--- a/src/main/java/com/example/temp/oauth/domain/OAuthInfoRepository.java
+++ b/src/main/java/com/example/temp/oauth/domain/OAuthInfoRepository.java
@@ -3,7 +3,9 @@ package com.example.temp.oauth.domain;
 import com.example.temp.oauth.OAuthProviderType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface OAuthInfoRepository extends JpaRepository<OAuthInfo, Long> {
 
     Optional<OAuthInfo> findByIdUsingResourceServerAndType(String idUsingResourceServer, OAuthProviderType type);

--- a/src/test/java/com/example/temp/common/entity/ExtensionTest.java
+++ b/src/test/java/com/example/temp/common/entity/ExtensionTest.java
@@ -1,0 +1,23 @@
+package com.example.temp.common.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ExtensionTest {
+
+    @ParameterizedTest
+    @DisplayName("확장자의 타입이 이미지인지 검사한다.")
+    @ValueSource(strings = {"JPEG", "JPG", "PNG"})
+    void checkImageType(String typeValue) throws Exception {
+        // given
+
+        // when
+        Extension extension = Extension.valueOf(typeValue);
+
+        // then
+        Assertions.assertThat(extension.isImageType()).isTrue();
+    }
+
+}

--- a/src/test/java/com/example/temp/common/entity/ExtensionTest.java
+++ b/src/test/java/com/example/temp/common/entity/ExtensionTest.java
@@ -11,13 +11,20 @@ class ExtensionTest {
     @DisplayName("확장자의 타입이 이미지인지 검사한다.")
     @ValueSource(strings = {"JPEG", "JPG", "PNG"})
     void checkImageType(String typeValue) throws Exception {
-        // given
-
         // when
         Extension extension = Extension.valueOf(typeValue);
 
         // then
         Assertions.assertThat(extension.isImageType()).isTrue();
+    }
+
+    @DisplayName("확장자의 타입이 이미지가 아닌지 검사한다.")
+    void checkNotImageType() throws Exception {
+        // when
+        Extension extension = Extension.valueOf("TXT");
+
+        // then
+        Assertions.assertThat(extension.isImageType()).isFalse();
     }
 
 }

--- a/src/test/java/com/example/temp/common/utils/random/DefaultRandomGeneratorTest.java
+++ b/src/test/java/com/example/temp/common/utils/random/DefaultRandomGeneratorTest.java
@@ -1,0 +1,61 @@
+package com.example.temp.common.utils.random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DefaultRandomGeneratorTest {
+
+    DefaultRandomGenerator randomGenerator;
+
+    @BeforeEach
+    void setUp() {
+        randomGenerator = new DefaultRandomGenerator();
+    }
+
+    @Test
+    @DisplayName("랜덤한 닉네임을 생성한다")
+    void generate() throws Exception {
+        Set<String> values = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            String value = randomGenerator.generate();
+            assertThat(value).isNotNull();
+            values.add(value);
+        }
+        assertThat(values.size()).isBetween(2, 1000);
+    }
+
+    @Test
+    @DisplayName("랜덤한 닉네임을 사이즈와 함께 생성한다")
+    void generateWithSize() throws Exception {
+        int size = 5;
+
+        Set<String> values = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            String value = randomGenerator.generate(size);
+            assertThat(value).hasSize(size);
+            values.add(value);
+        }
+        assertThat(values.size()).isBetween(2, 1000);
+    }
+
+    @Test
+    @DisplayName("시드를 지정하면 만들어지는 문자열은 항상 동일하다.")
+    void generateWithSeed() throws Exception {
+        String seed = "1";
+        int size = 5;
+
+        Set<String> values = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            String value = randomGenerator.generateWithSeed(seed, size);
+            assertThat(value).hasSize(size);
+            values.add(value);
+        }
+        assertThat(values).hasSize(1);
+    }
+
+}

--- a/src/test/java/com/example/temp/image/application/ImageServiceTest.java
+++ b/src/test/java/com/example/temp/image/application/ImageServiceTest.java
@@ -1,25 +1,62 @@
 package com.example.temp.image.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.common.properties.S3Properties;
 import com.example.temp.image.dto.request.PresignedUrlRequest;
+import java.net.MalformedURLException;
 import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @SpringBootTest
 class ImageServiceTest {
 
-    @Autowired
     ImageService imageService;
+
+    S3Presigner s3Presigner;
 
     @Autowired
     S3Properties s3Properties;
+
+    @BeforeEach
+    void setUp() {
+        s3Presigner = S3Presigner.builder()
+            .region(Region.of(s3Properties.region()))
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("accessKey", "secretKey")))
+            .build();
+        imageService = new ImageService(s3Presigner, s3Properties);
+    }
+
+    @Test
+    @DisplayName("presigned url을 생성한다")
+    void createPresignedUrl() throws MalformedURLException {
+        long contentLength = s3Properties.imgMaxContentLength();
+        String extValue = "JPEG";
+        PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
+
+        // when
+        URL presignedUrl = imageService.createPresignedUrl(request);
+
+        // then
+        validateUrl(presignedUrl);
+    }
+
+    private void validateUrl(URL presignedUrl) {
+        assertThat(presignedUrl.getHost()).endsWith(".amazonaws.com");
+        String bucketName = presignedUrl.getHost().split("\\.")[0];
+        assertThat(bucketName).isEqualTo(s3Properties.bucket());
+    }
 
     @Test
     @DisplayName("서버에서 지정한 사이즈보다 큰 이미지에 대해서는 presigned url을 생성하지 않는다")

--- a/src/test/java/com/example/temp/image/application/ImageServiceTest.java
+++ b/src/test/java/com/example/temp/image/application/ImageServiceTest.java
@@ -8,6 +8,7 @@ import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.common.properties.S3Properties;
 import com.example.temp.common.utils.random.RandomGenerator;
+import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.image.dto.request.PresignedUrlRequest;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -34,13 +35,16 @@ class ImageServiceTest {
     @Autowired
     RandomGenerator randomGenerator;
 
+    @Autowired
+    ImageRepository imageRepository;
+
     @BeforeEach
     void setUp() {
         s3Presigner = S3Presigner.builder()
             .region(Region.of(s3Properties.region()))
             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("accessKey", "secretKey")))
             .build();
-        imageService = new ImageService(s3Presigner, s3Properties, randomGenerator);
+        imageService = new ImageService(s3Presigner, s3Properties, randomGenerator, imageRepository);
     }
 
     @Test
@@ -56,6 +60,8 @@ class ImageServiceTest {
 
         // then
         validateUrl(presignedUrl);
+        String path = presignedUrl.getPath().substring(1);
+        assertThat(imageRepository.existsByFileName(path)).isTrue();
     }
 
     /**

--- a/src/test/java/com/example/temp/image/application/ImageServiceTest.java
+++ b/src/test/java/com/example/temp/image/application/ImageServiceTest.java
@@ -3,9 +3,11 @@ package com.example.temp.image.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.common.properties.S3Properties;
+import com.example.temp.common.utils.random.RandomGenerator;
 import com.example.temp.image.dto.request.PresignedUrlRequest;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -29,45 +31,58 @@ class ImageServiceTest {
     @Autowired
     S3Properties s3Properties;
 
+    @Autowired
+    RandomGenerator randomGenerator;
+
     @BeforeEach
     void setUp() {
         s3Presigner = S3Presigner.builder()
             .region(Region.of(s3Properties.region()))
             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("accessKey", "secretKey")))
             .build();
-        imageService = new ImageService(s3Presigner, s3Properties);
+        imageService = new ImageService(s3Presigner, s3Properties, randomGenerator);
     }
 
     @Test
     @DisplayName("presigned url을 생성한다")
     void createPresignedUrl() throws MalformedURLException {
+        UserContext userContext = new UserContext(1L);
         long contentLength = s3Properties.imgMaxContentLength();
         String extValue = "JPEG";
         PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
 
         // when
-        URL presignedUrl = imageService.createPresignedUrl(request);
+        URL presignedUrl = imageService.createPresignedUrl(userContext, request);
 
         // then
         validateUrl(presignedUrl);
     }
 
+    /**
+     * host가 .amazonaws.com이어야 하고, 버킷명이 지정한 값으로 나와야 합니다. 또한, path는 [id.uuid] 형태로 이뤄졌는지 검사합니다.
+     */
     private void validateUrl(URL presignedUrl) {
         assertThat(presignedUrl.getHost()).endsWith(".amazonaws.com");
         String bucketName = presignedUrl.getHost().split("\\.")[0];
         assertThat(bucketName).isEqualTo(s3Properties.bucket());
+
+        String fileName = presignedUrl.getPath();
+        String[] idAndUuid = fileName.split("\\.");
+        assertThat(idAndUuid).hasSize(2)
+            .doesNotContainNull();
     }
 
     @Test
     @DisplayName("서버에서 지정한 사이즈보다 큰 이미지에 대해서는 presigned url을 생성하지 않는다")
     void createFailImageTooBig() throws Exception {
         // given
+        UserContext userContext = new UserContext(1L);
         long contentLength = s3Properties.imgMaxContentLength() + 1;
         String extValue = "JPEG";
         PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
 
         // when & then
-        assertThatThrownBy(() -> imageService.createPresignedUrl(request))
+        assertThatThrownBy(() -> imageService.createPresignedUrl(userContext, request))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.IMAGE_TOO_BIG.getMessage());
     }
@@ -76,12 +91,13 @@ class ImageServiceTest {
     @DisplayName("이미지가 아닌 확장자에 대해서는 presigned url을 생성하지 않는다.")
     void createFailInvalidExt() throws Exception {
         // given
+        UserContext userContext = new UserContext(1L);
         long contentLength = s3Properties.imgMaxContentLength();
         String extValue = "TXT";
         PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
 
         // when & then
-        assertThatThrownBy(() -> imageService.createPresignedUrl(request))
+        assertThatThrownBy(() -> imageService.createPresignedUrl(userContext, request))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.EXTENSION_NOT_SUPPORTED.getMessage());
     }
@@ -90,12 +106,13 @@ class ImageServiceTest {
     @DisplayName("존재하지 않는 확장자에 대해서는 presigned url을 생성하지 않는다.")
     void createFailNotExistsExt() throws Exception {
         // given
+        UserContext userContext = new UserContext(1L);
         long contentLength = s3Properties.imgMaxContentLength();
         String extValue = "NOT_FOUND";
         PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
 
         // when & then
-        assertThatThrownBy(() -> imageService.createPresignedUrl(request))
+        assertThatThrownBy(() -> imageService.createPresignedUrl(userContext, request))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.EXTENSION_NOT_SUPPORTED.getMessage());
     }

--- a/src/test/java/com/example/temp/image/application/ImageServiceTest.java
+++ b/src/test/java/com/example/temp/image/application/ImageServiceTest.java
@@ -1,0 +1,66 @@
+package com.example.temp.image.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.temp.common.exception.ApiException;
+import com.example.temp.common.exception.ErrorCode;
+import com.example.temp.common.properties.S3Properties;
+import com.example.temp.image.dto.request.PresignedUrlRequest;
+import java.net.URL;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ImageServiceTest {
+
+    @Autowired
+    ImageService imageService;
+
+    @Autowired
+    S3Properties s3Properties;
+
+    @Test
+    @DisplayName("서버에서 지정한 사이즈보다 큰 이미지에 대해서는 presigned url을 생성하지 않는다")
+    void createFailImageTooBig() throws Exception {
+        // given
+        long contentLength = s3Properties.imgMaxContentLength() + 1;
+        String extValue = "JPEG";
+        PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
+
+        // when & then
+        assertThatThrownBy(() -> imageService.createPresignedUrl(request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.IMAGE_TOO_BIG.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미지가 아닌 확장자에 대해서는 presigned url을 생성하지 않는다.")
+    void createFailInvalidExt() throws Exception {
+        // given
+        long contentLength = s3Properties.imgMaxContentLength();
+        String extValue = "TXT";
+        PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
+
+        // when & then
+        assertThatThrownBy(() -> imageService.createPresignedUrl(request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.EXTENSION_NOT_SUPPORTED.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 확장자에 대해서는 presigned url을 생성하지 않는다.")
+    void createFailNotExistsExt() throws Exception {
+        // given
+        long contentLength = s3Properties.imgMaxContentLength();
+        String extValue = "NOT_FOUND";
+        PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
+
+        // when & then
+        assertThatThrownBy(() -> imageService.createPresignedUrl(request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.EXTENSION_NOT_SUPPORTED.getMessage());
+    }
+
+}

--- a/src/test/java/com/example/temp/image/domain/ImageTest.java
+++ b/src/test/java/com/example/temp/image/domain/ImageTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 class ImageTest {
 
     @Test
-    @DisplayName("이미지를 생성한다.")
+    @DisplayName("presigned 요청 시 서버에 이미지를 생성한다.")
     void create() throws Exception {
         // given
         String fileName = "randomFileName";
@@ -18,6 +18,7 @@ class ImageTest {
 
         // then
         assertThat(image.getFileName()).isEqualTo(fileName);
+        assertThat(image.isUsed()).isFalse();
     }
 
 }

--- a/src/test/java/com/example/temp/image/domain/ImageTest.java
+++ b/src/test/java/com/example/temp/image/domain/ImageTest.java
@@ -1,0 +1,23 @@
+package com.example.temp.image.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ImageTest {
+
+    @Test
+    @DisplayName("이미지를 생성한다.")
+    void create() throws Exception {
+        // given
+        String fileName = "randomFileName";
+
+        // when
+        Image image = Image.create(fileName);
+
+        // then
+        assertThat(image.getFileName()).isEqualTo(fileName);
+    }
+
+}

--- a/src/test/java/com/example/temp/image/dto/response/PresignedUrlResponseTest.java
+++ b/src/test/java/com/example/temp/image/dto/response/PresignedUrlResponseTest.java
@@ -2,6 +2,7 @@ package com.example.temp.image.dto.response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URL;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -11,15 +12,13 @@ class PresignedUrlResponseTest {
     @DisplayName("응답을 생성한다.")
     void create() throws Exception {
         // given
-        String presignedUrl = "http://test.com";
+        URL presignedUrl = new URL("http://test.com");
 
         // when
-        PresignedUrlResponse result = PresignedUrlResponse.builder()
-            .presignedUrl(presignedUrl)
-            .build();
+        PresignedUrlResponse result = PresignedUrlResponse.create(presignedUrl);
 
         // then
-        assertThat(result.getPresignedUrl()).isEqualTo(presignedUrl);
+        assertThat(result.getPresignedUrl()).isEqualTo(presignedUrl.toString());
     }
 
 }

--- a/src/test/java/com/example/temp/image/dto/response/PresignedUrlResponseTest.java
+++ b/src/test/java/com/example/temp/image/dto/response/PresignedUrlResponseTest.java
@@ -1,0 +1,25 @@
+package com.example.temp.image.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PresignedUrlResponseTest {
+
+    @Test
+    @DisplayName("응답을 생성한다.")
+    void create() throws Exception {
+        // given
+        String presignedUrl = "http://test.com";
+
+        // when
+        PresignedUrlResponse result = PresignedUrlResponse.builder()
+            .presignedUrl(presignedUrl)
+            .build();
+
+        // then
+        assertThat(result.getPresignedUrl()).isEqualTo(presignedUrl);
+    }
+
+}

--- a/src/test/java/com/example/temp/member/domain/nickname/RandomNicknameGeneratorTest.java
+++ b/src/test/java/com/example/temp/member/domain/nickname/RandomNicknameGeneratorTest.java
@@ -2,6 +2,8 @@ package com.example.temp.member.domain.nickname;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.common.utils.random.DefaultRandomGenerator;
+import com.example.temp.common.utils.random.RandomGenerator;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,9 +14,12 @@ class RandomNicknameGeneratorTest {
 
     RandomNicknameGenerator nicknameGenerator;
 
+    RandomGenerator randomGenerator;
+
     @BeforeEach
     void setUp() {
-        nicknameGenerator = new RandomNicknameGenerator();
+        randomGenerator = new DefaultRandomGenerator();
+        nicknameGenerator = new RandomNicknameGenerator(randomGenerator);
     }
 
     @Test
@@ -24,6 +29,7 @@ class RandomNicknameGeneratorTest {
         for (int i = 0; i < 1000; i++) {
             Nickname nickname = nicknameGenerator.generate();
             assertThat(nickname).isNotNull();
+            assertThat(nickname.getValue()).hasSize(Nickname.NICKNAME_MAX_LENGTH);
             nicknames.add(nickname);
         }
         assertThat(nicknames.size()).isBetween(2, 1000);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,3 +16,10 @@ refresh-cookie:
   secure: false
   max-age: 1000000
   same-site: None
+
+s3:
+  endpoint: http://localhost:4566
+  region: us-east-1
+  bucket: test
+  presigned-expires: 60
+  img-max-content-length: 10000


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] LocalStack 설치
- [x] Local 환경에서 PresignedUrl 잘 동작하는지 테스트
- [x] S3, IAM 학습
- [x] 랜덤한 파일명 생성

## 🏌🏻 리뷰 포인트

### 악의적인 사용자가 presigned url을 사용해서 큰 용량(1GB)의 파일을 올려버리면 어떡하지?
S3에 데이터를 올릴 때, 크기 제한을 두는 기능은 제공되지 않습니다.(이 때 진짜 당황했습니다..)
따라서 Presigned Url이 있으면 아무리 큰 파일도 그냥 올려버릴 수 있게 되는데, 
이렇게 되면 저희 서비스는 저장공간 문제, 비용 문제를 경험하게 될 거에요.

어떻게 해결하지 고민하다가 Presigned URL은 Header가 일치하는지 검사하는 기능이 있더라구요.
그래서 클라이언트에게 이미지의 Content-Length를 입력받도록 구현했습니다.
```
POST /images/presigned_url

{
    "contentLength":1000,
    "extension": "JPEG | JPG | PNG"
}
```
서버는 contentLength의 크기가 너무 크면 요청을 거절합니다.

요청에 성공하면 Content-Length 헤더가 입력한 값과 일치하는 파일만 등록할 수 있는 Presigned URL이 만들어집니다.
이렇게 클라이언트가 S3에 파일을 올릴 때, 제약 조건을 하나 만드는 방식으로 문제를 해결했습니다.

### S3 버킷에서 오브젝트 이름은 중복되어서는 안되는데 이걸 어떻게 처리하지?
-> 이건 문제없겠네요. 생각을 잘못 했습니다.
<details>
<summary>생각 잘못한 부분(무시하시면 됩니다)</summary>

S3 버킷에 1번 사용자가 올린 A라는 파일이 있었다고 가정하겠습니다.
이 때, 2번 사용자도 A라는 동일한 이름의 파일을 올린다면, 기존 A의 파일이 삭제됩니다.

즉, `절대로 S3에 저장되어 있는 파일과 동일한 이름을 만들어서는 안된다` 는 비즈니스 요구사항이 추가되었습니다.

가장 쉬운 건 S3에게 해당되는 이름이 존재하는지 물어보는 거지만, 네트워크를 너무 많이 타기 때문에 이 방법은 좋지 않습니다.
두 번째 방법은 DB에 이미지들의 이름을 저장해두는 겁니다. 이렇게 하면 S3에게 물어보지 않고도 중복 검사를 할 수 있게 됩니다.

하지만,,, `동시성`에 관련한 문제가 남아있습니다.
만약 우연의 일치로 A와 B가 동시에 요청을 보내고, 동일한 파일명 "hello" 를 발급받으면 어떻게 될까요?
이렇게 되면 A와 B 중 먼저 파일을 올리는 사람은 파일이 지워지는 문제를 겪게 됩니다.
그뿐이면 차라리 다행인데, A가 올린 게시물에는 B가 올린 이미지가 보여지는 심각한 문제를 경험하게 됩니다.(이미지 주소가 같으니까요)

이 문제를 해결하기 위해 저는 파일명에 사용자의 식별자를 포함시켰습니다.
`A는 A.hello에 파일을 저장, B는 B.hello에 파일을 저장`

실제로 발급되는 Presigned URL을 살펴보며 설명을 마무리하겠습니다.
**http://localhost:4566/버킷명/M2xEgD8ZLJ.7LNszwnORAtzrs6DKtNX?...**

`M2xEgD8ZLJ.7LNszwnORAtzrs6DKtNX` 이 부분이 파일 이름이 되는데요. 
사이에 `.` 을 기준으로 앞에는 사용자 ID를 난수화한 것, 뒤에는 랜덤으로 발급한 파일명입니다.

</details>


## 🧘🏻 기타 사항
로컬 환경에서 AWS의 S3 환경을 에뮬레이팅해야 합니다.
그걸 위해 LocalStack을 사용하는데 해당 세팅은 문서를 만들어서 공유하겠습니다.
(템플릿을 만들어두기는 했는데 프론트 개발자들에게도 공유를 해야 하니 조금 정제를 하겠습니다)

close #56 