### PR TITLE
[#62] 테스트 커버리지 분석 대상에서 common/config, **/presentation 경로 제거하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,12 +66,12 @@ tasks.named('test') {
 }
 
 jacocoTestReport {
-//    afterEvaluate {
-//        classDirectories = files(classDirectories.files.collect {
-//            fileTree(dir: it,
-//                    exclude: ['**/common/config', "**/presentation/**"])
-//        })
-//    }
+    afterEvaluate {
+        classDirectories = files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: ['**/common/config', "**/presentation/**"])
+        })
+    }
     reports {
         xml.required.set(true)
         html.required.set(true)


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 테스트 커버리지 분석 대상에서 common/config, **/presentation 경로 제거하기

[앞선 커밋](https://github.com/GymHubCommunity/GymHub-BE/commit/d9446341f83cfdfb6b21b87726c434e55718f471)에서 임시로 비활성화했던 설정을 다시 활성화했습니다.

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
없습니다.

close #62 