### PR TITLE
[#66] 누락된 작업 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Custom
 /src/main/resources/application.yml
+.DS_Store
 
 HELP.md
 .gradle

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -45,7 +45,7 @@ public class MemberService {
     public Member saveInitStatusMember(OAuthResponse oAuthResponse) {
         try {
             Nickname nickname = nicknameGenerator.generate();
-            if (memberRepository.existsByNickname(nickname)) {
+            if (memberRepository.existsByNickname(nickname.getValue())) {
                 throw new NicknameDuplicatedException();
             }
             Member member = oAuthResponse.toInitStatusMemberWith(nickname);
@@ -70,7 +70,7 @@ public class MemberService {
         Member member = memberRepository.findMemberIncludingUnregisteredById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
         Nickname nickname = Nickname.create(request.nickname());
-        if (memberRepository.existsByNickname(nickname)) {
+        if (memberRepository.existsByNickname(nickname.getValue())) {
             throw new ApiException(ErrorCode.NICKNAME_DUPLICATED);
         }
         member.init(nickname, request.profileUrl());

--- a/src/main/java/com/example/temp/member/domain/MemberRepository.java
+++ b/src/main/java/com/example/temp/member/domain/MemberRepository.java
@@ -1,6 +1,5 @@
 package com.example.temp.member.domain;
 
-import com.example.temp.member.domain.nickname.Nickname;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,9 +18,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findById(@Param(value = "memberId") long memberId);
 
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m"
-        + " WHERE m.nickname = :nickname"
+        + " WHERE m.nickname.value = :nickname"
         + " AND m.deleted = false")
-    boolean existsByNickname(@Param(value = "nickname") Nickname nickname);
+    boolean existsByNickname(@Param(value = "nickname") String nickname);
 
     @Query("SELECT m FROM Member m WHERE m.id = :memberId AND m.deleted = false")
     Optional<Member> findMemberIncludingUnregisteredById(@Param(value = "memberId") long memberId);

--- a/src/main/java/com/example/temp/member/domain/MemberRepository.java
+++ b/src/main/java/com/example/temp/member/domain/MemberRepository.java
@@ -21,7 +21,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m"
         + " WHERE m.nickname = :nickname"
         + " AND m.deleted = false")
-    boolean existsByNickname(Nickname nickname);
+    boolean existsByNickname(@Param(value = "nickname") Nickname nickname);
 
     @Query("SELECT m FROM Member m WHERE m.id = :memberId AND m.deleted = false")
     Optional<Member> findMemberIncludingUnregisteredById(@Param(value = "memberId") long memberId);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,3 @@
-INSERT INTO members(member_id, registered, nickname, email, profile_url, privacy_policy, follow_strategy)
-VALUES (1, true, '김태훈', 'first@test.com', 'https://avatars.githubusercontent.com/u/67636607?s=80&u=66f65ed6f693c3235b3ba0a4a1ed93b7eeae50cb&v=4', 'PUBLIC', 'EAGER'),
-       (2, true, '이정우', 'another@test.org', 'https://avatars.githubusercontent.com/u/49686619?v=4', 'PUBLIC', 'EAGER');
+INSERT INTO members(member_id, registered, deleted, nickname, email, profile_url, privacy_policy, follow_strategy)
+VALUES (1, true, false, '김태훈', 'first@test.com', 'https://avatars.githubusercontent.com/u/67636607?s=80&u=66f65ed6f693c3235b3ba0a4a1ed93b7eeae50cb&v=4', 'PUBLIC', 'EAGER'),
+       (2, true, false, '이정우', 'another@test.org', 'https://avatars.githubusercontent.com/u/49686619?v=4', 'PUBLIC', 'EAGER');

--- a/src/test/java/com/example/temp/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberRepositoryTest.java
@@ -25,7 +25,7 @@ class MemberRepositoryTest {
     @DisplayName("해당 닉네임이 DB에 존재하면 true를 반환한다.")
     void existsByNicknameSuccess() throws Exception {
         Nickname nickname = Nickname.create("firstNick");
-        assertThat(memberRepository.existsByNickname(nickname)).isFalse();
+        assertThat(memberRepository.existsByNickname(nickname.getValue())).isFalse();
     }
 
     @Test
@@ -37,7 +37,7 @@ class MemberRepositoryTest {
         em.persist(member);
 
         // when & then
-        assertThat(memberRepository.existsByNickname(nickname)).isTrue();
+        assertThat(memberRepository.existsByNickname(nickname.getValue())).isTrue();
 
     }
 


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] data.sql에서 members 테이블에 deleted 컬럼을 추가
- [x] JPQL @Param 빠진 부분 추가
- [x] JpaRepository 메서드에서 값타입 제거
- [x] lombok 라이브러리 jacoco 타겟에서 제거 
- [x] .DS_Store gitignore 처리


## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
**data.sql에서 members 테이블에 deleted 컬럼을 추가**
deleted 작업은 왜 빠졌을까요? 분명 지난번에 커밋했던 게 기억이 나는데,,,
확인을 해보지는 않았지만 rebase 과정에서 빠지지 않았을까 싶습니다.
이따 시간 여유될 때 확인해보겠습니닷


**JpaRepository 메서드에서 값타입 제거**
```java
    @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END FROM Member m"
        + " WHERE m.nickname.value = :nickname"
        + " AND m.deleted = false")
    boolean existsByNickname(@Param(value = "nickname") String nickname);
```
해당 메서드의 파라미터 타입을 Nickname에서 String으로 변경했는데요,
이유는 JPQL이 값타입을 파라미터로 받는 걸 지원하지 않기 때문입니다.
지금 Nickname은 컬럼이 한 개라서 어떻게든 동작을 했는데, 컬럼이 여러 개인 값타입은 메서드의 파라미터로 넣을 수 없다네요.
추후에 헷갈릴까봐 바꿔뒀습니다.


close #66