### PR TITLE
[#54] 게시글 작성

### DIFF
--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -38,7 +38,8 @@ public enum ErrorCode {
 
     // 이미지
     IMAGE_TOO_BIG(HttpStatus.BAD_REQUEST, "이미지의 크기가 너무 큽니다"),
-    IMAGE_NAME_DUPLICATED(HttpStatus.CONFLICT, "서버에서 생성한 이미지의 이름이 중복되었습니다. 다시 한 번 요청을 보내주세요.");
+    IMAGE_NAME_DUPLICATED(HttpStatus.CONFLICT, "서버에서 생성한 이미지의 이름이 중복되었습니다. 다시 한 번 요청을 보내주세요."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이미지를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/temp/image/domain/Image.java
+++ b/src/main/java/com/example/temp/image/domain/Image.java
@@ -23,7 +23,7 @@ public class Image {
     private Long id;
 
     @Column(unique = true, nullable = false)
-    private String fileName;
+    private String url;
 
     /**
      * 다른 엔티티(Post)에서 해당 이미지를 사용할 때 true 값을 갖습니다.
@@ -31,19 +31,19 @@ public class Image {
     private boolean used;
 
     @Builder
-    private Image(String fileName, boolean used) {
-        this.fileName = fileName;
+    private Image(String url, boolean used) {
+        this.url = url;
         this.used = used;
     }
 
     /**
      * 초기 상태 이미지를 생성합니다.
      *
-     * @param fileName
+     * @param url
      */
-    public static Image create(String fileName) {
+    public static Image create(String url) {
         return Image.builder()
-            .fileName(fileName)
+            .url(url)
             .used(false)
             .build();
     }

--- a/src/main/java/com/example/temp/image/domain/Image.java
+++ b/src/main/java/com/example/temp/image/domain/Image.java
@@ -47,4 +47,8 @@ public class Image {
             .used(false)
             .build();
     }
+
+    public void use() {
+        this.used = true;
+    }
 }

--- a/src/main/java/com/example/temp/image/domain/ImageRepository.java
+++ b/src/main/java/com/example/temp/image/domain/ImageRepository.java
@@ -8,4 +8,6 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     boolean existsByUrl(String url);
 
+    Image findByUrl(String url);
+
 }

--- a/src/main/java/com/example/temp/image/domain/ImageRepository.java
+++ b/src/main/java/com/example/temp/image/domain/ImageRepository.java
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
-    boolean existsByFileName(String fileName);
+    boolean existsByUrl(String url);
 
 }

--- a/src/main/java/com/example/temp/image/domain/ImageRepository.java
+++ b/src/main/java/com/example/temp/image/domain/ImageRepository.java
@@ -1,5 +1,6 @@
 package com.example.temp.image.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,6 +9,6 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     boolean existsByUrl(String url);
 
-    Image findByUrl(String url);
+    Optional<Image> findByUrl(String url);
 
 }

--- a/src/main/java/com/example/temp/image/domain/ImageRepository.java
+++ b/src/main/java/com/example/temp/image/domain/ImageRepository.java
@@ -1,6 +1,5 @@
 package com.example.temp.image.domain;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,6 +8,6 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     boolean existsByUrl(String url);
 
-    Optional<Image> findByUrl(String url);
+    Image findByUrl(String url);
 
 }

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -21,7 +21,6 @@ import com.example.temp.post.dto.response.PostCreateResponse;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -57,7 +56,7 @@ public class PostService {
     }
 
     private void createPostImages(List<String> imageUrl, Post post) {
-        List<String> url = Optional.ofNullable(imageUrl).orElse(Collections.emptyList());
+        List<String> url = imageUrl != null ? imageUrl : Collections.emptyList();
         url.stream()
             .map(this::getImageByUrl)
             .map(this::createPostImage)

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -19,6 +19,7 @@ import com.example.temp.post.dto.request.PostCreateRequest;
 import com.example.temp.post.dto.response.PagePostResponse;
 import com.example.temp.post.dto.response.PostCreateResponse;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -61,6 +62,10 @@ public class PostService {
     }
 
     private List<PostImage> createPostImages(PostCreateRequest postCreateRequest) {
+        if (isImageUrlEmpty(postCreateRequest)) {
+            return new ArrayList<>();
+        }
+
         return postCreateRequest.imageUrl().stream()
             .map(this::getImageByUrl)
             .map(image -> {
@@ -68,6 +73,10 @@ public class PostService {
                 return PostImage.createPostImage(image);
             })
             .toList();
+    }
+
+    private boolean isImageUrlEmpty(PostCreateRequest postCreateRequest) {
+        return postCreateRequest.imageUrl() == null || postCreateRequest.imageUrl().isEmpty();
     }
 
     private Image getImageByUrl(String imageUrl) {

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -37,7 +37,7 @@ public class PostService {
     private final ImageRepository imageRepository;
 
     @Transactional
-    public PostCreateResponse create(UserContext userContext, PostCreateRequest postCreateRequest,
+    public PostCreateResponse createPost(UserContext userContext, PostCreateRequest postCreateRequest,
         LocalDateTime registeredAt) {
         Member member = findMember(userContext);
         List<PostImage> postImages = createPostImages(postCreateRequest);

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -78,8 +78,10 @@ public class PostService {
     }
 
     private Image getImageByUrl(String imageUrl) {
-        return imageRepository.findByUrl(imageUrl)
-            .orElseThrow(() -> new ApiException(IMAGE_NOT_FOUND));
+        if (!imageRepository.existsByUrl(imageUrl)) {
+            throw new ApiException(IMAGE_NOT_FOUND);
+        }
+        return imageRepository.findByUrl(imageUrl);
     }
 
     private List<Member> findFollowingOf(Member member) {

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -1,7 +1,7 @@
 package com.example.temp.post.application;
 
+import static com.example.temp.common.exception.ErrorCode.AUTHENTICATED_FAIL;
 import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
-import static com.example.temp.common.exception.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ApiException;
@@ -56,7 +56,7 @@ public class PostService {
 
     private Member findMember(UserContext userContext) {
         return memberRepository.findById(userContext.id())
-            .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new ApiException(AUTHENTICATED_FAIL));
     }
 
     private void createPostImages(List<String> imageUrl, Post post) {

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -1,5 +1,6 @@
 package com.example.temp.post.application;
 
+import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
 import static com.example.temp.common.exception.ErrorCode.MEMBER_NOT_FOUND;
 
 import com.example.temp.common.dto.UserContext;
@@ -7,11 +8,17 @@ import com.example.temp.common.exception.ApiException;
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowRepository;
 import com.example.temp.follow.domain.FollowStatus;
+import com.example.temp.image.domain.Image;
+import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
 import com.example.temp.post.domain.Post;
+import com.example.temp.post.domain.PostImage;
 import com.example.temp.post.domain.PostRepository;
+import com.example.temp.post.dto.request.PostCreateRequest;
 import com.example.temp.post.dto.response.PagePostResponse;
+import com.example.temp.post.dto.response.PostCreateResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,13 +34,47 @@ public class PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public PostCreateResponse create(UserContext userContext, PostCreateRequest postCreateRequest,
+        LocalDateTime registeredAt) {
+        Member member = findMember(userContext);
+        List<PostImage> postImages = createPostImages(postCreateRequest);
+
+        Post post = postCreateRequest.toEntity(member, registeredAt, postImages);
+        Post savedPost = postRepository.save(post);
+
+        return PostCreateResponse.from(savedPost);
+    }
 
     public PagePostResponse findPostsFromFollowings(UserContext userContext, Pageable pageable) {
-        Member member = memberRepository.findById(userContext.id())
-            .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
+        Member member = findMember(userContext);
         List<Member> followings = findFollowingFrom(member);
         Page<Post> posts = postRepository.findByMemberInOrderByCreatedAtDesc(followings, pageable);
         return PagePostResponse.from(posts);
+    }
+
+    private Member findMember(UserContext userContext) {
+        return memberRepository.findById(userContext.id())
+            .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
+    }
+
+    private List<PostImage> createPostImages(PostCreateRequest postCreateRequest) {
+        return postCreateRequest.imageUrl().stream()
+            .map(this::getImageByUrl)
+            .map(image -> {
+                image.use();
+                return PostImage.createPostImage(image);
+            })
+            .toList();
+    }
+
+    private Image getImageByUrl(String imageUrl) {
+        if (!imageRepository.existsByUrl(imageUrl)) {
+            throw new ApiException(IMAGE_NOT_FOUND);
+        }
+        return imageRepository.findByUrl(imageUrl);
     }
 
     private List<Member> findFollowingFrom(Member member) {

--- a/src/main/java/com/example/temp/post/domain/Content.java
+++ b/src/main/java/com/example/temp/post/domain/Content.java
@@ -27,6 +27,12 @@ public class Content {
         this.value = value;
     }
 
+    public static Content create(String value) {
+        return Content.builder()
+            .value(value)
+            .build();
+    }
+
     private void validate(String value) {
         if (value.length() > MAX_CONTENT_LENGTH) {
             throw new ApiException(ErrorCode.CONTENT_TOO_LONG);

--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -47,10 +47,9 @@ public class Post extends BaseTimeEntity {
     private LocalDateTime registeredAt;
 
     @Builder
-    public Post(Member member, Content content, List<PostImage> postImages, LocalDateTime registeredAt) {
+    public Post(Member member, Content content, LocalDateTime registeredAt) {
         this.member = member;
         this.content = content;
-        this.postImages = postImages;
         this.registeredAt = registeredAt;
     }
 

--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,14 +35,17 @@ public class Post extends BaseTimeEntity {
 
     @Embedded
     private Content content;
-    
+
     private String imageUrl;
 
+    private LocalDateTime registeredAt;
+
     @Builder
-    private Post(Member member, Content content, String imageUrl) {
+    private Post(Member member, Content content, String imageUrl, LocalDateTime registeredAt) {
         this.member = member;
         this.content = content;
         this.imageUrl = imageUrl;
+        this.registeredAt = registeredAt;
     }
 
     public String getContent() {

--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -1,7 +1,9 @@
 package com.example.temp.post.domain;
 
 import com.example.temp.common.entity.BaseTimeEntity;
+import com.example.temp.image.domain.Image;
 import com.example.temp.member.domain.Member;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -11,8 +13,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,19 +41,28 @@ public class Post extends BaseTimeEntity {
     @Embedded
     private Content content;
 
-    private String imageUrl;
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostImage> postImages = new ArrayList<>();
 
     private LocalDateTime registeredAt;
 
     @Builder
-    private Post(Member member, Content content, String imageUrl, LocalDateTime registeredAt) {
+    public Post(Member member, Content content, List<PostImage> postImages, LocalDateTime registeredAt) {
         this.member = member;
         this.content = content;
-        this.imageUrl = imageUrl;
+        this.postImages = postImages;
         this.registeredAt = registeredAt;
     }
 
     public String getContent() {
         return content.getValue();
+    }
+
+    public String getImageUrl() {
+        return postImages.stream()
+            .findFirst()
+            .map(PostImage::getImage)
+            .map(Image::getUrl)
+            .orElse(null);
     }
 }

--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -42,6 +43,7 @@ public class Post extends BaseTimeEntity {
     private Content content;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
     private List<PostImage> postImages = new ArrayList<>();
 
     private LocalDateTime registeredAt;

--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -59,11 +60,11 @@ public class Post extends BaseTimeEntity {
         return content.getValue();
     }
 
-    public String getImageUrl() {
+    public Optional<String> getImageUrl() {
         return postImages.stream()
             .findFirst()
             .map(PostImage::getImage)
-            .map(Image::getUrl)
-            .orElse(null);
+            .map(Image::getUrl);
     }
+
 }

--- a/src/main/java/com/example/temp/post/domain/PostImage.java
+++ b/src/main/java/com/example/temp/post/domain/PostImage.java
@@ -2,7 +2,6 @@ package com.example.temp.post.domain;
 
 import com.example.temp.common.entity.BaseTimeEntity;
 import com.example.temp.image.domain.Image;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -46,5 +45,14 @@ public class PostImage extends BaseTimeEntity {
         return PostImage.builder()
             .image(image)
             .build();
+    }
+
+    //== 연관관계 편의 메소드 ==//
+    public void addPost(Post post) {
+        if (this.post != null) {
+            this.post.getPostImages().remove(this);
+        }
+        this.post = post;
+        post.getPostImages().add(this);
     }
 }

--- a/src/main/java/com/example/temp/post/domain/PostImage.java
+++ b/src/main/java/com/example/temp/post/domain/PostImage.java
@@ -42,6 +42,7 @@ public class PostImage extends BaseTimeEntity {
     }
 
     public static PostImage createPostImage(Image image) {
+        image.use();
         return PostImage.builder()
             .image(image)
             .build();

--- a/src/main/java/com/example/temp/post/domain/PostImage.java
+++ b/src/main/java/com/example/temp/post/domain/PostImage.java
@@ -1,5 +1,7 @@
 package com.example.temp.post.domain;
 
+import com.example.temp.image.domain.Image;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,8 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,12 +25,25 @@ public class PostImage {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "image_id")
+    @Column(name = "post_image_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
-    private String url;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    @Builder
+    private PostImage(Image image) {
+        this.image = image;
+    }
+
+    public static PostImage createPostImage(Image image) {
+        return PostImage.builder()
+            .image(image)
+            .build();
+    }
 }

--- a/src/main/java/com/example/temp/post/domain/PostImage.java
+++ b/src/main/java/com/example/temp/post/domain/PostImage.java
@@ -1,5 +1,6 @@
 package com.example.temp.post.domain;
 
+import com.example.temp.common.entity.BaseTimeEntity;
 import com.example.temp.image.domain.Image;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "post_images")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PostImage {
+public class PostImage extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
@@ -3,8 +3,8 @@ package com.example.temp.post.dto.request;
 import com.example.temp.member.domain.Member;
 import com.example.temp.post.domain.Content;
 import com.example.temp.post.domain.Post;
-import com.example.temp.post.domain.PostImage;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public record PostCreateRequest(
@@ -12,11 +12,11 @@ public record PostCreateRequest(
     List<String> imageUrl
 ) {
 
-    public Post toEntity(Member member, LocalDateTime registeredAt, List<PostImage> postImages) {
+    public Post toEntity(Member member, LocalDateTime registeredAt) {
         return Post.builder()
             .member(member)
             .content(Content.create(content))
-            .postImages(postImages)
+            .postImages(new ArrayList<>())
             .registeredAt(registeredAt)
             .build();
     }

--- a/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
@@ -3,11 +3,13 @@ package com.example.temp.post.dto.request;
 import com.example.temp.member.domain.Member;
 import com.example.temp.post.domain.Content;
 import com.example.temp.post.domain.Post;
+import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record PostCreateRequest(
     String content,
+    @Nullable
     List<String> imageUrl
 ) {
 

--- a/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
@@ -4,7 +4,6 @@ import com.example.temp.member.domain.Member;
 import com.example.temp.post.domain.Content;
 import com.example.temp.post.domain.Post;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 public record PostCreateRequest(
@@ -16,7 +15,6 @@ public record PostCreateRequest(
         return Post.builder()
             .member(member)
             .content(Content.create(content))
-            .postImages(new ArrayList<>())
             .registeredAt(registeredAt)
             .build();
     }

--- a/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
@@ -1,0 +1,23 @@
+package com.example.temp.post.dto.request;
+
+import com.example.temp.member.domain.Member;
+import com.example.temp.post.domain.Content;
+import com.example.temp.post.domain.Post;
+import com.example.temp.post.domain.PostImage;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostCreateRequest(
+    String content,
+    List<String> imageUrl
+) {
+
+    public Post toEntity(Member member, LocalDateTime registeredAt, List<PostImage> postImages) {
+        return Post.builder()
+            .member(member)
+            .content(Content.create(content))
+            .postImages(postImages)
+            .registeredAt(registeredAt)
+            .build();
+    }
+}

--- a/src/main/java/com/example/temp/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostCreateResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 
 @Builder
 public record PostCreateResponse(
-    Long id,
+    Long postId,
     WriterInfo writerInfo,
     String content,
     List<String> postImages,
@@ -17,7 +17,7 @@ public record PostCreateResponse(
 
     public static PostCreateResponse from(Post savedPost) {
         return PostCreateResponse.builder()
-            .id(savedPost.getId())
+            .postId(savedPost.getId())
             .writerInfo(WriterInfo.from(savedPost.getMember()))
             .content(savedPost.getContent())
             .postImages(urlFromPostImage(savedPost))

--- a/src/main/java/com/example/temp/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostCreateResponse.java
@@ -1,0 +1,33 @@
+package com.example.temp.post.dto.response;
+
+import com.example.temp.post.domain.Post;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+
+@Builder
+public record PostCreateResponse(
+    Long id,
+    WriterInfo writerInfo,
+    String content,
+    List<String> postImages,
+    LocalDateTime registeredAt
+) {
+
+    public static PostCreateResponse from(Post savedPost) {
+        return PostCreateResponse.builder()
+            .id(savedPost.getId())
+            .writerInfo(WriterInfo.from(savedPost.getMember()))
+            .content(savedPost.getContent())
+            .postImages(urlFromPostImage(savedPost))
+            .registeredAt(savedPost.getRegisteredAt())
+            .build();
+    }
+
+    private static List<String> urlFromPostImage(Post savedPost) {
+        return savedPost.getPostImages().stream()
+            .map(postImage -> postImage.getImage().getUrl())
+            .toList();
+    }
+}

--- a/src/main/java/com/example/temp/post/dto/response/PostElementResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostElementResponse.java
@@ -16,7 +16,7 @@ public record PostElementResponse(
         return PostElementResponse.builder()
             .writerInfo(WriterInfo.from(post.getMember()))
             .content(post.getContent())
-            .imageUrl(post.getImageUrl())
+            .imageUrl(post.getImageUrl().orElse(null))
             .createdAt(post.getCreatedAt())
             .build();
     }

--- a/src/main/java/com/example/temp/post/presentation/PostController.java
+++ b/src/main/java/com/example/temp/post/presentation/PostController.java
@@ -30,7 +30,7 @@ public class PostController {
     public ResponseEntity<PostCreateResponse> createPost(@Login UserContext userContext,
         @RequestBody PostCreateRequest postCreateRequest) {
         LocalDateTime registeredAt = LocalDateTime.now();
-        return ResponseEntity.ok(postService.create(userContext, postCreateRequest, registeredAt));
+        return ResponseEntity.ok(postService.createPost(userContext, postCreateRequest, registeredAt));
     }
 
     @GetMapping

--- a/src/main/java/com/example/temp/post/presentation/PostController.java
+++ b/src/main/java/com/example/temp/post/presentation/PostController.java
@@ -5,12 +5,17 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 import com.example.temp.common.annotation.Login;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.post.application.PostService;
+import com.example.temp.post.dto.request.PostCreateRequest;
 import com.example.temp.post.dto.response.PagePostResponse;
+import com.example.temp.post.dto.response.PostCreateResponse;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +25,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<PostCreateResponse> createPost(@Login UserContext userContext,
+        @RequestBody PostCreateRequest postCreateRequest) {
+        LocalDateTime registeredAt = LocalDateTime.now();
+        return ResponseEntity.ok(postService.create(userContext, postCreateRequest, registeredAt));
+    }
 
     @GetMapping
     public ResponseEntity<PagePostResponse> getFollowingPosts(@Login UserContext userContext,

--- a/src/test/java/com/example/temp/image/application/ImageServiceTest.java
+++ b/src/test/java/com/example/temp/image/application/ImageServiceTest.java
@@ -61,7 +61,7 @@ class ImageServiceTest {
         // then
         validateUrl(presignedUrl);
         String path = presignedUrl.getPath().substring(1);
-        assertThat(imageRepository.existsByFileName(path)).isTrue();
+        assertThat(imageRepository.existsByUrl(path)).isTrue();
     }
 
     /**

--- a/src/test/java/com/example/temp/image/domain/ImageTest.java
+++ b/src/test/java/com/example/temp/image/domain/ImageTest.java
@@ -17,7 +17,7 @@ class ImageTest {
         Image image = Image.create(fileName);
 
         // then
-        assertThat(image.getFileName()).isEqualTo(fileName);
+        assertThat(image.getUrl()).isEqualTo(fileName);
         assertThat(image.isUsed()).isFalse();
     }
 

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -30,7 +30,6 @@ import com.example.temp.post.dto.response.WriterInfo;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -190,6 +189,26 @@ class PostServiceTest {
         assertThatThrownBy(() -> postService.createPost(userContext, request, LocalDateTime.now()))
             .isInstanceOf(ApiException.class)
             .hasMessage(IMAGE_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("이미지를 첨부하지 않아도 게시글을 작성할 수 있다.")
+    @Test
+    void createPostWithoutImage() {
+        //given
+        Member member = saveMember("email@test.com", "nick");
+        UserContext userContext = UserContext.from(member);
+        PostCreateRequest postCreateRequest = new PostCreateRequest("content", null);
+
+        //when
+        PostCreateResponse postCreateResponse = postService.createPost(userContext, postCreateRequest,
+            LocalDateTime.now());
+
+        //then
+        assertThat(postCreateResponse).isNotNull()
+            .satisfies(response -> {
+                assertThat(response.content()).isEqualTo("content");
+                assertThat(response.postImages()).isEmpty();
+            });
     }
 
     private Member saveMember(String email, String nickname) {

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -29,15 +29,12 @@ import com.example.temp.post.dto.response.PostElementResponse;
 import com.example.temp.post.dto.response.WriterInfo;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.annotation.Commit;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -70,6 +67,10 @@ class PostServiceTest {
         saveFollow(member1, member2);
         saveFollow(member1, member3);
 
+        saveImage("image1");
+        saveImage("image2");
+        saveImage("image3");
+
         savePost(member2, "content1", List.of("image1"));
         savePost(member3, "content2", List.of("image2"));
         savePost(member1, "content3", List.of("image3"));
@@ -97,6 +98,11 @@ class PostServiceTest {
 
         saveFollow(member1, member2);
         saveFollow(member1, member3);
+
+        saveImage("image1");
+        saveImage("image2");
+        saveImage("image3");
+        saveImage("image4");
 
         savePost(member2, "content1", List.of("image1"));
         savePost(member3, "content2", List.of("image2"));
@@ -126,6 +132,11 @@ class PostServiceTest {
 
         saveFollow(member1, member2);
         saveFollow(member1, member3);
+
+        saveImage("image1");
+        saveImage("image2");
+        saveImage("image3");
+        saveImage("image4");
 
         savePost(member2, "content1", List.of("image1"));
         savePost(member3, "content2", List.of("image2"));
@@ -233,25 +244,27 @@ class PostServiceTest {
         followRepository.save(follow);
     }
 
-    private Post savePost(Member member, String content, List<String> imageUrls) {
-        List<PostImage> postImages = imageUrls.stream()
-            .map(this::saveImage)
-            .map(PostImage::createPostImage)
-            .collect(Collectors.toList());
-
+    private void savePost(Member member, String content, List<String> imageUrls) {
         Post post = Post.builder()
             .member(member)
             .content(Content.builder()
                 .value(content)
                 .build())
-            .postImages(postImages)
             .build();
 
-        return postRepository.save(post);
+        imageUrls.stream()
+            .map(url -> imageRepository.findByUrl(url))
+            .forEach(image -> {
+                image.use();
+                PostImage postImage = PostImage.createPostImage(image);
+                postImage.addPost(post);
+
+            });
+        postRepository.save(post);
     }
 
-    private Image saveImage(String url) {
+    private void saveImage(String url) {
         Image image = Image.create(url);
-        return imageRepository.save(image);
+        imageRepository.save(image);
     }
 }

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -36,6 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -255,7 +255,6 @@ class PostServiceTest {
         imageUrls.stream()
             .map(url -> imageRepository.findByUrl(url))
             .forEach(image -> {
-                image.use();
                 PostImage postImage = PostImage.createPostImage(image);
                 postImage.addPost(post);
 

--- a/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
@@ -4,12 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import com.example.temp.common.entity.Email;
+import com.example.temp.image.domain.Image;
+import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
 import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.domain.nickname.Nickname;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +33,9 @@ class PostRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private ImageRepository imageRepository;
+
     @DisplayName("팔로우 리스트에 들어 있는 사용자의 게시글만 조회할 수 있다.")
     @Test
     void findByMemberIn() {
@@ -38,9 +44,9 @@ class PostRepositoryTest {
         Member member2 = saveMember("email2@test.com", "nick2");
         Member member3 = saveMember("email3@test.com", "nick3");
 
-        savePost(member1, "내용1", "이미지1");
-        savePost(member2, "내용2", "이미지2");
-        savePost(member3, "내용3", "이미지3");
+        savePost(member1, "내용1", List.of("image1"));
+        savePost(member2, "내용2", List.of("image2"));
+        savePost(member3, "내용3", List.of("image3"));
 
         List<Member> followMembers = List.of(member1, member2);
         Pageable pageable = PageRequest.of(0, 10);
@@ -63,7 +69,7 @@ class PostRepositoryTest {
         Member member2 = saveMember("email2@test.com", "nick2");
         Member member3 = saveMember("email3@test.com", "nick3");
 
-        savePost(member3, "content", "image");
+        savePost(member3, "content", List.of("image1"));
 
         // When
         Pageable pageable = PageRequest.of(0, 10);
@@ -83,7 +89,7 @@ class PostRepositoryTest {
         Member member2 = saveMember("email2@test.com", "nick2");
 
         for (int i = 0; i < 20; i++) {
-            savePost(member1, "content" + i, "image" + i);
+            savePost(member1, "content" + i, List.of("image" + i));
         }
 
         // When
@@ -103,8 +109,8 @@ class PostRepositoryTest {
         Member member1 = saveMember("email1@test.com", "nick1");
         Member member2 = saveMember("email2@test.com", "nick2");
 
-        savePost(member1, "내용1", "이미지1");
-        savePost(member2, "내용2", "이미지2");
+        savePost(member1, "내용1", List.of("image1"));
+        savePost(member2, "내용2", List.of("image2"));
 
         List<Member> followMembers = List.of(member1, member2);
         Pageable pageable = PageRequest.of(0, 10);
@@ -122,17 +128,6 @@ class PostRepositoryTest {
             );
     }
 
-    private Post savePost(Member member, String content, String url) {
-        Post post = Post.builder()
-            .member(member)
-            .content(Content.builder()
-                .value(content)
-                .build())
-            .imageUrl(url)
-            .build();
-        return postRepository.save(post);
-    }
-
     private Member saveMember(String email, String nickname) {
         Member member = Member.builder()
             .email(Email.create(email))
@@ -142,5 +137,27 @@ class PostRepositoryTest {
             .privacyPolicy(PrivacyPolicy.PUBLIC)
             .build();
         return memberRepository.save(member);
+    }
+
+    private Post savePost(Member member, String content, List<String> imageUrls) {
+        List<PostImage> postImages = imageUrls.stream()
+            .map(this::saveImage)
+            .map(PostImage::createPostImage)
+            .collect(Collectors.toList());
+
+        Post post = Post.builder()
+            .member(member)
+            .content(Content.builder()
+                .value(content)
+                .build())
+            .postImages(postImages)
+            .build();
+
+        return postRepository.save(post);
+    }
+
+    private Image saveImage(String url) {
+        Image image = Image.create(url);
+        return imageRepository.save(image);
     }
 }

--- a/src/test/java/com/example/temp/post/domain/PostTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostTest.java
@@ -19,13 +19,12 @@ class PostTest {
     @Test
     void getImageUrl() {
         // Given
-        List<PostImage> postImages = getPostImages(List.of("image1", "image2"));
         Post post = Post.builder()
             .member(getMember())
             .content(Content.create("content"))
-            .postImages(postImages)
             .registeredAt(LocalDateTime.now())
             .build();
+        List<PostImage> postImages = getPostImages(List.of("image1", "image2"), post);
 
         // When
         String imageUrl = post.getImageUrl();
@@ -44,11 +43,13 @@ class PostTest {
             .build();
     }
 
-    private List<PostImage> getPostImages(List<String> imageUrls) {
+    private List<PostImage> getPostImages(List<String> imageUrls, Post post) {
         return imageUrls.stream()
             .map(url -> {
                 Image image = Image.create(url);
-                return PostImage.createPostImage(image);
+                PostImage postImage = PostImage.createPostImage(image);
+                postImage.addPost(post);
+                return postImage;
             })
             .toList();
     }

--- a/src/test/java/com/example/temp/post/domain/PostTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostTest.java
@@ -1,0 +1,56 @@
+package com.example.temp.post.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.common.entity.Email;
+import com.example.temp.image.domain.Image;
+import com.example.temp.member.domain.FollowStrategy;
+import com.example.temp.member.domain.Member;
+import com.example.temp.member.domain.PrivacyPolicy;
+import com.example.temp.member.domain.nickname.Nickname;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostTest {
+
+    @DisplayName("PostImage에 등록된 url 중 처음등록된  url을 가져온다.")
+    @Test
+    void getImageUrl() {
+        // Given
+        List<PostImage> postImages = getPostImages(List.of("image1", "image2"));
+        Post post = Post.builder()
+            .member(getMember())
+            .content(Content.create("content"))
+            .postImages(postImages)
+            .registeredAt(LocalDateTime.now())
+            .build();
+
+        // When
+        String imageUrl = post.getImageUrl();
+
+        // Then
+        assertThat(imageUrl).isEqualTo("image1");
+    }
+
+    private Member getMember() {
+        return Member.builder()
+            .email(Email.create("email@test.com"))
+            .profileUrl("프로필")
+            .nickname(Nickname.create("nick"))
+            .followStrategy(FollowStrategy.EAGER)
+            .privacyPolicy(PrivacyPolicy.PUBLIC)
+            .build();
+    }
+
+    private List<PostImage> getPostImages(List<String> imageUrls) {
+        return imageUrls.stream()
+            .map(url -> {
+                Image image = Image.create(url);
+                return PostImage.createPostImage(image);
+            })
+            .toList();
+    }
+
+}

--- a/src/test/java/com/example/temp/post/domain/PostTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostTest.java
@@ -27,7 +27,7 @@ class PostTest {
         List<PostImage> postImages = getPostImages(List.of("image1", "image2"), post);
 
         // When
-        String imageUrl = post.getImageUrl();
+        String imageUrl = post.getImageUrl().orElse(null);
 
         // Then
         assertThat(imageUrl).isEqualTo("image1");


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] 게시글 작성
- [X] 게시글 작성 시 Image used -> true처리

## 🏌🏻 리뷰 포인트
처음 게시글 리스트 조회시 저희가 이미지 한장을 보여줘야해서 역정규화 하고 해당 url을 String타입으로 가져오고 있었는데요.
게시글 작성 부분을 개발하면서 기획단계에서 나왔듯이 이미지를 여러장 첨부 할 수 있도록 확장가능성을 여러두고 개발해야 한다면 처음부터 여러장 받을 수 있도록 설계하는게 훨씬 나은방법이라고 생각해서 구조자체를 전부 뜯어 고쳤습니다.

가장 큰 고민인 부분은 연관관계 주인 부분인데요 현재는 보통의 설계처럼 외래키를 들고 있는 PostImage를 연관관계 주인으로 설정했는데 게시글 입장에서 생각해보면 Post가 PostImage를 자주 사용하는 구조이기 때문에 연관관계 주인을 Post쪽으로 두는게 어떤지 고민 중에 있습니다.
```java
@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<PostImage> postImages = new ArrayList<>();
```

코드 한번 리뷰 해주시면 제 의견과 합쳐서 반영하고 피드백 받을게요

## 🧘🏻 기타 사항

```java
public String getImageUrl() {
        return postImages.stream()
            .findFirst()
            .map(PostImage::getImage)
            .map(Image::getUrl)
            .orElse(null);
    }
```

해당 부분은 Post에서 게시글 리스트쪽에 사용할 Url정보만 가져오는 메소드 인데 현재는 등록된 url중에 첫번째 url을 받도록 작성해놨는데 이 부분에 대해선 크게 문제가 없을 지 더 나은 방법이 있을지 태훈님 의견이 궁금합니다.

close #54 