### PR TITLE
data.sql에서 members 초기화할 때 member_id 제거

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,3 @@
-INSERT INTO members(member_id, registered, deleted, nickname, email, profile_url, privacy_policy, follow_strategy)
-VALUES (1, true, false, '김태훈', 'first@test.com', 'https://avatars.githubusercontent.com/u/67636607?s=80&u=66f65ed6f693c3235b3ba0a4a1ed93b7eeae50cb&v=4', 'PUBLIC', 'EAGER'),
-       (2, true, false, '이정우', 'another@test.org', 'https://avatars.githubusercontent.com/u/49686619?v=4', 'PUBLIC', 'EAGER');
+INSERT INTO members(registered, deleted, nickname, email, profile_url, privacy_policy, follow_strategy)
+VALUES (true, false, '김태훈', 'first@test.com', 'https://avatars.githubusercontent.com/u/67636607?s=80&u=66f65ed6f693c3235b3ba0a4a1ed93b7eeae50cb&v=4', 'PUBLIC', 'EAGER'),
+       (true, false, '이정우', 'another@test.org', 'https://avatars.githubusercontent.com/u/49686619?v=4', 'PUBLIC', 'EAGER');


### PR DESCRIPTION
## 👊🏻 작업 내용
ID 전략(IDENTIFY) 과 data.sql이 충돌이 일어나서 오류가 발생했습니다.
data.sql에서 회원을 저장할 때, member_id를 제거해줌으로써 DB가 모든 id를 관리하도록 만들어주었습니다.

- [x] data.sql에서 members 초기화할 때 member_id 제거

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
없습니다.

close #73 