### PR TITLE
[#72] 회원가입 시 Profile URL 선택인자로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /src/main/resources/application.yml
 .DS_Store
 .localstack
+localstack
 
 HELP.md
 .gradle

--- a/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,9 @@ import com.example.temp.member.exception.NicknameDuplicatedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -30,6 +33,21 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse.create(
                 String.format("'%s'의 타입이 잘못되었습니다.", exception.getParameter().getParameterName())));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException exception) {
+        FieldError fieldError = getFirstFieldError(exception);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.create(
+                String.format(String.format("[%s] %s", fieldError.getField(), fieldError.getDefaultMessage()))));
+    }
+
+    private FieldError getFirstFieldError(MethodArgumentNotValidException exception) {
+        BindingResult bindingResult = exception.getBindingResult();
+        return bindingResult.getFieldErrors().get(0);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -4,6 +4,7 @@ import com.example.temp.auth.dto.response.MemberInfo;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
+import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
 import com.example.temp.member.domain.PrivacyPolicy;
@@ -31,6 +32,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final NicknameGenerator nicknameGenerator;
     private final ApplicationEventPublisher eventPublisher;
+    private final ImageRepository imageRepository;
 
     /**
      * OAuthResponse과 nicknameGenerator에서 생성한 닉네임을 사용해 Member를 저장합니다. NicknameDuplicatedException 발생 시 최대 다섯 번 재시도를 하며
@@ -72,6 +74,9 @@ public class MemberService {
         Nickname nickname = Nickname.create(request.nickname());
         if (memberRepository.existsByNickname(nickname.getValue())) {
             throw new ApiException(ErrorCode.NICKNAME_DUPLICATED);
+        }
+        if (request.profileUrl() != null && !imageRepository.existsByUrl(request.profileUrl())) {
+            throw new ApiException(ErrorCode.IMAGE_NOT_FOUND);
         }
         member.init(nickname, request.profileUrl());
         return MemberInfo.of(member);

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -57,7 +57,7 @@ public class MemberService {
     }
 
     /**
-     * 가입 처리가 완료되지 않은 회원을 가입시킵니다.
+     * 가입 처리가 완료되지 않은 회원을 가입시킵니다. profile url을 입력하지 않은 회원은 디폴트 이미지를 사용해 저장합니다.
      *
      * @param userContext 로그인한 사용자의 정보
      * @param request     회원 가입에 필요한 정보

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -100,9 +100,8 @@ public class Member {
      * @throws ApiException MEMBER_ALREADY_REGISTER: 이미 가입이 완료된 회원이 해당 메서드를 호출했을 때 발생합니다.
      */
     public void init(Nickname nickname, String profileUrl) {
-        if (profileUrl == null) {
-            profileUrl = DEFAULT_PROFILE;
-        }
+        profileUrl = (profileUrl == null ? DEFAULT_PROFILE : profileUrl);
+
         if (registered) {
             throw new ApiException(ErrorCode.MEMBER_ALREADY_REGISTER);
         }

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Member {
 
-    public static final String DEFAULT_PROFILE = "defaultprofile";
+    public static final String DEFAULT_PROFILE = "https://avatars.githubusercontent.com/u/87960006?v=4";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -143,4 +143,3 @@ public class Member {
     }
 
 }
-

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -25,6 +25,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Member {
 
+    public static final String DEFAULT_PROFILE = "defaultprofile";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
@@ -90,13 +92,17 @@ public class Member {
     }
 
     /**
-     * nickname과 profileUrl을 입력받아 회원가입 처리를 완료합니다. 공개 계정이며, EAGER 팔로우 전략을 갖습니다.
+     * nickname과 profileUrl을 입력받아 회원가입 처리를 완료합니다. 공개 계정이며, EAGER 팔로우 전략을 갖습니다. 만약 profileUrl을 입력받지 않았다면 DEFAULT_PROFILE로
+     * 회원을 등록합니다.
      *
      * @param nickname
-     * @param profileUrl
+     * @param profileUrl nullable
      * @throws ApiException MEMBER_ALREADY_REGISTER: 이미 가입이 완료된 회원이 해당 메서드를 호출했을 때 발생합니다.
      */
     public void init(Nickname nickname, String profileUrl) {
+        if (profileUrl == null) {
+            profileUrl = DEFAULT_PROFILE;
+        }
         if (registered) {
             throw new ApiException(ErrorCode.MEMBER_ALREADY_REGISTER);
         }
@@ -134,6 +140,10 @@ public class Member {
 
     public void delete() {
         this.deleted = true;
+    }
+
+    public void initWithDefaultProfile(Nickname nickname) {
+        init(nickname, DEFAULT_PROFILE);
     }
 }
 

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -142,8 +142,5 @@ public class Member {
         this.deleted = true;
     }
 
-    public void initWithDefaultProfile(Nickname nickname) {
-        init(nickname, DEFAULT_PROFILE);
-    }
 }
 

--- a/src/main/java/com/example/temp/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/com/example/temp/member/dto/request/MemberRegisterRequest.java
@@ -1,7 +1,13 @@
 package com.example.temp.member.dto.request;
 
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+
 public record MemberRegisterRequest(
+    @Nullable
     String profileUrl,
+
+    @NotBlank
     String nickname
 ) {
 

--- a/src/main/java/com/example/temp/member/presentation/MemberController.java
+++ b/src/main/java/com/example/temp/member/presentation/MemberController.java
@@ -8,6 +8,7 @@ import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.dto.request.MemberRegisterRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,7 +26,7 @@ public class MemberController {
 
     @PostMapping("/register")
     public ResponseEntity<MemberInfo> register(@Login UserContext userContext,
-        @RequestBody MemberRegisterRequest memberRegisterRequest) {
+        @RequestBody @Validated MemberRegisterRequest memberRegisterRequest) {
         MemberInfo response = memberService.register(userContext, memberRegisterRequest);
         return ResponseEntity.ok(response);
     }

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.temp.member.application;
 
+import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
 import static com.example.temp.common.exception.ErrorCode.NICKNAME_DUPLICATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -13,6 +14,7 @@ import com.example.temp.common.entity.Email;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.follow.domain.Follow;
+import com.example.temp.image.domain.Image;
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.PrivacyPolicy;
@@ -153,20 +155,33 @@ class MemberServiceTest {
     void registerSuccess() throws Exception {
         // given
         Member member = saveNotInitializedMember(Nickname.create("닉넴"));
-        String changedProfileUrl = "변경할프로필";
+        Image changedProfile = saveImage("https://changedurl");
         String changedNickname = "변경할닉네임";
 
         // when
         MemberInfo result = memberService.register(UserContext.from(member),
-            new MemberRegisterRequest(changedProfileUrl, changedNickname));
+            new MemberRegisterRequest(changedProfile.getUrl(), changedNickname));
 
         // then
         assertThat(member.getPrivacyPolicy()).isEqualTo(PrivacyPolicy.PUBLIC);
         assertThat(member.getFollowStrategy()).isEqualTo(FollowStrategy.EAGER);
         assertThat(result.registered()).isTrue();
         assertThat(result.id()).isEqualTo(member.getId());
-        assertThat(result.profileUrl()).isEqualTo(changedProfileUrl);
+        assertThat(result.profileUrl()).isEqualTo(changedProfile.getUrl());
         assertThat(result.nickname()).isEqualTo(changedNickname);
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 이미지로는 회원가입을 할 수 없다.")
+    void registerImageNotFound() throws Exception {
+        // given
+        Member member = saveNotInitializedMember(Nickname.create("닉넴"));
+        MemberRegisterRequest request = new MemberRegisterRequest("https://imageNotFound", "변경할닉네임");
+
+        // when & then
+        assertThatThrownBy(() -> memberService.register(UserContext.from(member), request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(IMAGE_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -185,7 +200,7 @@ class MemberServiceTest {
         assertThat(member.getFollowStrategy()).isEqualTo(FollowStrategy.EAGER);
         assertThat(result.registered()).isTrue();
         assertThat(result.id()).isEqualTo(member.getId());
-        assertThat(result.profileUrl()).isNotNull();
+        assertThat(result.profileUrl()).isEqualTo(Member.DEFAULT_PROFILE);
         assertThat(result.nickname()).isEqualTo(changedNickname);
     }
 
@@ -209,12 +224,12 @@ class MemberServiceTest {
     void registerFailAlreadyRegistered() throws Exception {
         // given
         Member member = saveRegisteredMember(Nickname.create("닉넴"));
-        String changedProfileUrl = "변경하는프로필주소";
+        Image changedProfile = saveImage("https://changedurl");
         String changedNickname = "변경할닉네임";
 
         // when & then
         assertThatThrownBy(() -> memberService.register(UserContext.from(member),
-            new MemberRegisterRequest(changedProfileUrl, changedNickname)))
+            new MemberRegisterRequest(changedProfile.getUrl(), changedNickname)))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.MEMBER_ALREADY_REGISTER.getMessage());
     }
@@ -281,6 +296,15 @@ class MemberServiceTest {
         assertThat(em.find(Follow.class, follow1.getId())).isNull();
         assertThat(em.find(Follow.class, follow2.getId())).isNull();
         assertThat(em.find(Follow.class, notRelatedFollow.getId())).isNotNull();
+    }
+
+
+    private Image saveImage(String url) {
+        Image image = Image.builder()
+            .url(url)
+            .build();
+        em.persist(image);
+        return image;
     }
 
     private Follow saveFollow(Member fromMember, Member toMember) {

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -170,6 +170,26 @@ class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("프로필 이미지를 입력하지 않고 회원가입하면 디폴트 이미지로 회원가입 처리가 된다.")
+    void registerSuccessNotProfileUrl() throws Exception {
+        // given
+        Member member = saveNotInitializedMember(Nickname.create("닉넴"));
+        String changedNickname = "변경할닉네임";
+
+        // when
+        MemberInfo result = memberService.register(UserContext.from(member),
+            new MemberRegisterRequest(null, changedNickname));
+
+        // then
+        assertThat(member.getPrivacyPolicy()).isEqualTo(PrivacyPolicy.PUBLIC);
+        assertThat(member.getFollowStrategy()).isEqualTo(FollowStrategy.EAGER);
+        assertThat(result.registered()).isTrue();
+        assertThat(result.id()).isEqualTo(member.getId());
+        assertThat(result.profileUrl()).isNotNull();
+        assertThat(result.nickname()).isEqualTo(changedNickname);
+    }
+
+    @Test
     @DisplayName("회원가입 시 다른 회원과 중복된 닉네임으로는 가입이 불가능하다.")
     void registerFailDuplicatedNickname() throws Exception {
         // given

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -39,6 +39,27 @@ class MemberTest {
     }
 
     @Test
+    @DisplayName("회원을 초기화할 때, 프로필 이미지를 입력하지 않으면 디폴트 이미지를 가진 회원이 생성된다.")
+    void initNotProfileUrl() throws Exception {
+        // given
+        Nickname changedNickname = Nickname.create("변경할닉넴");
+        String changedProfileUrl = null;
+        Member member = Member.builder()
+            .registered(false)
+            .build();
+
+        // when
+        member.init(changedNickname, changedProfileUrl);
+
+        // then
+        assertThat(member.getProfileUrl()).isEqualTo(Member.DEFAULT_PROFILE);
+        assertThat(member.isRegistered()).isTrue();
+        assertThat(member.getPrivacyPolicy()).isEqualTo(PUBLIC);
+        assertThat(member.getFollowStrategy()).isEqualTo(EAGER);
+        assertThat(member.getNickname()).isEqualTo(changedNickname);
+    }
+
+    @Test
     @DisplayName("초기화되어있던 회원은 초기화할 수 없다")
     void initFailAlreadyInit() throws Exception {
         // given


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 회원가입 시 Profile Url 선택인자로 변경
- [x] 기본 프로필 적용
- [x] 기존에 등록한 적 없는 이미지로 프로필 변경하려 할 때 예외 출력

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
기존 설계에서 프로필 주소를 안받는다는 걸 전혀 고려하지 않았는데요.
지금 구조 살리면서 위 기능을 추가하니까 코드가 마음에 들지는 않습니다.

지금 Member 엔티티에 DEFAULT_PROFILE이라는 상수로 특정 이미지를 넣어뒀는데요.
해당 부분 yml로 관리하는 게 베스트라고 생각하는데, 단순 값 하나 넣겠다고 Properties 만드는 게 별로라고 생각했습니다.
`@Value` 를 사용하려고도 했는데, Member 엔티티에서만 값을 관리하도록 만들고 싶은데 역시나 구조 분리가 필요한 거 같아요.
(사실 저는 Value를 거의 안써서 자료를 찾아봤는데, 찾아본 자료를 첨부할게요)
https://jkpark.me/springboot/java/2020/06/04/Spring-Boot-static-%EB%B3%80%EC%88%98%EC%97%90%EC%84%9C-@value-annontation-%EC%82%AC%EC%9A%A9.html

그래서 상수로 이미지 URL을 하나 들고있도록 설계했습니다 (하... 맘에 안들어요)


close #72 