### PR TITLE
[#79] CORS 문제 해결

### DIFF
--- a/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+import software.amazon.awssdk.utils.StringUtils;
 
 @RequiredArgsConstructor
 @Component
@@ -22,6 +23,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
         throws Exception {
+        if (StringUtils.equals(request.getMethod(), "OPTIONS")) {
+            return true;
+        }
         String accessTokenBeforeProcessing = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (accessTokenBeforeProcessing == null || !accessTokenBeforeProcessing.startsWith(BEARER)) {
             response.setStatus(HttpStatus.UNAUTHORIZED.value());


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] OPTIONS 메서드에 대해 인증 인터셉터 비활성화

### 문제 원인
한 문장으로 정리하면 Preflight 요청에 대해 인증을 검사하면서 발생했던 문제입니다.

1. 브라우저는 먼저 서버에게 OPTIONS 타입의 Preflight 요청을 보냅니다.
2. 서버는 OPTIONS 요청에 대해 인증되었는지 검사합니다. (**검사 안하는 흐름이 맞는 흐름입니다**)
3. OPTIONS 메서드는 `Authorization` 헤더를 들고 있지 않기 때문에 서버에서는 "인증 X"라는 결과를 보냅니다.
4. 브라우저는 이제 응답이 400번대 상태가 온걸 보고, "Preflight 요청을 보냈는데 실패했으니 이거 CORS구나" 라고 생각합니다.
5. 윤혁님의 PC에 CORS가 보여집니다,,


## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
1. 다른 프론트 분들은 CORS가 발생하지 않음
2. 저 역시 Postman으로 Origin : http://localhost:3000 헤더를 붙여서 보냈을 때 CORS 통과

이 두 가지 때문에 문제 발생 지점을 윤혁님 개인 환경으로 착각을 했고, 문제 발견까지 오랜 시간이 걸렸습니다.
윤혁님 어제 하루종일 고생하신 거 봤던 입장이라 정말 죄송한 마음이 듭니다,,, 그리고 저 역시도 속상하네요 😢😢😢
정말 혹시나 싶어 제가 프론트 환경 만들어서 테스트해보니 CORS가 발생하더라구요. 이때서야 서버에 문제가 있다고 확신할 수 있었습니다.

아마 윤혁님 제외 다른 분들은 로그인이 잘 되는지 확인하셨을테고, 해당 요청은 AuthenticationInterceptor를 거치지 않아서 CORS가 발생하지 않았을 걸로 예상합니다.
해당 부분은 블로그에 주말쯤 글을 작성하고 공유드리겠습니다. 다시 한 번 죄송합니다 ㅠㅠㅠ


close #79 