### PR TITLE
[#78] 게시글 작성 시 해시태그

### DIFF
--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -39,7 +39,10 @@ public enum ErrorCode {
     // 이미지
     IMAGE_TOO_BIG(HttpStatus.BAD_REQUEST, "이미지의 크기가 너무 큽니다"),
     IMAGE_NAME_DUPLICATED(HttpStatus.CONFLICT, "서버에서 생성한 이미지의 이름이 중복되었습니다. 다시 한 번 요청을 보내주세요."),
-    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이미지를 찾을 수 없습니다.");
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이미지를 찾을 수 없습니다."),
+
+    // 해시태그
+    HASHTAG_PATTERN_MISMATCH(HttpStatus.BAD_REQUEST, "해시태그 형식에 맞지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/temp/hashtag/application/HashtagService.java
+++ b/src/main/java/com/example/temp/hashtag/application/HashtagService.java
@@ -1,0 +1,32 @@
+package com.example.temp.hashtag.application;
+
+import com.example.temp.hashtag.domain.Hashtag;
+import com.example.temp.hashtag.domain.HashtagRepository;
+import com.example.temp.post.domain.Post;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+
+    @Transactional
+    public List<Hashtag> saveHashtag(List<String> names, Post post) {
+        return names.stream()
+            .map(this::saveOrFind)
+            .toList();
+    }
+
+    private Hashtag saveOrFind(String name) {
+        return hashtagRepository
+            .findByName(name)
+            .orElseGet(() -> hashtagRepository.save(Hashtag.builder()
+                .name(name)
+                .build()));
+    }
+}

--- a/src/main/java/com/example/temp/hashtag/application/HashtagService.java
+++ b/src/main/java/com/example/temp/hashtag/application/HashtagService.java
@@ -17,11 +17,11 @@ public class HashtagService {
     @Transactional
     public List<Hashtag> saveHashtag(List<String> names) {
         return names.stream()
-            .map(this::saveOrFind)
+            .map(this::findOrElseSave)
             .toList();
     }
 
-    private Hashtag saveOrFind(String name) {
+    private Hashtag findOrElseSave(String name) {
         return hashtagRepository
             .findByName(name)
             .orElseGet(() -> hashtagRepository.save(Hashtag.builder()

--- a/src/main/java/com/example/temp/hashtag/application/HashtagService.java
+++ b/src/main/java/com/example/temp/hashtag/application/HashtagService.java
@@ -2,7 +2,6 @@ package com.example.temp.hashtag.application;
 
 import com.example.temp.hashtag.domain.Hashtag;
 import com.example.temp.hashtag.domain.HashtagRepository;
-import com.example.temp.post.domain.Post;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +15,7 @@ public class HashtagService {
     private final HashtagRepository hashtagRepository;
 
     @Transactional
-    public List<Hashtag> saveHashtag(List<String> names, Post post) {
+    public List<Hashtag> saveHashtag(List<String> names) {
         return names.stream()
             .map(this::saveOrFind)
             .toList();

--- a/src/main/java/com/example/temp/hashtag/domain/HashTag.java
+++ b/src/main/java/com/example/temp/hashtag/domain/HashTag.java
@@ -1,0 +1,32 @@
+package com.example.temp.hashtag.domain;
+
+import com.example.temp.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hashtags")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class HashTag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "hashtag_id")
+    private Long id;
+
+    private String name;
+
+    @Builder
+    public HashTag(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
@@ -30,6 +30,13 @@ public class Hashtag extends BaseTimeEntity {
 
     @Builder
     public Hashtag(String name) {
+        validate(name);
         this.name = name;
+    }
+
+    private void validate(String name) {
+        if (name.matches("^#[\\w가-힣]+$")) {
+            throw new IllegalArgumentException("지원하지 않는 해시태그 형식입니다.");
+        }
     }
 }

--- a/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
@@ -35,7 +35,7 @@ public class Hashtag extends BaseTimeEntity {
     }
 
     private void validate(String name) {
-        if (name.matches("^#[\\w가-힣]+$")) {
+        if (!name.matches("^#[\\w가-힣]+$")) {
             throw new IllegalArgumentException("지원하지 않는 해시태그 형식입니다.");
         }
     }

--- a/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,17 +17,35 @@ import lombok.NoArgsConstructor;
 @Table(name = "hashtags")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class HashTag extends BaseTimeEntity {
+public class Hashtag extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "hashtag_id")
     private Long id;
 
+    @Column(unique = true)
     private String name;
 
     @Builder
-    public HashTag(String name) {
+    public Hashtag(String name) {
         this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof Hashtag)) {
+            return false;
+        }
+        Hashtag hashTag = (Hashtag) o;
+        return Objects.equals(getName(), hashTag.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
     }
 }

--- a/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
@@ -22,6 +22,14 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 public class Hashtag extends BaseTimeEntity {
 
+    /**
+     * ^ : 문자열의 시작을 나타냅니다.
+     * # : 해시태그 기호를 나타냅니다.
+     * [\w가-힣]은 모든 영문자, 숫자, 밑줄, 그리고 한글을 포함하는 문자를 의미합니다.
+     * + : 앞의 문자나 그룹이 하나 이상 반복되는 패턴을 나타냅니다.
+     * $ : 문자열의 끝을 나타냅니다.
+     * #으로 시작해서 한글, 영문자, 숫자, 밑줄만 작성되었는지 확인하는 정규표현식 입니다.
+     */
     private static final String HASHTAG_REGEX = "^#[\\w가-힣]+$";
 
     @Id

--- a/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
@@ -7,9 +7,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "hashtags")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class Hashtag extends BaseTimeEntity {
 
     @Id
@@ -30,22 +31,5 @@ public class Hashtag extends BaseTimeEntity {
     @Builder
     public Hashtag(String name) {
         this.name = name;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || !(o instanceof Hashtag)) {
-            return false;
-        }
-        Hashtag hashTag = (Hashtag) o;
-        return Objects.equals(getName(), hashTag.getName());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getName());
     }
 }

--- a/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
@@ -1,6 +1,8 @@
 package com.example.temp.hashtag.domain;
 
 import com.example.temp.common.entity.BaseTimeEntity;
+import com.example.temp.common.exception.ApiException;
+import com.example.temp.common.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,6 +22,8 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode(callSuper = true)
 public class Hashtag extends BaseTimeEntity {
 
+    private static final String HASHTAG_REGEX = "^#[\\w가-힣]+$";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "hashtag_id")
@@ -35,8 +39,8 @@ public class Hashtag extends BaseTimeEntity {
     }
 
     private void validate(String name) {
-        if (!name.matches("^#[\\w가-힣]+$")) {
-            throw new IllegalArgumentException("지원하지 않는 해시태그 형식입니다.");
+        if (!name.matches(HASHTAG_REGEX)) {
+            throw new ApiException(ErrorCode.HASHTAG_PATTERN_MISMATCH);
         }
     }
 }

--- a/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/example/temp/hashtag/domain/Hashtag.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "hashtags")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode
 public class Hashtag extends BaseTimeEntity {
 
     private static final String HASHTAG_REGEX = "^#[\\w가-힣]+$";

--- a/src/main/java/com/example/temp/hashtag/domain/HashtagRepository.java
+++ b/src/main/java/com/example/temp/hashtag/domain/HashtagRepository.java
@@ -1,0 +1,11 @@
+package com.example.temp.hashtag.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+    Optional<Hashtag> findByName(String name);
+}

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -87,14 +87,14 @@ public class PostService {
     }
 
     private void addPostImageToPost(PostImage postImage, Post post) {
-        postImage.addPost(post);
+        postImage.relate(post);
     }
 
     private void createPostHashtags(List<String> hashtags, Post post) {
         List<Hashtag> savedHashtags = hashtagService.saveHashtag(hashtags);
         savedHashtags.stream()
             .map(PostHashtag::createPostHashtag)
-            .forEach(postHashtag -> postHashtag.addPost(post));
+            .forEach(postHashtag -> postHashtag.relatePost(post));
     }
 
     private List<Member> findFollowingOf(Member member) {

--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -47,6 +47,9 @@ public class Post extends BaseTimeEntity {
     @OrderBy("createdAt ASC")
     private List<PostImage> postImages = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<PostHashtag> postHashtags = new ArrayList<>();
+
     private LocalDateTime registeredAt;
 
     @Builder

--- a/src/main/java/com/example/temp/post/domain/PostHashtag.java
+++ b/src/main/java/com/example/temp/post/domain/PostHashtag.java
@@ -35,8 +35,22 @@ public class PostHashtag {
     private Hashtag hashtag;
 
     @Builder
-    private PostHashtag(Post post, Hashtag hashtag) {
-        this.post = post;
+    private PostHashtag(Hashtag hashtag) {
         this.hashtag = hashtag;
+    }
+
+    public static PostHashtag createPostHashtag(Hashtag hashtag) {
+        return PostHashtag.builder()
+            .hashtag(hashtag)
+            .build();
+    }
+
+    //== 연관관계 편의 메서드 ==//
+    public void addPost(Post post) {
+        if (this.post != null) {
+            this.post.getPostHashtags().remove(this);
+        }
+        this.post = post;
+        post.getPostHashtags().add(this);
     }
 }

--- a/src/main/java/com/example/temp/post/domain/PostHashtag.java
+++ b/src/main/java/com/example/temp/post/domain/PostHashtag.java
@@ -46,7 +46,7 @@ public class PostHashtag {
     }
 
     //== 연관관계 편의 메서드 ==//
-    public void addPost(Post post) {
+    public void relatePost(Post post) {
         if (this.post != null) {
             this.post.getPostHashtags().remove(this);
         }

--- a/src/main/java/com/example/temp/post/domain/PostHashtag.java
+++ b/src/main/java/com/example/temp/post/domain/PostHashtag.java
@@ -1,0 +1,42 @@
+package com.example.temp.post.domain;
+
+import com.example.temp.hashtag.domain.Hashtag;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post_hashtags")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PostHashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_hashtag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag;
+
+    @Builder
+    private PostHashtag(Post post, Hashtag hashtag) {
+        this.post = post;
+        this.hashtag = hashtag;
+    }
+}

--- a/src/main/java/com/example/temp/post/domain/PostImage.java
+++ b/src/main/java/com/example/temp/post/domain/PostImage.java
@@ -49,7 +49,7 @@ public class PostImage extends BaseTimeEntity {
     }
 
     //== 연관관계 편의 메소드 ==//
-    public void addPost(Post post) {
+    public void relate(Post post) {
         if (this.post != null) {
             this.post.getPostImages().remove(this);
         }

--- a/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/temp/post/dto/request/PostCreateRequest.java
@@ -10,7 +10,9 @@ import java.util.List;
 public record PostCreateRequest(
     String content,
     @Nullable
-    List<String> imageUrl
+    List<String> imageUrls,
+    @Nullable
+    List<String> hashTags
 ) {
 
     public Post toEntity(Member member, LocalDateTime registeredAt) {

--- a/src/main/java/com/example/temp/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostCreateResponse.java
@@ -1,9 +1,10 @@
 package com.example.temp.post.dto.response;
 
 import com.example.temp.post.domain.Post;
+import com.example.temp.post.domain.PostHashtag;
+import com.example.temp.post.domain.PostImage;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 
 @Builder
@@ -12,6 +13,7 @@ public record PostCreateResponse(
     WriterInfo writerInfo,
     String content,
     List<String> postImages,
+    List<String> hashtags,
     LocalDateTime registeredAt
 ) {
 
@@ -20,14 +22,21 @@ public record PostCreateResponse(
             .postId(savedPost.getId())
             .writerInfo(WriterInfo.from(savedPost.getMember()))
             .content(savedPost.getContent())
-            .postImages(urlFromPostImage(savedPost))
+            .postImages(urlFromPostImage(savedPost.getPostImages()))
+            .hashtags(hashtagFromPostHashtag(savedPost.getPostHashtags()))
             .registeredAt(savedPost.getRegisteredAt())
             .build();
     }
 
-    private static List<String> urlFromPostImage(Post savedPost) {
-        return savedPost.getPostImages().stream()
+    private static List<String> urlFromPostImage(List<PostImage> postImages) {
+        return postImages.stream()
             .map(postImage -> postImage.getImage().getUrl())
+            .toList();
+    }
+
+    private static List<String> hashtagFromPostHashtag(List<PostHashtag> postHashtags) {
+        return postHashtags.stream()
+            .map(postHashtag -> postHashtag.getHashtag().getName())
             .toList();
     }
 }

--- a/src/test/java/com/example/temp/hashtag/application/HashtagServiceTest.java
+++ b/src/test/java/com/example/temp/hashtag/application/HashtagServiceTest.java
@@ -1,0 +1,73 @@
+package com.example.temp.hashtag.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.hashtag.domain.Hashtag;
+import com.example.temp.hashtag.domain.HashtagRepository;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class HashtagServiceTest {
+
+    @Autowired
+    private HashtagService hashtagService;
+
+    @Autowired
+    private HashtagRepository hashtagRepository;
+
+    @DisplayName("새로운 해시태그가 들어오면 해시태그를 저장할 수 있다.")
+    @Test
+    void saveHashtag() {
+        // given
+        List<String> names = List.of("#test1", "#test2", "#test3");
+
+        // when
+        List<Hashtag> hashtags = hashtagService.saveHashtag(names);
+
+        // then
+        assertThat(hashtags).hasSize(3)
+            .extracting("name")
+            .containsExactly("#test1", "#test2", "#test3");
+    }
+
+    @DisplayName("리스트가 비어 있는 경우 비어 있는 해시태그 리스트를 반환한다.")
+    @Test
+    void saveHashtagEmptyList() {
+        // given
+        List<String> names = Collections.emptyList();
+
+        // when
+        List<Hashtag> hashtags = hashtagService.saveHashtag(names);
+
+        // then
+        assertThat(hashtags).isEmpty();
+    }
+
+
+    @DisplayName("이미 존재하는 해시태그를 저장하는 경우 존재하는 해시태그를 반환한다.")
+    @Test
+    void saveDuplicateHashtag() {
+        // given
+        String hashtagName = "#test";
+        Hashtag existingHashtag = hashtagRepository.save(Hashtag
+            .builder()
+            .name(hashtagName)
+            .build());
+
+        List<String> names = List.of(hashtagName);
+
+        // when
+        List<Hashtag> hashtags = hashtagService.saveHashtag(names);
+
+        // then
+        assertThat(hashtags).hasSize(1);
+        assertThat(hashtags.get(0)).isEqualTo(existingHashtag);
+    }
+}

--- a/src/test/java/com/example/temp/hashtag/domain/HashtagRepositoryTest.java
+++ b/src/test/java/com/example/temp/hashtag/domain/HashtagRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.example.temp.hashtag.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class HashtagRepositoryTest {
+
+    @Autowired
+    private HashtagRepository hashtagRepository;
+
+    private Hashtag hashtag;
+
+    @BeforeEach
+    public void setup() {
+        hashtag = new Hashtag("#test");
+        hashtagRepository.save(hashtag);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        hashtagRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("저장 된 해시태그를 이름으로 찾아 올 수 있다.")
+    @Test
+    void findByNameTest() {
+        //when
+        Optional<Hashtag> result = hashtagRepository.findByName("#test");
+
+        //given, then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get().getName()).isEqualTo("#test");
+    }
+
+    @DisplayName("저장되어 있지 않은 해시태그는 찾을 수 없다.")
+    @Test
+    void findByNameNotFoundTest() {
+        //when
+        Optional<Hashtag> result = hashtagRepository.findByName("notFound");
+
+        //given, then
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/example/temp/hashtag/domain/HashtagTest.java
+++ b/src/test/java/com/example/temp/hashtag/domain/HashtagTest.java
@@ -1,0 +1,55 @@
+package com.example.temp.hashtag.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HashtagTest {
+
+    @DisplayName("해시태그는 #뒤에 한글, 영어, 숫자, '_' 기호만 올 수 있다.")
+    @Test
+    void validatePassCase() {
+        //given
+        Hashtag hashtag1 = createHashtag("#해시태그");
+        Hashtag hashtag2 = createHashtag("#hashtag");
+        Hashtag hashtag3 = createHashtag("#해시태그");
+        Hashtag hashtag4 = createHashtag("#1234");
+        Hashtag hashtag5 = createHashtag("#_해시tag123");
+        List<Hashtag> hashtags = List.of(hashtag1, hashtag2, hashtag3, hashtag4, hashtag5);
+
+        //when, then
+        assertThat(hashtags).extracting("name")
+            .containsExactly("#해시태그", "#hashtag", "#해시태그", "#1234", "#_해시tag123");
+    }
+
+    @DisplayName("해시태그는 반드시 #으로 시작해야 한다.")
+    @Test
+    void validateNotPassCase1() {
+        //when, then
+        assertThatThrownBy(() -> createHashtag("해시태그"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("지원하지 않는 해시태그 형식입니다.");
+    }
+
+    @DisplayName("해시태그에는 +, -, @ 같은 특수문자는 들어올 수 없다.")
+    @Test
+    void validateNotPassCase2() {
+        //when, then
+        assertThatThrownBy(() -> createHashtag("#해시태그+"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("지원하지 않는 해시태그 형식입니다.");
+
+        assertThatThrownBy(() -> createHashtag("#해%시태그@"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("지원하지 않는 해시태그 형식입니다.");
+    }
+
+    private Hashtag createHashtag(String name) {
+        return Hashtag.builder()
+            .name(name)
+            .build();
+    }
+}

--- a/src/test/java/com/example/temp/hashtag/domain/HashtagTest.java
+++ b/src/test/java/com/example/temp/hashtag/domain/HashtagTest.java
@@ -3,9 +3,13 @@ package com.example.temp.hashtag.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.temp.common.exception.ApiException;
+import com.example.temp.common.exception.ErrorCode;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class HashtagTest {
 
@@ -26,25 +30,22 @@ class HashtagTest {
     }
 
     @DisplayName("해시태그는 반드시 #으로 시작해야 한다.")
-    @Test
-    void validateNotPassCase1() {
+    @ParameterizedTest
+    @ValueSource(strings = {"해시태그", "hashtag", "hash#tag", "hashtag#"})
+    void validateNotPassCase1(String hashtag) {
         //when, then
-        assertThatThrownBy(() -> createHashtag("해시태그"))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("지원하지 않는 해시태그 형식입니다.");
+        assertThatThrownBy(() -> createHashtag(hashtag))
+            .isInstanceOf(ApiException.class)
+            .hasMessage(ErrorCode.HASHTAG_PATTERN_MISMATCH.getMessage());
     }
 
     @DisplayName("해시태그에는 +, -, @ 같은 특수문자는 들어올 수 없다.")
-    @Test
-    void validateNotPassCase2() {
-        //when, then
-        assertThatThrownBy(() -> createHashtag("#해시태그+"))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("지원하지 않는 해시태그 형식입니다.");
-
-        assertThatThrownBy(() -> createHashtag("#해%시태그@"))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("지원하지 않는 해시태그 형식입니다.");
+    @ParameterizedTest
+    @ValueSource(strings = {"#해시태그+", "#해%시태그@", "@@@", "ahsh2@haah"})
+    void validateNotPassCase2(String hashtag) {
+        assertThatThrownBy(() -> createHashtag(hashtag))
+            .isInstanceOf(ApiException.class)
+            .hasMessage(ErrorCode.HASHTAG_PATTERN_MISMATCH.getMessage());
     }
 
     private Hashtag createHashtag(String name) {

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -261,7 +261,7 @@ class PostServiceTest {
             .map(url -> imageRepository.findByUrl(url))
             .forEach(image -> {
                 PostImage postImage = PostImage.createPostImage(image);
-                postImage.addPost(post);
+                postImage.relate(post);
 
             });
         postRepository.save(post);

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -11,6 +11,8 @@ import com.example.temp.common.exception.ApiException;
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowRepository;
 import com.example.temp.follow.domain.FollowStatus;
+import com.example.temp.hashtag.domain.Hashtag;
+import com.example.temp.hashtag.domain.HashtagRepository;
 import com.example.temp.image.domain.Image;
 import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.member.domain.FollowStrategy;
@@ -28,6 +30,7 @@ import com.example.temp.post.dto.response.PostCreateResponse;
 import com.example.temp.post.dto.response.PostElementResponse;
 import com.example.temp.post.dto.response.WriterInfo;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,6 +55,9 @@ class PostServiceTest {
 
     @Autowired
     private ImageRepository imageRepository;
+
+    @Autowired
+    private HashtagRepository hashtagRepository;
 
     @Autowired
     private FollowRepository followRepository;
@@ -169,7 +175,10 @@ class PostServiceTest {
         UserContext userContext = UserContext.from(member);
         List<String> imageUrls = List.of("imageUrl1", "ImageUrl2");
         List<String> savedImageUrls = saveImagesAndGetUrls(imageUrls);
-        PostCreateRequest request = new PostCreateRequest("content1", savedImageUrls);
+        List<String> hashtags = List.of("#hashtag1", "#hashtag2");
+        List<String> savedHashtags = saveHashtagAndGet(hashtags);
+
+        PostCreateRequest request = new PostCreateRequest("content1", savedImageUrls, savedHashtags);
         LocalDateTime registeredAt = LocalDateTime.now();
 
         //when
@@ -182,11 +191,6 @@ class PostServiceTest {
         assertThat(response.postImages()).containsExactlyElementsOf(imageUrls);
     }
 
-    private List<String> saveImagesAndGetUrls(List<String> imageUrls) {
-        imageUrls.forEach(this::saveImage);
-        return imageUrls;
-    }
-
     @DisplayName("이미지 url로 해당 이미지를 찾지 못하면 예외를 발생시킨다.")
     @Test
     void createPostWithNonexistentImage() {
@@ -196,7 +200,7 @@ class PostServiceTest {
 
         List<String> imageUrls = List.of("nonexistent_image");
 
-        PostCreateRequest request = new PostCreateRequest("content1", imageUrls);
+        PostCreateRequest request = new PostCreateRequest("content1", imageUrls, new ArrayList<>());
 
         // When & Then
         assertThatThrownBy(() -> postService.createPost(userContext, request, LocalDateTime.now()))
@@ -210,7 +214,7 @@ class PostServiceTest {
         //given
         Member member = saveMember("email@test.com", "nick");
         UserContext userContext = UserContext.from(member);
-        PostCreateRequest postCreateRequest = new PostCreateRequest("content", null);
+        PostCreateRequest postCreateRequest = new PostCreateRequest("content", null, new ArrayList<>());
 
         //when
         PostCreateResponse postCreateResponse = postService.createPost(userContext, postCreateRequest,
@@ -263,8 +267,25 @@ class PostServiceTest {
         postRepository.save(post);
     }
 
+    private List<String> saveImagesAndGetUrls(List<String> imageUrls) {
+        imageUrls.forEach(this::saveImage);
+        return imageUrls;
+    }
+
+    private List<String> saveHashtagAndGet(List<String> names) {
+        names.forEach(this::saveHashtag);
+        return names;
+    }
+
     private void saveImage(String url) {
         Image image = Image.create(url);
         imageRepository.save(image);
+    }
+
+    private void saveHashtag(String name) {
+        Hashtag hashtag = Hashtag.builder()
+            .name(name)
+            .build();
+        hashtagRepository.save(hashtag);
     }
 }

--- a/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
@@ -163,7 +163,7 @@ class PostRepositoryTest {
             .forEach(image -> {
                 image.use();
                 PostImage postImage = PostImage.createPostImage(image);
-                postImage.addPost(post);
+                postImage.relate(post);
 
             });
         postRepository.save(post);

--- a/src/test/java/com/example/temp/post/domain/PostTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostTest.java
@@ -48,7 +48,7 @@ class PostTest {
             .map(url -> {
                 Image image = Image.create(url);
                 PostImage postImage = PostImage.createPostImage(image);
-                postImage.addPost(post);
+                postImage.relate(post);
                 return postImage;
             })
             .toList();


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] Hashtag 엔티티 추가
- [X] Post, Hashtag 매핑 테이블인 PostHashtag 엔티티 추가
- [X] hashtag 이미 존재하는 해시태그 저장시 해당 해시 태그 반환
- [X] 게시글 작성 시 해시태그 저장 및 PostHashtag에 저장

## 🏌🏻 리뷰 포인트
해시태그 부분을 처음에는 해시태그 검색 부분이 후 순위로 밀려있어서 고려하지 못하고 있다가 작성 시 해시태그가 필요한 걸 느끼고 해시태그 부분을 추가했습니다. 현재는 저장하고 해당 해시태그가 있는지 조회하는 로직만 추가 되었고 추후 해시태그로 게시글 검색 관련 기능을 추가할 때 나머지 기능을 추가할 예정입니다.

이전 게시글 이미지 작업부터 양방향 연관관계를 이용하는 작업이 생겨 현재 해당 코드가 잘 작성된건지에 대한 의문이 조금은 들고 있어서 해당 부분을 리뷰해주시고 의아한 부분이 있으시면 말씀해 주시면 감사하겠습니다.

## 🧘🏻 기타 사항

close #78