### PR TITLE
[#87] HttpMessageNotReadableException 발생 시 클라이언트에게 메세지 보여주기

### DIFF
--- a/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.example.temp.member.exception.NicknameDuplicatedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -34,6 +35,13 @@ public class GlobalExceptionHandler {
             .body(ErrorResponse.create(
                 String.format("'%s'의 타입이 잘못되었습니다.", exception.getParameter().getParameterName())));
     }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.create("요청보내신 바디의 형태가 잘못되었습니다."));
+    }
+
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] HttpMessageNotReadableException 발생 시 클라이언트에게 메세지 보여주기

이런 오류가 날 수도 있군요. 처음 봤는데 ExceptionHandler 템플릿에 추가해야겠어요
## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
없습니다.

close #87 