### PR TITLE
[#94] 팔로우, 팔로잉 목록 조회 무한스크롤로 변경

### DIFF
--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -12,6 +12,7 @@ import com.example.temp.follow.domain.Follow;
 import com.example.temp.follow.domain.FollowRepository;
 import com.example.temp.follow.domain.FollowStatus;
 import com.example.temp.follow.dto.response.FollowInfo;
+import com.example.temp.follow.dto.response.FollowInfoResult;
 import com.example.temp.follow.dto.response.FollowResponse;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
@@ -20,6 +21,8 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,18 +39,19 @@ public class FollowService {
      *
      * @param userContext 로그인한 사용자의 정보
      * @param targetId    팔로잉 목록을 보려고 하는 대상의 ID
+     * @param pageable
      * @return FollowInfo 객체 리스트를 반환합니다. 각 FollowInfo 객체는 팔로잉 대상의 정보와 팔로우 ID를 포함하고 있습니다.
      * @throws ApiException AUTHORIZED_FAIL: 팔로잉 목록을 볼 권한이 없을 때 발생합니다.
      */
-    public List<FollowInfo> getFollowings(UserContext userContext, long targetId) {
+    public FollowInfoResult getFollowings(UserContext userContext, long targetId, Pageable pageable) {
         Member target = memberRepository.findById(targetId)
             .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
         if (!target.isPublicAccount()) {
             validateViewAuthorization(targetId, userContext.id());
         }
-        return followRepository.findAllByFromIdAndStatus(targetId, FollowStatus.APPROVED).stream()
-            .map(follow -> FollowInfo.of(follow.getTo(), follow.getId()))
-            .toList();
+        Slice<Follow> follows = followRepository.findAllByFromIdAndStatus(targetId, FollowStatus.APPROVED,
+            pageable);
+        return FollowInfoResult.from(follows);
     }
 
     /**
@@ -55,16 +59,17 @@ public class FollowService {
      *
      * @param userContext 로그인한 사용자의 정보
      * @param targetId    팔로워 목록을 보려고 하는 대상의 ID
+     * @param pageable
      * @return FollowInfo 객체 리스트를 반환합니다. 각 FollowInfo 객체는 팔로워 대상의 정보와 팔로우 ID를 포함하고 있습니다.
      * @throws ApiException AUTHORIZED_FAIL: 팔로워 목록을 볼 권한이 없을 때 발생합니다.
      */
-    public List<FollowInfo> getFollowers(UserContext userContext, long targetId) {
+    public List<FollowInfo> getFollowers(UserContext userContext, long targetId, Pageable pageable) {
         Member target = memberRepository.findById(targetId)
             .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
         if (!target.isPublicAccount()) {
             validateViewAuthorization(targetId, userContext.id());
         }
-        return followRepository.findAllByToIdAndStatus(targetId, FollowStatus.APPROVED).stream()
+        return followRepository.findAllByToIdAndStatus(targetId, FollowStatus.APPROVED, pageable).stream()
             .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
             .toList();
     }

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -39,18 +39,19 @@ public class FollowService {
      *
      * @param userContext 로그인한 사용자의 정보
      * @param targetId    팔로잉 목록을 보려고 하는 대상의 ID
+     * @param lastId      이전에 조회했던 마지막 팔로우 엔티티의 아이디
      * @param pageable
      * @return FollowInfo 객체 리스트를 반환합니다. 각 FollowInfo 객체는 팔로잉 대상의 정보와 팔로우 ID를 포함하고 있습니다.
      * @throws ApiException AUTHORIZED_FAIL: 팔로잉 목록을 볼 권한이 없을 때 발생합니다.
      */
-    public FollowInfoResult getFollowings(UserContext userContext, long targetId, Pageable pageable) {
+    public FollowInfoResult getFollowings(UserContext userContext, Long targetId, long lastId, Pageable pageable) {
         Member target = memberRepository.findById(targetId)
             .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
         if (!target.isPublicAccount()) {
             validateViewAuthorization(targetId, userContext.id());
         }
         Slice<Follow> follows = followRepository.findAllByFromIdAndStatus(targetId, FollowStatus.APPROVED,
-            pageable);
+            lastId, pageable);
         return FollowInfoResult.createFollowingsResult(follows);
     }
 
@@ -60,18 +61,19 @@ public class FollowService {
      *
      * @param userContext 로그인한 사용자의 정보
      * @param targetId    팔로워 목록을 보려고 하는 대상의 ID
+     * @param lastId      이전에 조회했던 마지막 팔로우 엔티티의 아이디
      * @param pageable
      * @return FollowInfo 객체 리스트를 반환합니다. 각 FollowInfo 객체는 팔로워 대상의 정보와 팔로우 ID를 포함하고 있습니다.
      * @throws ApiException AUTHORIZED_FAIL: 팔로워 목록을 볼 권한이 없을 때 발생합니다.
      */
-    public FollowInfoResult getFollowers(UserContext userContext, long targetId, Pageable pageable) {
+    public FollowInfoResult getFollowers(UserContext userContext, long targetId, long lastId, Pageable pageable) {
         Member target = memberRepository.findById(targetId)
             .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
         if (!target.isPublicAccount()) {
             validateViewAuthorization(targetId, userContext.id());
         }
-        Slice<Follow> follows = followRepository.findAllByToIdAndStatus(targetId, FollowStatus.APPROVED,
-            pageable);
+        Slice<Follow> follows = followRepository.findAllByToIdAndStatus(targetId,
+            FollowStatus.APPROVED, lastId, pageable);
         return FollowInfoResult.createFollowersResult(follows);
     }
 

--- a/src/main/java/com/example/temp/follow/domain/Follow.java
+++ b/src/main/java/com/example/temp/follow/domain/Follow.java
@@ -35,14 +35,15 @@ public class Follow {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "from_id")
+    @JoinColumn(name = "from_id", nullable = false)
     private Member from;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "to_id")
+    @JoinColumn(name = "to_id", nullable = false)
     private Member to;
 
     @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
     private FollowStatus status;
 
     @Builder

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -2,6 +2,8 @@ package com.example.temp.follow.domain;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +16,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     @Query("SELECT f FROM Follow f JOIN FETCH f.to WHERE f.from.id = :fromId AND f.status = :status")
     List<Follow> findAllByFromIdAndStatus(@Param("fromId") long fromId, @Param("status") FollowStatus status);
+
+    @Query("SELECT f FROM Follow f JOIN FETCH f.to WHERE f.from.id = :fromId AND f.status = :status")
+    Slice<Follow> findAllByFromIdAndStatus(@Param("fromId") long fromId,
+        @Param("status") FollowStatus status, Pageable pageable);
 
     @Query("SELECT f FROM Follow f JOIN FETCH f.from WHERE f.to.id = :toId AND f.status = :status")
     List<Follow> findAllByToIdAndStatus(@Param("toId") long toId, @Param("status") FollowStatus status);

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -17,16 +17,44 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     @Query("SELECT f FROM Follow f JOIN FETCH f.to WHERE f.from.id = :fromId AND f.status = :status")
     List<Follow> findAllByFromIdAndStatus(@Param("fromId") long fromId, @Param("status") FollowStatus status);
 
-    @Query("SELECT f FROM Follow f JOIN FETCH f.to WHERE f.from.id = :fromId AND f.status = :status")
+    /**
+     * fromId와 status를 사용해 pageable.size만큼 팔로우 엔티티를 가져옵니다. 커서 기반 페이징을 지원하기 위한 메서드입니다.
+     *
+     * @param fromId
+     * @param status
+     * @param lastId   입력된 lastId보다 id가 큰 Follow만 조회가 가능합니다.
+     * @param pageable page는 0이어야 합니다.(PageRequest.ofSize를 사용해 객체를 만들어주세요)
+     */
+    @Query("SELECT f FROM Follow f JOIN FETCH f.to "
+        + "WHERE f.from.id = :fromId "
+        + "AND f.status = :status "
+        + "AND f.id > :lastId "
+        + "ORDER BY f.id ASC")
     Slice<Follow> findAllByFromIdAndStatus(@Param("fromId") long fromId,
-        @Param("status") FollowStatus status, Pageable pageable);
+        @Param("status") FollowStatus status,
+        @Param("lastId") long lastId,
+        Pageable pageable);
 
     @Query("SELECT f FROM Follow f JOIN FETCH f.from WHERE f.to.id = :toId AND f.status = :status")
     List<Follow> findAllByToIdAndStatus(@Param("toId") long toId, @Param("status") FollowStatus status);
 
-    @Query("SELECT f FROM Follow f JOIN FETCH f.from WHERE f.to.id = :toId AND f.status = :status")
+    /**
+     * toId와 status를 사용해 pageable.size만큼 팔로우 엔티티를 가져옵니다. 커서 기반 페이징을 지원하기 위한 메서드입니다.
+     *
+     * @param toId
+     * @param status
+     * @param lastId   입력된 lastId보다 id가 큰 Follow만 조회가 가능합니다.
+     * @param pageable page는 0이어야 합니다.(PageRequest.ofSize를 사용해 객체를 만들어주세요)
+     */
+    @Query("SELECT f FROM Follow f JOIN FETCH f.from "
+        + "WHERE f.to.id = :toId "
+        + "AND f.status = :status "
+        + "AND f.id > :lastId "
+        + "ORDER BY f.id ASC")
     Slice<Follow> findAllByToIdAndStatus(@Param("toId") long toId,
-        @Param("status") FollowStatus status, Pageable pageable);
+        @Param("status") FollowStatus status,
+        @Param("lastId") long lastId,
+        Pageable pageable);
 
 
     @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END FROM Follow f"

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -24,6 +24,11 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     @Query("SELECT f FROM Follow f JOIN FETCH f.from WHERE f.to.id = :toId AND f.status = :status")
     List<Follow> findAllByToIdAndStatus(@Param("toId") long toId, @Param("status") FollowStatus status);
 
+    @Query("SELECT f FROM Follow f JOIN FETCH f.from WHERE f.to.id = :toId AND f.status = :status")
+    Slice<Follow> findAllByToIdAndStatus(@Param("toId") long toId,
+        @Param("status") FollowStatus status, Pageable pageable);
+
+
     @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END FROM Follow f"
         + " WHERE f.from.id = :executorId AND f.to.id = :targetId AND f.status = 'APPROVED'")
     boolean checkExecutorFollowsTarget(@Param("executorId") long executorId, @Param("targetId") long targetId);

--- a/src/main/java/com/example/temp/follow/dto/response/FollowInfoResult.java
+++ b/src/main/java/com/example/temp/follow/dto/response/FollowInfoResult.java
@@ -9,9 +9,29 @@ public record FollowInfoResult(
     boolean hasNext
 ) {
 
-    public static FollowInfoResult from(Slice<Follow> follows) {
+    /**
+     * 특정 사용자가 팔로우 하고 있는(... -> To) 사용자들과 hasNext
+     *
+     * @param follows
+     * @return
+     */
+    public static FollowInfoResult createFollowingsResult(Slice<Follow> follows) {
         List<FollowInfo> followInfos = follows.stream()
             .map(follow -> FollowInfo.of(follow.getTo(), follow.getId()))
+            .toList();
+        boolean hasNext = follows.hasNext();
+        return new FollowInfoResult(followInfos, hasNext);
+    }
+
+    /**
+     * 특정 사용자를 팔로우 하고 있는(from -> ...) 사용자들을 꺼냅니다.
+     *
+     * @param follows
+     * @return
+     */
+    public static FollowInfoResult createFollowersResult(Slice<Follow> follows) {
+        List<FollowInfo> followInfos = follows.stream()
+            .map(follow -> FollowInfo.of(follow.getFrom(), follow.getId()))
             .toList();
         boolean hasNext = follows.hasNext();
         return new FollowInfoResult(followInfos, hasNext);

--- a/src/main/java/com/example/temp/follow/dto/response/FollowInfoResult.java
+++ b/src/main/java/com/example/temp/follow/dto/response/FollowInfoResult.java
@@ -1,0 +1,19 @@
+package com.example.temp.follow.dto.response;
+
+import com.example.temp.follow.domain.Follow;
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record FollowInfoResult(
+    List<FollowInfo> followInfos,
+    boolean hasNext
+) {
+
+    public static FollowInfoResult from(Slice<Follow> follows) {
+        List<FollowInfo> followInfos = follows.stream()
+            .map(follow -> FollowInfo.of(follow.getTo(), follow.getId()))
+            .toList();
+        boolean hasNext = follows.hasNext();
+        return new FollowInfoResult(followInfos, hasNext);
+    }
+}

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -4,15 +4,18 @@ import com.example.temp.common.annotation.Login;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.follow.application.FollowService;
 import com.example.temp.follow.dto.response.FollowInfo;
+import com.example.temp.follow.dto.response.FollowInfoResult;
 import com.example.temp.follow.dto.response.FollowInfos;
 import com.example.temp.follow.dto.response.FollowResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,9 +25,10 @@ public class FollowController {
     private final FollowService followService;
 
     @GetMapping("/members/{memberId}/followings")
-    public ResponseEntity<FollowInfos> getFollowings(@Login UserContext userContext, @PathVariable Long memberId) {
-        List<FollowInfo> followInfos = followService.getFollowings(userContext, memberId);
-        return ResponseEntity.ok(FollowInfos.from(followInfos));
+    public ResponseEntity<FollowInfoResult> getFollowings(@Login UserContext userContext, @PathVariable Long memberId,
+        @RequestParam Pageable pageable) {
+        FollowInfoResult result = followService.getFollowings(userContext, memberId, pageable);
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/members/{memberId}/followers")

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -3,11 +3,8 @@ package com.example.temp.follow.presentation;
 import com.example.temp.common.annotation.Login;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.follow.application.FollowService;
-import com.example.temp.follow.dto.response.FollowInfo;
 import com.example.temp.follow.dto.response.FollowInfoResult;
-import com.example.temp.follow.dto.response.FollowInfos;
 import com.example.temp.follow.dto.response.FollowResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -32,9 +29,10 @@ public class FollowController {
     }
 
     @GetMapping("/members/{memberId}/followers")
-    public ResponseEntity<FollowInfos> getFollowers(@Login UserContext userContext, @PathVariable Long memberId) {
-        List<FollowInfo> followInfos = followService.getFollowers(userContext, memberId);
-        return ResponseEntity.ok(FollowInfos.from(followInfos));
+    public ResponseEntity<FollowInfoResult> getFollowers(@Login UserContext userContext, @PathVariable Long memberId,
+        @RequestParam Pageable pageable) {
+        FollowInfoResult result = followService.getFollowers(userContext, memberId, pageable);
+        return ResponseEntity.ok(result);
     }
 
     @PostMapping("/members/{memberId}/follow")

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -6,7 +6,7 @@ import com.example.temp.follow.application.FollowService;
 import com.example.temp.follow.dto.response.FollowInfoResult;
 import com.example.temp.follow.dto.response.FollowResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,15 +23,15 @@ public class FollowController {
 
     @GetMapping("/members/{memberId}/followings")
     public ResponseEntity<FollowInfoResult> getFollowings(@Login UserContext userContext, @PathVariable Long memberId,
-        @RequestParam Pageable pageable) {
-        FollowInfoResult result = followService.getFollowings(userContext, memberId, pageable);
+        @RequestParam(defaultValue = "-1") Long lastId, @RequestParam int size) {
+        FollowInfoResult result = followService.getFollowings(userContext, memberId, lastId, PageRequest.ofSize(size));
         return ResponseEntity.ok(result);
     }
 
     @GetMapping("/members/{memberId}/followers")
     public ResponseEntity<FollowInfoResult> getFollowers(@Login UserContext userContext, @PathVariable Long memberId,
-        @RequestParam Pageable pageable) {
-        FollowInfoResult result = followService.getFollowers(userContext, memberId, pageable);
+        @RequestParam(defaultValue = "-1") Long lastId, @RequestParam int size) {
+        FollowInfoResult result = followService.getFollowers(userContext, memberId, lastId, PageRequest.ofSize(size));
         return ResponseEntity.ok(result);
     }
 

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -311,7 +311,7 @@ class FollowServiceTest {
             .toList();
 
         // when
-        FollowInfoResult result = followService.getFollowings(UserContext.from(target), target.getId(), pageable);
+        FollowInfoResult result = followService.getFollowings(UserContext.from(target), target.getId(), -1, pageable);
 
         // then
         List<FollowInfo> infos = result.followInfos();
@@ -342,7 +342,7 @@ class FollowServiceTest {
         saveTargetFollowings(FollowStatus.APPROVED, target, members, idx, approvedCnt);
 
         // when
-        FollowInfoResult result = followService.getFollowings(UserContext.from(target), target.getId(), pageable);
+        FollowInfoResult result = followService.getFollowings(UserContext.from(target), target.getId(), -1, pageable);
 
         // then
         assertThat(result.followInfos()).hasSize(approvedCnt);
@@ -359,7 +359,8 @@ class FollowServiceTest {
 
         // when & then
         assertDoesNotThrow(
-            () -> followService.getFollowings(UserContext.from(anotherMember), publicAccountMember.getId(), pageable));
+            () -> followService.getFollowings(UserContext.from(anotherMember), publicAccountMember.getId(), -1,
+                pageable));
     }
 
     @Test
@@ -370,7 +371,7 @@ class FollowServiceTest {
         Member member = saveMember();
 
         // when
-        FollowInfoResult result = followService.getFollowings(UserContext.from(member), member.getId(), pageable);
+        FollowInfoResult result = followService.getFollowings(UserContext.from(member), member.getId(), -1, pageable);
 
         // then
         assertThat(result.hasNext()).isFalse();
@@ -388,7 +389,7 @@ class FollowServiceTest {
         saveFollow(member, other2, FollowStatus.APPROVED);
 
         // when
-        FollowInfoResult result = followService.getFollowings(UserContext.from(member), member.getId(), pageable);
+        FollowInfoResult result = followService.getFollowings(UserContext.from(member), member.getId(), -1, pageable);
 
         // then
         assertThat(result.hasNext()).isTrue();
@@ -406,7 +407,7 @@ class FollowServiceTest {
 
         // when & then
         assertDoesNotThrow(
-            () -> followService.getFollowings(UserContext.from(anotherMember), privateMember.getId(), pageable));
+            () -> followService.getFollowings(UserContext.from(anotherMember), privateMember.getId(), -1, pageable));
     }
 
     @Test
@@ -421,7 +422,7 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(
-            () -> followService.getFollowings(UserContext.from(anotherMember), privateMember.getId(), pageable))
+            () -> followService.getFollowings(UserContext.from(anotherMember), privateMember.getId(), -1, pageable))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }
@@ -443,7 +444,7 @@ class FollowServiceTest {
         em.clear();
 
         // when
-        FollowInfoResult result = followService.getFollowers(UserContext.from(target), target.getId(), pageable);
+        FollowInfoResult result = followService.getFollowers(UserContext.from(target), target.getId(), -1, pageable);
 
         // then
         List<FollowInfo> infos = result.followInfos();
@@ -475,7 +476,7 @@ class FollowServiceTest {
         saveTargetFollowers(FollowStatus.APPROVED, target, members, idx, approvedCnt);
 
         // when
-        FollowInfoResult result = followService.getFollowers(UserContext.from(target), target.getId(), pageable);
+        FollowInfoResult result = followService.getFollowers(UserContext.from(target), target.getId(), -1, pageable);
 
         // then
         assertThat(result.followInfos()).hasSize(approvedCnt);
@@ -492,7 +493,8 @@ class FollowServiceTest {
 
         // when & then
         assertDoesNotThrow(
-            () -> followService.getFollowers(UserContext.from(anotherMember), publicAccountMember.getId(), pageable));
+            () -> followService.getFollowers(UserContext.from(anotherMember), publicAccountMember.getId(), -1,
+                pageable));
     }
 
     @Test
@@ -506,7 +508,7 @@ class FollowServiceTest {
         saveFollow(anotherMember, privateMember, FollowStatus.APPROVED);
 
         // when & then
-        assertDoesNotThrow(() -> followService.getFollowers(UserContext.from(anotherMember), privateMember.getId(),
+        assertDoesNotThrow(() -> followService.getFollowers(UserContext.from(anotherMember), privateMember.getId(), -1,
             pageable));
     }
 
@@ -518,7 +520,7 @@ class FollowServiceTest {
         Member member = saveMember();
 
         // when
-        FollowInfoResult result = followService.getFollowers(UserContext.from(member), member.getId(), pageable);
+        FollowInfoResult result = followService.getFollowers(UserContext.from(member), member.getId(), -1, pageable);
 
         // then
         assertThat(result.hasNext()).isFalse();
@@ -536,7 +538,7 @@ class FollowServiceTest {
         saveFollow(other2, member, FollowStatus.APPROVED);
 
         // when
-        FollowInfoResult result = followService.getFollowers(UserContext.from(member), member.getId(), pageable);
+        FollowInfoResult result = followService.getFollowers(UserContext.from(member), member.getId(), -1, pageable);
 
         // then
         assertThat(result.hasNext()).isTrue();
@@ -554,7 +556,7 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.getFollowers(UserContext.from(anotherMember), privateMember.getId(),
-            pageable))
+            -1, pageable))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -39,10 +39,7 @@ class FollowRepositoryTest {
         Member fromMember = saveMember();
         Member toMember = saveMember();
 
-        Follow follow = Follow.builder()
-            .from(fromMember)
-            .to(toMember)
-            .build();
+        Follow follow = saveFollow(fromMember, toMember);
         em.persist(follow);
 
         // when
@@ -60,12 +57,7 @@ class FollowRepositoryTest {
         // given
         Member fromMember = saveMember();
         Member toMember = saveMember();
-
-        Follow follow = Follow.builder()
-            .from(fromMember)
-            .to(toMember)
-            .build();
-        em.persist(follow);
+        saveFollow(fromMember, toMember);
 
         // when
         Optional<Follow> resultOpt = followRepository.findByFromIdAndToId(fromMember.getId(), notExistId);
@@ -80,13 +72,7 @@ class FollowRepositoryTest {
         // given
         Member executor = saveMember();
         Member target = saveMember();
-
-        Follow follow = Follow.builder()
-            .from(executor)
-            .to(target)
-            .status(FollowStatus.APPROVED)
-            .build();
-        em.persist(follow);
+        saveFollow(executor, target);
 
         // when
         boolean result = followRepository.checkExecutorFollowsTarget(executor.getId(), target.getId());
@@ -98,17 +84,11 @@ class FollowRepositoryTest {
     @ParameterizedTest
     @DisplayName("executor가 target에 대해 팔로우가 SUCCESS 이외의 상태라면 false를 반환한다")
     @ValueSource(strings = {"PENDING", "REJECTED", "CANCELED"})
-    void checkExecutorFollowTargetFalse1(String statusStr) throws Exception {
+    void checkExecutorFollowTargetFalse1(String statusValue) throws Exception {
         // given
         Member executor = saveMember();
         Member target = saveMember();
-
-        Follow follow = Follow.builder()
-            .from(executor)
-            .to(target)
-            .status(FollowStatus.valueOf(statusStr))
-            .build();
-        em.persist(follow);
+        saveFollow(executor, target, FollowStatus.valueOf(statusValue));
 
         // when
         boolean result = followRepository.checkExecutorFollowsTarget(executor.getId(), target.getId());
@@ -125,12 +105,7 @@ class FollowRepositoryTest {
         Member target = saveMember();
         Member anotherMember = saveMember();
 
-        Follow follow = Follow.builder()
-            .from(executor)
-            .to(anotherMember)
-            .status(FollowStatus.APPROVED)
-            .build();
-        em.persist(follow);
+        saveFollow(executor, anotherMember);
 
         // when
         boolean result = followRepository.checkExecutorFollowsTarget(executor.getId(), target.getId());
@@ -217,10 +192,16 @@ class FollowRepositoryTest {
             .contains(related1, related2);
     }
 
-    private Follow saveFollow(Member fromMember, Member toMember1, FollowStatus status) {
+
+    private Follow saveFollow(Member fromMember, Member toMember) {
+        return saveFollow(fromMember, toMember, FollowStatus.APPROVED);
+    }
+
+
+    private Follow saveFollow(Member fromMember, Member toMember, FollowStatus status) {
         Follow follow = Follow.builder()
             .from(fromMember)
-            .to(toMember1)
+            .to(toMember)
             .status(status)
             .build();
         em.persist(follow);

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -148,11 +148,11 @@ class FollowRepositoryTest {
 
         // when
         Slice<Follow> result = followRepository.findAllByFromIdAndStatus(fromMember.getId(), targetStatus,
-            PageRequest.of(0, 1));
+            PageRequest.of(0, 10));
 
         // then
-        assertThat(result).hasSize(1)
-            .contains(follow1);
+        assertThat(result).hasSize(2)
+            .containsExactly(follow1, follow2);
     }
 
     @Test
@@ -174,7 +174,7 @@ class FollowRepositoryTest {
     }
 
     @Test
-    @DisplayName("팔로우 페이지 요청시, 페이지 구간에 포함되지 않은 값은 결과에 포함되지 않는다.")
+    @DisplayName("fromId를 사용해 팔로우 페이지 요청시, 페이지 구간에 포함되지 않은 값은 결과에 포함되지 않는다.")
     void findAllByFromIdAndStatusUsingPageNotIn() throws Exception {
         // given
         Member fromMember = saveMember();
@@ -188,6 +188,66 @@ class FollowRepositoryTest {
 
         // when
         Slice<Follow> result = followRepository.findAllByFromIdAndStatus(fromMember.getId(), targetStatus,
+            PageRequest.of(1, 2));
+
+        // then
+        assertThat(result).hasSize(1)
+            .containsExactly(follow);
+    }
+
+    @Test
+    @DisplayName("toId와 status가 일치하는 Follow 페이지 목록을 조회한다")
+    void findAllByToIdAndStatusUsingPage() throws Exception {
+        // given
+        Member fromMember1 = saveMember();
+        Member fromMember2 = saveMember();
+        Member toMember = saveMember();
+        FollowStatus targetStatus = FollowStatus.PENDING;
+        Follow follow1 = saveFollow(fromMember1, toMember, targetStatus);
+        Follow follow2 = saveFollow(fromMember2, toMember, targetStatus);
+
+        // when
+        Slice<Follow> result = followRepository.findAllByToIdAndStatus(toMember.getId(), targetStatus,
+            PageRequest.of(0, 10));
+
+        // then
+        assertThat(result).hasSize(2)
+            .containsExactly(follow1, follow2);
+    }
+
+    @Test
+    @DisplayName("페이지 요청 시, 일치하는 toId와 status가 없으면 비어있는 결과를 반환한다.")
+    void findAllByToIdAndStatusUsingPageWhenEmpty() throws Exception {
+        // given
+        Member target = saveMember();
+        FollowStatus targetStatus = FollowStatus.PENDING;
+        Member fromMember = saveMember();
+        Member toMember = saveMember();
+        saveFollow(fromMember, toMember, targetStatus);
+
+        // when
+        Slice<Follow> result = followRepository.findAllByToIdAndStatus(target.getId(), targetStatus,
+            PageRequest.of(0, 10));
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toId를 사용해 팔로우 페이지 요청시, 페이지 구간에 포함되지 않은 값은 결과에 포함되지 않는다.")
+    void findAllByToIdAndStatusUsingPageNotIn() throws Exception {
+        // given
+        Member fromMember1 = saveMember();
+        Member fromMember2 = saveMember();
+        Member fromMember3 = saveMember();
+        Member toMember = saveMember();
+        FollowStatus targetStatus = FollowStatus.PENDING;
+        saveFollow(fromMember1, toMember, targetStatus);
+        saveFollow(fromMember2, toMember, targetStatus);
+        Follow follow = saveFollow(fromMember3, toMember, targetStatus);
+
+        // when
+        Slice<Follow> result = followRepository.findAllByToIdAndStatus(toMember.getId(), targetStatus,
             PageRequest.of(1, 2));
 
         // then

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -146,12 +147,13 @@ class FollowRepositoryTest {
         Follow follow1 = saveFollow(fromMember, toMember1, targetStatus);
         Follow follow2 = saveFollow(fromMember, toMember2, targetStatus);
 
+        Pageable pageable = PageRequest.ofSize(2);
         // when
-        Slice<Follow> result = followRepository.findAllByFromIdAndStatus(fromMember.getId(), targetStatus,
-            PageRequest.of(0, 10));
+        Slice<Follow> result = followRepository.findAllByFromIdAndStatus(
+            fromMember.getId(), targetStatus, -1, pageable);
 
         // then
-        assertThat(result).hasSize(2)
+        assertThat(result).hasSize((int) pageable.getPageSize())
             .containsExactly(follow1, follow2);
     }
 
@@ -165,9 +167,11 @@ class FollowRepositoryTest {
         FollowStatus targetStatus = FollowStatus.PENDING;
         saveFollow(fromMember, toMember, targetStatus);
 
+        Pageable pageable = PageRequest.ofSize(2);
+
         // when
         Slice<Follow> result = followRepository.findAllByFromIdAndStatus(target.getId(), targetStatus,
-            PageRequest.of(0, 10));
+            -1, pageable);
 
         // then
         assertThat(result).isEmpty();
@@ -180,19 +184,19 @@ class FollowRepositoryTest {
         Member fromMember = saveMember();
         Member toMember1 = saveMember();
         Member toMember2 = saveMember();
-        Member toMember3 = saveMember();
         FollowStatus targetStatus = FollowStatus.PENDING;
+
         saveFollow(fromMember, toMember1, targetStatus);
-        saveFollow(fromMember, toMember2, targetStatus);
-        Follow follow = saveFollow(fromMember, toMember3, targetStatus);
+        Follow follow = saveFollow(fromMember, toMember2, targetStatus);
+
+        Pageable pageable = PageRequest.ofSize(2);
 
         // when
         Slice<Follow> result = followRepository.findAllByFromIdAndStatus(fromMember.getId(), targetStatus,
-            PageRequest.of(1, 2));
+            follow.getId(), pageable);
 
         // then
-        assertThat(result).hasSize(1)
-            .containsExactly(follow);
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -206,9 +210,11 @@ class FollowRepositoryTest {
         Follow follow1 = saveFollow(fromMember1, toMember, targetStatus);
         Follow follow2 = saveFollow(fromMember2, toMember, targetStatus);
 
+        Pageable pageable = PageRequest.ofSize(2);
+
         // when
-        Slice<Follow> result = followRepository.findAllByToIdAndStatus(toMember.getId(), targetStatus,
-            PageRequest.of(0, 10));
+        Slice<Follow> result = followRepository.findAllByToIdAndStatus(
+            toMember.getId(), targetStatus, -1, pageable);
 
         // then
         assertThat(result).hasSize(2)
@@ -220,14 +226,17 @@ class FollowRepositoryTest {
     void findAllByToIdAndStatusUsingPageWhenEmpty() throws Exception {
         // given
         Member target = saveMember();
-        FollowStatus targetStatus = FollowStatus.PENDING;
         Member fromMember = saveMember();
         Member toMember = saveMember();
+
+        FollowStatus targetStatus = FollowStatus.PENDING;
         saveFollow(fromMember, toMember, targetStatus);
 
+        Pageable pageable = PageRequest.ofSize(2);
+
         // when
-        Slice<Follow> result = followRepository.findAllByToIdAndStatus(target.getId(), targetStatus,
-            PageRequest.of(0, 10));
+        Slice<Follow> result = followRepository.findAllByToIdAndStatus(
+            target.getId(), targetStatus, -1, pageable);
 
         // then
         assertThat(result).isEmpty();
@@ -239,20 +248,19 @@ class FollowRepositoryTest {
         // given
         Member fromMember1 = saveMember();
         Member fromMember2 = saveMember();
-        Member fromMember3 = saveMember();
         Member toMember = saveMember();
         FollowStatus targetStatus = FollowStatus.PENDING;
         saveFollow(fromMember1, toMember, targetStatus);
-        saveFollow(fromMember2, toMember, targetStatus);
-        Follow follow = saveFollow(fromMember3, toMember, targetStatus);
+        Follow follow = saveFollow(fromMember2, toMember, targetStatus);
+
+        Pageable pageable = PageRequest.ofSize(2);
 
         // when
         Slice<Follow> result = followRepository.findAllByToIdAndStatus(toMember.getId(), targetStatus,
-            PageRequest.of(1, 2));
+            follow.getId(), pageable);
 
         // then
-        assertThat(result).hasSize(1)
-            .containsExactly(follow);
+        assertThat(result).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/example/temp/follow/dto/response/FollowInfoResultTest.java
+++ b/src/test/java/com/example/temp/follow/dto/response/FollowInfoResultTest.java
@@ -1,0 +1,42 @@
+package com.example.temp.follow.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.follow.domain.Follow;
+import com.example.temp.member.domain.Member;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+class FollowInfoResultTest {
+
+    @Test
+    @DisplayName("생성 테스트")
+    void create() throws Exception {
+        // given
+        Member member1 = Member.builder().build();
+        Member member2 = Member.builder().build();
+
+        Follow follow1 = createFollow(member1, member2);
+        Follow follow2 = createFollow(member2, member1);
+
+        Slice<Follow> slice = new SliceImpl<>(List.of(follow1, follow2));
+
+        // when
+        FollowInfoResult result = FollowInfoResult.from(slice);
+
+        // then
+        assertThat(result.followInfos()).hasSize(2);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    private static Follow createFollow(Member member1, Member member2) {
+        return Follow.builder()
+            .from(member1)
+            .to(member2)
+            .build();
+    }
+
+}

--- a/src/test/java/com/example/temp/follow/dto/response/FollowInfoResultTest.java
+++ b/src/test/java/com/example/temp/follow/dto/response/FollowInfoResultTest.java
@@ -13,8 +13,8 @@ import org.springframework.data.domain.SliceImpl;
 class FollowInfoResultTest {
 
     @Test
-    @DisplayName("생성 테스트")
-    void create() throws Exception {
+    @DisplayName("Following 목록 생성 테스트")
+    void createFollowings() throws Exception {
         // given
         Member member1 = Member.builder().build();
         Member member2 = Member.builder().build();
@@ -25,7 +25,27 @@ class FollowInfoResultTest {
         Slice<Follow> slice = new SliceImpl<>(List.of(follow1, follow2));
 
         // when
-        FollowInfoResult result = FollowInfoResult.from(slice);
+        FollowInfoResult result = FollowInfoResult.createFollowingsResult(slice);
+
+        // then
+        assertThat(result.followInfos()).hasSize(2);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Follower 목록 생성 테스트")
+    void createFollowers() throws Exception {
+        // given
+        Member member1 = Member.builder().build();
+        Member member2 = Member.builder().build();
+
+        Follow follow1 = createFollow(member1, member2);
+        Follow follow2 = createFollow(member2, member1);
+
+        Slice<Follow> slice = new SliceImpl<>(List.of(follow1, follow2));
+
+        // when
+        FollowInfoResult result = FollowInfoResult.createFollowersResult(slice);
 
         // then
         assertThat(result.followInfos()).hasSize(2);

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -14,6 +14,7 @@ import com.example.temp.common.entity.Email;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.follow.domain.Follow;
+import com.example.temp.follow.domain.FollowStatus;
 import com.example.temp.image.domain.Image;
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
@@ -311,6 +312,7 @@ class MemberServiceTest {
         Follow follow = Follow.builder()
             .from(fromMember)
             .to(toMember)
+            .status(FollowStatus.APPROVED)
             .build();
         em.persist(follow);
         return follow;


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 팔로우, 팔로잉 목록 조회하는 기능을 무한스크롤로 변경

## 🏌🏻 리뷰 포인트
없습니다. 

## 🧘🏻 기타 사항
**Pageable을 생성하는 객체가 필요하다?!**
Pageable 객체를 만들어주는 별도의 객체를 만들어야겠다는 생각을 했습니다.(인터셉터나 AOP가 적절할 거 같다고 생각중입니다.)
예를 들면 사용자가 데이터를 100개 이상 조회하지 못하게 한다던가 이런 제약조건을 넣고 싶은데요.
컨트롤러나 서비스 계층에 위치시키기에는 책임이 적절하지 않다고 느껴져요.
우선은 해당 부분은 지금 하지 않더라도 문제될 건 없다고 생각해서 추후 과제로 남겨두려고 합니다.

**복잡한 페이징 테스트**
Follow 관련 페이징 테스트 코드가 읽는게 쉽지 않네요.
해당 테스트를 리팩토링하면서 테스트 코드를 읽게 되었는데요. 
느낌상 given절이 많아서 뭘 테스트하는건지 파악하는 게 쉽지는 않았습니다.
읽느라 고생 많으셨습니다 🥲 다음번에 이런 복잡한 given절을 갖는 테스트를 작성할 때는 JavaDoc이라도 적어둬야겠습니다.

**혼란스러운 followers, followings**
도메인 명칭을 잘못 정한 거 같습니다.
코드를 짜면서 느끼는 건 용어적으로 굉장히 혼란스럽더라구요. 아무래도 이 부분 명칭 잘못 잡은 거 같다는 생각을 합니다.

아무래도 제가 이런 관계를 나타낼 때, 머리에서 꼬이는 게 있어서 그런가 싶기도 합니다 ㅜㅜ(영국은 한국보다 시간이 빠르다 이런 거..)

나중에 Follower, Following과 같은 작업을 할 때 저는 굉장히 신경써서 네이밍할거 같네요.

close #94 