### PR TITLE
[#84] 게시글 상세보기

### DIFF
--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
 
     //게시글
     CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "게시글은 최대 2,000자 까지 가능합니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
 
     // 이미지
     IMAGE_TOO_BIG(HttpStatus.BAD_REQUEST, "이미지의 크기가 너무 큽니다"),

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -2,6 +2,7 @@ package com.example.temp.post.application;
 
 import static com.example.temp.common.exception.ErrorCode.AUTHENTICATED_FAIL;
 import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
+import static com.example.temp.common.exception.ErrorCode.POST_NOT_FOUND;
 
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ApiException;
@@ -21,6 +22,7 @@ import com.example.temp.post.domain.PostRepository;
 import com.example.temp.post.dto.request.PostCreateRequest;
 import com.example.temp.post.dto.response.PagePostResponse;
 import com.example.temp.post.dto.response.PostCreateResponse;
+import com.example.temp.post.dto.response.PostDetailResponse;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +62,13 @@ public class PostService {
         List<Member> followings = findFollowingOf(member);
         Page<Post> posts = postRepository.findByMemberInOrderByRegisteredAtDesc(followings, pageable);
         return PagePostResponse.from(posts);
+    }
+
+    public PostDetailResponse findPost(Long postId, UserContext userContext) {
+        findMember(userContext);
+        Post findPost = postRepository.findById(postId)
+            .orElseThrow(() -> new ApiException(POST_NOT_FOUND));
+        return PostDetailResponse.from(findPost);
     }
 
     private Member findMember(UserContext userContext) {

--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -24,6 +24,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "posts")
@@ -43,10 +44,12 @@ public class Post extends BaseTimeEntity {
     @Embedded
     private Content content;
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("createdAt ASC")
     private List<PostImage> postImages = new ArrayList<>();
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<PostHashtag> postHashtags = new ArrayList<>();
 

--- a/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
@@ -11,7 +11,7 @@ public record PostDetailResponse(
     Long postId,
     WriterInfo writerInfo,
     String content,
-    List<String> imageUrl,
+    List<String> imageUrls,
     List<String> hashtags,
     LocalDateTime registeredAt
 ) {
@@ -21,7 +21,7 @@ public record PostDetailResponse(
             .postId(post.getId())
             .writerInfo(WriterInfo.from(post.getMember()))
             .content(post.getContent())
-            .imageUrl(getImageUrls(post))
+            .imageUrls(getImageUrls(post))
             .hashtags(getHashtags(post))
             .registeredAt(post.getRegisteredAt())
             .build();
@@ -37,7 +37,7 @@ public record PostDetailResponse(
     private static List<String> getHashtags(Post post) {
         return post.getPostHashtags().isEmpty() ? Collections.emptyList() :
             post.getPostHashtags().stream()
-                .map(hashtag -> hashtag.getHashtag().getName())
+                .map(postHashtag -> postHashtag.getHashtag().getName())
                 .toList();
     }
 }

--- a/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
@@ -28,16 +28,14 @@ public record PostDetailResponse(
     }
 
     private static List<String> getImageUrls(Post post) {
-        return post.getPostImages().isEmpty() ? Collections.emptyList() :
-            post.getPostImages().stream()
-                .map(postImage -> postImage.getImage().getUrl())
-                .toList();
+        return post.getPostImages().stream()
+            .map(postImage -> postImage.getImage().getUrl())
+            .toList();
     }
 
     private static List<String> getHashtags(Post post) {
-        return post.getPostHashtags().isEmpty() ? Collections.emptyList() :
-            post.getPostHashtags().stream()
-                .map(postHashtag -> postHashtag.getHashtag().getName())
-                .toList();
+        return post.getPostHashtags().stream()
+            .map(postHashtag -> postHashtag.getHashtag().getName())
+            .toList();
     }
 }

--- a/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
@@ -1,0 +1,43 @@
+package com.example.temp.post.dto.response;
+
+import com.example.temp.post.domain.Post;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record PostDetailResponse(
+    Long postId,
+    WriterInfo writerInfo,
+    String content,
+    List<String> imageUrl,
+    List<String> hashtags,
+    LocalDateTime registeredAt
+) {
+
+    public static PostDetailResponse from(Post post) {
+        return PostDetailResponse.builder()
+            .postId(post.getId())
+            .writerInfo(WriterInfo.from(post.getMember()))
+            .content(post.getContent())
+            .imageUrl(getImageUrls(post))
+            .hashtags(getHashtags(post))
+            .registeredAt(post.getRegisteredAt())
+            .build();
+    }
+
+    private static List<String> getImageUrls(Post post) {
+        return post.getPostImages().isEmpty() ? Collections.emptyList() :
+            post.getPostImages().stream()
+                .map(postImage -> postImage.getImage().getUrl())
+                .toList();
+    }
+
+    private static List<String> getHashtags(Post post) {
+        return post.getPostHashtags().isEmpty() ? Collections.emptyList() :
+            post.getPostHashtags().stream()
+                .map(hashtag -> hashtag.getHashtag().getName())
+                .toList();
+    }
+}

--- a/src/main/java/com/example/temp/post/presentation/PostController.java
+++ b/src/main/java/com/example/temp/post/presentation/PostController.java
@@ -43,7 +43,7 @@ public class PostController {
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<PostDetailResponse> getPost(@PathVariable Long postId, UserContext userContext) {
+    public ResponseEntity<PostDetailResponse> getPost(@PathVariable Long postId, @Login UserContext userContext) {
         return ResponseEntity.ok(postService.findPost(postId, userContext));
     }
 }

--- a/src/main/java/com/example/temp/post/presentation/PostController.java
+++ b/src/main/java/com/example/temp/post/presentation/PostController.java
@@ -8,12 +8,14 @@ import com.example.temp.post.application.PostService;
 import com.example.temp.post.dto.request.PostCreateRequest;
 import com.example.temp.post.dto.response.PagePostResponse;
 import com.example.temp.post.dto.response.PostCreateResponse;
+import com.example.temp.post.dto.response.PostDetailResponse;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,5 +40,10 @@ public class PostController {
         @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
         PagePostResponse posts = postService.findPostsFromFollowings(userContext, pageable);
         return ResponseEntity.ok(posts);
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDetailResponse> getPost(@PathVariable Long postId, UserContext userContext) {
+        return ResponseEntity.ok(postService.findPost(postId, userContext));
     }
 }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] 게시글 상세보기 구현

## 🏌🏻 리뷰 포인트
이번엔 크게 고민한 부분은 없는 것 같습니다. 해당 부분에서 Post가 image와 hashtag쪽에 양방향 연관관계를 갖고 있어서 postId로 게시글을 조회해오면 필요한 정보가 다있기 때문에.. 하지만 실제로 서비스 운영시 jpa가 자동으로 조인해서 가져오는 쿼리의 성능이 실제로 얼마나 나올지 알지 못해서 현재시점에서는 이렇게 구현해두고 운영 및 학습을 통해 성능개선을 할 수 있도록 고민을 해봐야 할 것 같습니다.

Controller에서 UserContext 정보를 가지고 들어가는 데 현재 로직에서는 사실 딱히 로그인한 유저정보가 필요없지만 추후 개발될 좋아요 기능이나 댓글기능에서 로그인한 유저의 정보가 필요할 것 같아 파라미터로 service쪽에 넘겨준 상태입니다.

## 🧘🏻 기타 사항

close #84 