### PR TITLE
[#90] 어드민 추가, 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
 
     // Security 의존성 (암호화에 사용)
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-crypto:6.2.1'
 
     // AWS S3 의존성
     implementation 'software.amazon.awssdk:s3:2.23.19'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ repositories {
 
 dependencies {
 
+    // Security 의존성 (암호화에 사용)
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     // AWS S3 의존성
     implementation 'software.amazon.awssdk:s3:2.23.19'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     environment:
       - SERVICES=s3
       - DEBUG=1
+      - EXTRA_CORS_ALLOWED_ORIGINS=http://localhost:3000
+      - DATA_DIR=/tmp/localstack/data
+      - PORT_WEB_UI=${LOCALSTACK_WEB_UI_PORT:-8081}
+      - LAMBDA_EXECUTOR=local
       - DOCKER_SOCK=unix:///var/run/docker.sock
       - DEFAULT_REGION=ap-northeast-2
       - EDGE_PORT=4566

--- a/src/main/java/com/example/temp/admin/application/AdminRepository.java
+++ b/src/main/java/com/example/temp/admin/application/AdminRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface AdminRepository extends JpaRepository<Admin, Long> {
 
     Optional<Admin> findByUsername(String username);
+
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/example/temp/admin/application/AdminRepository.java
+++ b/src/main/java/com/example/temp/admin/application/AdminRepository.java
@@ -1,10 +1,12 @@
 package com.example.temp.admin.application;
 
 import com.example.temp.admin.domain.Admin;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Long> {
 
+    Optional<Admin> findByUsername(String username);
 }

--- a/src/main/java/com/example/temp/admin/application/AdminRepository.java
+++ b/src/main/java/com/example/temp/admin/application/AdminRepository.java
@@ -1,0 +1,10 @@
+package com.example.temp.admin.application;
+
+import com.example.temp.admin.domain.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+}

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminService {
 
     private final AdminRepository adminRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     public void login(AdminLoginRequest request) {
     }

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -1,0 +1,17 @@
+package com.example.temp.admin.application;
+
+import com.example.temp.admin.dto.request.AdminLoginRequest;
+import com.example.temp.admin.dto.request.AdminRegisterRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AdminService {
+
+    public void register(AdminRegisterRequest request) {
+    }
+
+    public void login(AdminLoginRequest request) {
+    }
+}

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -23,8 +23,14 @@ public class AdminService {
     private final BCryptPasswordEncoder passwordEncoder;
 
     @Transactional
-    public void login(AdminLoginRequest request) {
-        // TODO
+    public void login(AdminLoginRequest request, LocalDateTime now) {
+        Admin admin = adminRepository.findByUsername(request.username())
+            .orElseThrow(() -> new ApiException(ErrorCode.ADMIN_LOGIN_FAIL));
+        boolean isSamePwd = passwordEncoder.matches(request.pwd(), admin.getPassword());
+        if (!isSamePwd) {
+            throw new ApiException(ErrorCode.ADMIN_LOGIN_FAIL);
+        }
+        admin.login(now);
     }
 
     @Transactional

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -30,6 +30,9 @@ public class AdminService {
         if (!isSamePwd) {
             throw new ApiException(ErrorCode.ADMIN_LOGIN_FAIL);
         }
+        if (!admin.isActivate()) {
+            throw new ApiException(ErrorCode.ADMIN_PENDING);
+        }
         admin.login(now);
         return admin.getId();
     }

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -23,7 +23,7 @@ public class AdminService {
     private final BCryptPasswordEncoder passwordEncoder;
 
     @Transactional
-    public void login(AdminLoginRequest request, LocalDateTime now) {
+    public long login(AdminLoginRequest request, LocalDateTime now) {
         Admin admin = adminRepository.findByUsername(request.username())
             .orElseThrow(() -> new ApiException(ErrorCode.ADMIN_LOGIN_FAIL));
         boolean isSamePwd = passwordEncoder.matches(request.pwd(), admin.getPassword());
@@ -31,6 +31,7 @@ public class AdminService {
             throw new ApiException(ErrorCode.ADMIN_LOGIN_FAIL);
         }
         admin.login(now);
+        return admin.getId();
     }
 
     @Transactional

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -7,7 +7,7 @@ import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +20,7 @@ public class AdminService {
     public static final String PWD_REGEX = "^(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&*\\-+=]).*$";
 
     private final AdminRepository adminRepository;
-    private final BCryptPasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public long login(AdminLoginRequest request, LocalDateTime now) {

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -40,6 +40,9 @@ public class AdminService {
     @Transactional
     public long register(AdminRegisterRequest request, LocalDateTime now) {
         validatePwd(request.pwd());
+        if (adminRepository.existsByUsername(request.username())) {
+            throw new ApiException(ErrorCode.ADMIN_USERNAME_DUPLICATED);
+        }
         Admin admin = request.toEntityWithEncoderAndTime(passwordEncoder, now);
         adminRepository.save(admin);
         return admin.getId();

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -1,9 +1,11 @@
 package com.example.temp.admin.application;
 
+import com.example.temp.admin.domain.Admin;
 import com.example.temp.admin.dto.request.AdminLoginRequest;
 import com.example.temp.admin.dto.request.AdminRegisterRequest;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,5 +18,19 @@ public class AdminService {
     private final BCryptPasswordEncoder passwordEncoder;
 
     public void login(AdminLoginRequest request) {
+        // TODO
     }
+
+    @Transactional
+    public long register(AdminRegisterRequest request, LocalDateTime now) {
+        Admin admin = Admin.builder()
+            .username(request.username())
+            .password(passwordEncoder.encode(request.pwd()))
+            .lastLogin(now)
+            .build();
+
+        adminRepository.save(admin);
+        return admin.getId();
+    }
+
 }

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -3,6 +3,8 @@ package com.example.temp.admin.application;
 import com.example.temp.admin.domain.Admin;
 import com.example.temp.admin.dto.request.AdminLoginRequest;
 import com.example.temp.admin.dto.request.AdminRegisterRequest;
+import com.example.temp.common.exception.ApiException;
+import com.example.temp.common.exception.ErrorCode;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -14,6 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AdminService {
 
+    public static final int PWD_MIN_LENGTH = 4;
+    public static final String PWD_REGEX = "^(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&*\\-+=]).*$";
+
     private final AdminRepository adminRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
@@ -23,6 +28,7 @@ public class AdminService {
 
     @Transactional
     public long register(AdminRegisterRequest request, LocalDateTime now) {
+        validatePwd(request.pwd());
         Admin admin = Admin.builder()
             .username(request.username())
             .password(passwordEncoder.encode(request.pwd()))
@@ -31,6 +37,15 @@ public class AdminService {
 
         adminRepository.save(admin);
         return admin.getId();
+    }
+
+    private void validatePwd(String pwd) {
+        if (pwd == null || pwd.length() < PWD_MIN_LENGTH) {
+            throw new ApiException(ErrorCode.ADMIN_PWD_TOO_SHORT);
+        }
+        if (!pwd.matches(PWD_REGEX)) {
+            throw new ApiException(ErrorCode.ADMIN_PWD_INVALID);
+        }
     }
 
 }

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -22,6 +22,7 @@ public class AdminService {
     private final AdminRepository adminRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
+    @Transactional
     public void login(AdminLoginRequest request) {
         // TODO
     }
@@ -29,12 +30,7 @@ public class AdminService {
     @Transactional
     public long register(AdminRegisterRequest request, LocalDateTime now) {
         validatePwd(request.pwd());
-        Admin admin = Admin.builder()
-            .username(request.username())
-            .password(passwordEncoder.encode(request.pwd()))
-            .lastLogin(now)
-            .build();
-
+        Admin admin = request.toEntityWithEncoderAndTime(passwordEncoder, now);
         adminRepository.save(admin);
         return admin.getId();
     }

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminService {
 
     public static final int PWD_MIN_LENGTH = 4;
+
+    @SuppressWarnings("java:S2068")
     public static final String PWD_REGEX = "^(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&*\\-+=]).*$";
 
     private final AdminRepository adminRepository;

--- a/src/main/java/com/example/temp/admin/application/AdminService.java
+++ b/src/main/java/com/example/temp/admin/application/AdminService.java
@@ -2,15 +2,17 @@ package com.example.temp.admin.application;
 
 import com.example.temp.admin.dto.request.AdminLoginRequest;
 import com.example.temp.admin.dto.request.AdminRegisterRequest;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class AdminService {
 
-    public void register(AdminRegisterRequest request) {
-    }
+    private final AdminRepository adminRepository;
 
     public void login(AdminLoginRequest request) {
     }

--- a/src/main/java/com/example/temp/admin/domain/Admin.java
+++ b/src/main/java/com/example/temp/admin/domain/Admin.java
@@ -27,17 +27,20 @@ public class Admin extends BaseTimeEntity {
     @Column(nullable = false, unique = true, length = 32)
     private String username;
 
-    @Column(nullable = false, length = 64)
+    @Column(nullable = false)
     private String password;
 
     @Column(nullable = false)
     private LocalDateTime lastLogin;
 
+    private boolean activate;
+
     @Builder
-    private Admin(String username, String password, LocalDateTime lastLogin) {
+    private Admin(String username, String password, LocalDateTime lastLogin, boolean activate) {
         this.username = username;
         this.password = password;
         this.lastLogin = lastLogin;
+        this.activate = activate;
     }
 
 }

--- a/src/main/java/com/example/temp/admin/domain/Admin.java
+++ b/src/main/java/com/example/temp/admin/domain/Admin.java
@@ -43,4 +43,7 @@ public class Admin extends BaseTimeEntity {
         this.activate = activate;
     }
 
+    public void login(LocalDateTime now) {
+        this.lastLogin = now;
+    }
 }

--- a/src/main/java/com/example/temp/admin/domain/Admin.java
+++ b/src/main/java/com/example/temp/admin/domain/Admin.java
@@ -14,14 +14,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "admin_members")
+@Table(name = "admins")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class AdminMember extends BaseTimeEntity {
+public class Admin extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "admin_member_id")
+    @Column(name = "admin_id")
     private Long id;
 
     @Column(nullable = false, unique = true, length = 32)
@@ -34,7 +34,7 @@ public class AdminMember extends BaseTimeEntity {
     private LocalDateTime lastLogin;
 
     @Builder
-    private AdminMember(String username, String password, LocalDateTime lastLogin) {
+    private Admin(String username, String password, LocalDateTime lastLogin) {
         this.username = username;
         this.password = password;
         this.lastLogin = lastLogin;

--- a/src/main/java/com/example/temp/admin/domain/AdminMember.java
+++ b/src/main/java/com/example/temp/admin/domain/AdminMember.java
@@ -1,0 +1,43 @@
+package com.example.temp.admin.domain;
+
+import com.example.temp.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "admin_members")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AdminMember extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_member_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 32)
+    private String username;
+
+    @Column(nullable = false, length = 64)
+    private String password;
+
+    @Column(nullable = false)
+    private LocalDateTime lastLogin;
+
+    @Builder
+    private AdminMember(String username, String password, LocalDateTime lastLogin) {
+        this.username = username;
+        this.password = password;
+        this.lastLogin = lastLogin;
+    }
+
+}

--- a/src/main/java/com/example/temp/admin/dto/request/AdminLoginRequest.java
+++ b/src/main/java/com/example/temp/admin/dto/request/AdminLoginRequest.java
@@ -1,0 +1,5 @@
+package com.example.temp.admin.dto.request;
+
+public record AdminLoginRequest() {
+
+}

--- a/src/main/java/com/example/temp/admin/dto/request/AdminLoginRequest.java
+++ b/src/main/java/com/example/temp/admin/dto/request/AdminLoginRequest.java
@@ -1,5 +1,8 @@
 package com.example.temp.admin.dto.request;
 
-public record AdminLoginRequest() {
+public record AdminLoginRequest(
+    String username,
+    String pwd
+) {
 
 }

--- a/src/main/java/com/example/temp/admin/dto/request/AdminRegisterRequest.java
+++ b/src/main/java/com/example/temp/admin/dto/request/AdminRegisterRequest.java
@@ -1,5 +1,8 @@
 package com.example.temp.admin.dto.request;
 
-public record AdminRegisterRequest() {
+public record AdminRegisterRequest(
+    String username,
+    String pwd
+) {
 
 }

--- a/src/main/java/com/example/temp/admin/dto/request/AdminRegisterRequest.java
+++ b/src/main/java/com/example/temp/admin/dto/request/AdminRegisterRequest.java
@@ -1,8 +1,20 @@
 package com.example.temp.admin.dto.request;
 
+import com.example.temp.admin.domain.Admin;
+import java.time.LocalDateTime;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
 public record AdminRegisterRequest(
     String username,
     String pwd
 ) {
 
+    public Admin toEntityWithEncoderAndTime(PasswordEncoder passwordEncoder, LocalDateTime now) {
+        return Admin.builder()
+            .username(username())
+            .password(passwordEncoder.encode(pwd()))
+            .lastLogin(now)
+            .activate(false)
+            .build();
+    }
 }

--- a/src/main/java/com/example/temp/admin/dto/request/AdminRegisterRequest.java
+++ b/src/main/java/com/example/temp/admin/dto/request/AdminRegisterRequest.java
@@ -1,0 +1,5 @@
+package com.example.temp.admin.dto.request;
+
+public record AdminRegisterRequest() {
+
+}

--- a/src/main/java/com/example/temp/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/temp/admin/presentation/AdminController.java
@@ -3,10 +3,10 @@ package com.example.temp.admin.presentation;
 import com.example.temp.admin.application.AdminService;
 import com.example.temp.admin.dto.request.AdminLoginRequest;
 import com.example.temp.admin.dto.request.AdminRegisterRequest;
-import com.example.temp.machine.dto.request.MachineBulkCreateRequest;
-import com.example.temp.machine.dto.request.MachineCreateRequest;
 import com.example.temp.machine.application.MachineService;
+import com.example.temp.machine.dto.request.MachineBulkCreateRequest;
 import com.example.temp.machine.dto.response.MachineCreateResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +32,7 @@ public class AdminController {
 
     @PostMapping("/register")
     public ResponseEntity<Void> register(@RequestBody AdminRegisterRequest request) {
-        adminService.register(request);
+        adminService.register(request, LocalDateTime.now());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/temp/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/temp/admin/presentation/AdminController.java
@@ -11,6 +11,7 @@ import com.example.temp.auth.infrastructure.TokenManager;
 import com.example.temp.auth.presentation.RefreshCookieProperties;
 import com.example.temp.machine.application.MachineService;
 import com.example.temp.machine.dto.request.MachineBulkCreateRequest;
+import com.example.temp.machine.dto.request.MachineCreateRequest;
 import com.example.temp.machine.dto.response.MachineCreateResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
@@ -63,8 +64,14 @@ public class AdminController {
     }
 
     @PostMapping("/machines/bulk")
-    public ResponseEntity<List<MachineCreateResponse>> createMachinesBulk(MachineBulkCreateRequest request) {
+    public ResponseEntity<List<MachineCreateResponse>> createMachinesBulk(@RequestBody MachineBulkCreateRequest request) {
         List<MachineCreateResponse> response = machineService.createMachinesBulk(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/machines")
+    public ResponseEntity<MachineCreateResponse> createMachine(MachineCreateRequest request) {
+        MachineCreateResponse response = machineService.createMachine(request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/temp/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/temp/admin/presentation/AdminController.java
@@ -1,5 +1,8 @@
 package com.example.temp.admin.presentation;
 
+import com.example.temp.admin.application.AdminService;
+import com.example.temp.admin.dto.request.AdminLoginRequest;
+import com.example.temp.admin.dto.request.AdminRegisterRequest;
 import com.example.temp.machine.dto.request.MachineBulkCreateRequest;
 import com.example.temp.machine.dto.request.MachineCreateRequest;
 import com.example.temp.machine.application.MachineService;
@@ -8,6 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,10 +22,18 @@ public class AdminController {
 
     private final MachineService machineService;
 
-    @PostMapping("/machines")
-    public ResponseEntity<MachineCreateResponse> createMachine(MachineCreateRequest request) {
-        MachineCreateResponse response = machineService.createMachine(request);
-        return ResponseEntity.ok(response);
+    private final AdminService adminService;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody AdminLoginRequest request) {
+        adminService.login(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<Void> register(@RequestBody AdminRegisterRequest request) {
+        adminService.register(request);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/machines/bulk")

--- a/src/main/java/com/example/temp/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/temp/admin/presentation/AdminController.java
@@ -1,14 +1,22 @@
 package com.example.temp.admin.presentation;
 
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
 import com.example.temp.admin.application.AdminService;
 import com.example.temp.admin.dto.request.AdminLoginRequest;
 import com.example.temp.admin.dto.request.AdminRegisterRequest;
+import com.example.temp.auth.domain.Role;
+import com.example.temp.auth.dto.response.TokenInfo;
+import com.example.temp.auth.infrastructure.TokenManager;
+import com.example.temp.auth.presentation.RefreshCookieProperties;
 import com.example.temp.machine.application.MachineService;
 import com.example.temp.machine.dto.request.MachineBulkCreateRequest;
 import com.example.temp.machine.dto.response.MachineCreateResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,14 +28,32 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/admin")
 public class AdminController {
 
-    private final MachineService machineService;
+    public static final String REFRESH = "refresh";
 
+    private final RefreshCookieProperties refreshCookieProperties;
+    private final MachineService machineService;
     private final AdminService adminService;
+    private final TokenManager tokenManager;
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody AdminLoginRequest request) {
-        adminService.login(request, LocalDateTime.now());
-        return ResponseEntity.ok().build();
+    public ResponseEntity<TokenInfo> login(@RequestBody AdminLoginRequest request,
+        HttpServletResponse response) {
+        long loginUserId = adminService.login(request, LocalDateTime.now());
+        TokenInfo tokenInfo = tokenManager.issueWithRole(loginUserId, Role.ADMIN);
+
+        createRefreshCookie(tokenInfo.refreshToken(), response);
+        return ResponseEntity.ok(tokenInfo);
+    }
+
+    private void createRefreshCookie(String value, HttpServletResponse response) {
+        ResponseCookie refreshCookie = ResponseCookie.from(REFRESH, value)
+            .path("/")
+            .httpOnly(true)
+            .secure(refreshCookieProperties.secure())
+            .maxAge(refreshCookieProperties.maxAge())
+            .sameSite(refreshCookieProperties.sameSite())
+            .build();
+        response.addHeader(SET_COOKIE, refreshCookie.toString());
     }
 
     @PostMapping("/register")

--- a/src/main/java/com/example/temp/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/temp/admin/presentation/AdminController.java
@@ -26,7 +26,7 @@ public class AdminController {
 
     @PostMapping("/login")
     public ResponseEntity<Void> login(@RequestBody AdminLoginRequest request) {
-        adminService.login(request);
+        adminService.login(request, LocalDateTime.now());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/temp/auth/domain/Role.java
+++ b/src/main/java/com/example/temp/auth/domain/Role.java
@@ -1,0 +1,15 @@
+package com.example.temp.auth.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+    NORMAL("일반 사용자"),
+    ADMIN("어드민");
+
+    private final String text;
+
+    Role(String text) {
+        this.text = text;
+    }
+}

--- a/src/main/java/com/example/temp/auth/infrastructure/JwtTokenManager.java
+++ b/src/main/java/com/example/temp/auth/infrastructure/JwtTokenManager.java
@@ -86,16 +86,6 @@ public class JwtTokenManager implements TokenManager, TokenParser {
             .compact();
     }
 
-
-    private String makeToken(String sub, long expires, LocalDateTime now) {
-        LocalDateTime expiresDateTime = now.plusSeconds(expires);
-        return Jwts.builder()
-            .subject(sub)
-            .expiration(Timestamp.valueOf(expiresDateTime))
-            .signWith(key)
-            .compact();
-    }
-
     /**
      * 입력받은 refreshToken을 사용해 accessToken과 refreshToken을 재발급합니다.
      *
@@ -134,6 +124,7 @@ public class JwtTokenManager implements TokenManager, TokenParser {
         Claims claims = claimsJws.getPayload();
         return UserContext.builder()
             .id(Long.parseLong(claims.getSubject()))
+            .role(Role.valueOf(claims.get("role", String.class)))
             .build();
     }
 }

--- a/src/main/java/com/example/temp/auth/infrastructure/TokenManager.java
+++ b/src/main/java/com/example/temp/auth/infrastructure/TokenManager.java
@@ -6,12 +6,12 @@ import com.example.temp.auth.dto.response.TokenInfo;
 public interface TokenManager {
 
     /**
-     * 사용자 고유 id를 사용해 Token들을 발급한다.
+     * 사용자 고유 id와 Role을 사용해 Token들을 발급한다.
      *
      * @param id
-     * @return TokenInfo
+     * @param role
      */
-    TokenInfo issue(Long id);
+    TokenInfo issueWithRole(long id, Role role);
 
     /**
      * refresh Token을 사용해 Token들을 재발급한다.
@@ -21,11 +21,4 @@ public interface TokenManager {
      */
     TokenInfo reIssue(String refreshToken);
 
-    /**
-     * 사용자 고유 id와 Role을 사용해 Token들을 발급한다.
-     *
-     * @param id
-     * @param role
-     */
-    TokenInfo issueWithRole(long id, Role role);
 }

--- a/src/main/java/com/example/temp/auth/infrastructure/TokenManager.java
+++ b/src/main/java/com/example/temp/auth/infrastructure/TokenManager.java
@@ -1,5 +1,6 @@
 package com.example.temp.auth.infrastructure;
 
+import com.example.temp.auth.domain.Role;
 import com.example.temp.auth.dto.response.TokenInfo;
 
 public interface TokenManager {
@@ -19,4 +20,12 @@ public interface TokenManager {
      * @return TokenInfo
      */
     TokenInfo reIssue(String refreshToken);
+
+    /**
+     * 사용자 고유 id와 Role을 사용해 Token들을 발급한다.
+     *
+     * @param id
+     * @param role
+     */
+    TokenInfo issueWithRole(long id, Role role);
 }

--- a/src/main/java/com/example/temp/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/temp/auth/presentation/AuthController.java
@@ -2,6 +2,7 @@ package com.example.temp.auth.presentation;
 
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
+import com.example.temp.auth.domain.Role;
 import com.example.temp.auth.dto.request.OAuthLoginRequest;
 import com.example.temp.auth.dto.response.AuthorizedUrl;
 import com.example.temp.auth.dto.response.LoginResponse;
@@ -36,7 +37,7 @@ public class AuthController {
     public ResponseEntity<LoginResponse> oauthLogin(@PathVariable String provider,
         @RequestBody OAuthLoginRequest request, HttpServletResponse response) {
         MemberInfo memberResponse = oAuthService.login(provider, request.authCode());
-        TokenInfo tokenInfo = tokenManager.issue(memberResponse.id());
+        TokenInfo tokenInfo = tokenManager.issueWithRole(memberResponse.id(), Role.NORMAL);
 
         createRefreshCookie(tokenInfo.refreshToken(), response);
         return ResponseEntity.ok(LoginResponse.of(tokenInfo, memberResponse));

--- a/src/main/java/com/example/temp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/temp/common/config/SecurityConfig.java
@@ -2,10 +2,21 @@ package com.example.temp.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http.httpBasic(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .cors(AbstractHttpConfigurer::disable)
+            .build();
+    }
 
     @Bean
     BCryptPasswordEncoder passwordEncoder() {

--- a/src/main/java/com/example/temp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/temp/common/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.example.temp.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/example/temp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/temp/common/config/SecurityConfig.java
@@ -2,25 +2,14 @@ package com.example.temp.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        return http.httpBasic(AbstractHttpConfigurer::disable)
-            .csrf(AbstractHttpConfigurer::disable)
-            .cors(AbstractHttpConfigurer::disable)
-            .build();
-    }
-
-    @Bean
-    BCryptPasswordEncoder passwordEncoder() {
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
 }

--- a/src/main/java/com/example/temp/common/config/WebConfig.java
+++ b/src/main/java/com/example/temp/common/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.example.temp.common.config;
 
 import com.example.temp.common.convertor.StringToPrivacyPolicyConverter;
+import com.example.temp.common.interceptor.AdminInterceptor;
 import com.example.temp.common.interceptor.AuthenticationInterceptor;
 import com.example.temp.common.properties.CorsProperties;
 import com.example.temp.common.resolver.LoginUserArgumentResolver;
@@ -21,6 +22,8 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final AuthenticationInterceptor authenticationInterceptor;
 
+    private final AdminInterceptor adminInterceptor;
+
     private final LoginUserArgumentResolver loginUserArgumentResolver;
 
     @Override
@@ -35,7 +38,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(authenticationInterceptor)
+        registry.addInterceptor(adminInterceptor)
             .addPathPatterns("/admin/**")
             .excludePathPatterns("/admin/register", "/admin/login");
 

--- a/src/main/java/com/example/temp/common/config/WebConfig.java
+++ b/src/main/java/com/example/temp/common/config/WebConfig.java
@@ -37,6 +37,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
             .excludePathPatterns("/oauth/**", "/auth/refresh")
+            .excludePathPatterns("/admin/**")
             .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**");
     }
 

--- a/src/main/java/com/example/temp/common/config/WebConfig.java
+++ b/src/main/java/com/example/temp/common/config/WebConfig.java
@@ -36,6 +36,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
+            .addPathPatterns("/admin/**")
+            .excludePathPatterns("/admin/register", "/admin/login");
+
+        registry.addInterceptor(authenticationInterceptor)
             .excludePathPatterns("/oauth/**", "/auth/refresh")
             .excludePathPatterns("/admin/**")
             .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**");

--- a/src/main/java/com/example/temp/common/dto/UserContext.java
+++ b/src/main/java/com/example/temp/common/dto/UserContext.java
@@ -16,4 +16,8 @@ public record UserContext(
     public boolean isNormal() {
         return role == Role.NORMAL;
     }
+
+    public boolean isAdmin() {
+        return role == Role.ADMIN;
+    }
 }

--- a/src/main/java/com/example/temp/common/dto/UserContext.java
+++ b/src/main/java/com/example/temp/common/dto/UserContext.java
@@ -1,12 +1,15 @@
 package com.example.temp.common.dto;
 
+import com.example.temp.auth.domain.Role;
 import com.example.temp.member.domain.Member;
 import lombok.Builder;
 
 @Builder
-public record UserContext(Long id) {
+public record UserContext(
+    Long id,
+    Role role) {
 
-    public static UserContext from(Member fromMember) {
-        return new UserContext(fromMember.getId());
+    public static UserContext fromMember(Member fromMember) {
+        return new UserContext(fromMember.getId(), Role.NORMAL);
     }
 }

--- a/src/main/java/com/example/temp/common/dto/UserContext.java
+++ b/src/main/java/com/example/temp/common/dto/UserContext.java
@@ -12,4 +12,8 @@ public record UserContext(
     public static UserContext fromMember(Member fromMember) {
         return new UserContext(fromMember.getId(), Role.NORMAL);
     }
+
+    public boolean isNormal() {
+        return role == Role.NORMAL;
+    }
 }

--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     ADMIN_PWD_INVALID(HttpStatus.BAD_REQUEST, "비밀번호는 영문자, 숫자, 특수문자(! @ # $ % ^ & * - + = )가 포함되어야 합니다."),
     ADMIN_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 잘못되었습니다."),
     ADMIN_PENDING(HttpStatus.UNAUTHORIZED, "아직 권한이 부여되지 않았습니다."),
+    ADMIN_USERNAME_DUPLICATED(HttpStatus.BAD_REQUEST, "닉네임이 중복되었습니다."),
 
     // 닉네임
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "닉네임의 길이가 너무 깁니다."),

--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -14,10 +14,13 @@ public enum ErrorCode {
     AUTHENTICATED_FAIL(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     AUTHORIZED_FAIL(HttpStatus.FORBIDDEN, "인가 권한이 없는 사용자입니다."),
 
-
     // 회원
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당되는 회원을 찾을 수 없습니다."),
     MEMBER_ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "이미 가입이 완료된 회원입니다."),
+
+    // 어드민
+    ADMIN_PWD_TOO_SHORT(HttpStatus.BAD_REQUEST, "비밀번호가 너무 짧습니다."),
+    ADMIN_PWD_INVALID(HttpStatus.BAD_REQUEST, "비밀번호는 영문자, 숫자, 특수문자(! @ # $ % ^ & * - + = )가 포함되어야 합니다."),
 
     // 닉네임
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "닉네임의 길이가 너무 깁니다."),

--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     ADMIN_PWD_TOO_SHORT(HttpStatus.BAD_REQUEST, "비밀번호가 너무 짧습니다."),
     ADMIN_PWD_INVALID(HttpStatus.BAD_REQUEST, "비밀번호는 영문자, 숫자, 특수문자(! @ # $ % ^ & * - + = )가 포함되어야 합니다."),
     ADMIN_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 잘못되었습니다."),
+    ADMIN_PENDING(HttpStatus.UNAUTHORIZED, "아직 권한이 부여되지 않았습니다."),
 
     // 닉네임
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "닉네임의 길이가 너무 깁니다."),

--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     // 어드민
     ADMIN_PWD_TOO_SHORT(HttpStatus.BAD_REQUEST, "비밀번호가 너무 짧습니다."),
     ADMIN_PWD_INVALID(HttpStatus.BAD_REQUEST, "비밀번호는 영문자, 숫자, 특수문자(! @ # $ % ^ & * - + = )가 포함되어야 합니다."),
+    ADMIN_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 잘못되었습니다."),
 
     // 닉네임
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "닉네임의 길이가 너무 깁니다."),

--- a/src/main/java/com/example/temp/common/interceptor/AdminInterceptor.java
+++ b/src/main/java/com/example/temp/common/interceptor/AdminInterceptor.java
@@ -1,0 +1,42 @@
+package com.example.temp.common.interceptor;
+
+import com.example.temp.auth.infrastructure.TokenParser;
+import com.example.temp.common.dto.UserContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import software.amazon.awssdk.utils.StringUtils;
+
+@RequiredArgsConstructor
+@Component
+public class AdminInterceptor implements HandlerInterceptor {
+
+    public static final String BEARER = "Bearer ";
+    public static final String MEMBER_INFO = "memberInfo";
+
+    private final TokenParser tokenParser;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+        throws Exception {
+        if (StringUtils.equals(request.getMethod(), "OPTIONS")) {
+            return true;
+        }
+        String accessTokenBeforeProcessing = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (accessTokenBeforeProcessing == null || !accessTokenBeforeProcessing.startsWith(BEARER)) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+        String accessToken = accessTokenBeforeProcessing.substring(BEARER.length());
+        UserContext userContext = tokenParser.parsedClaims(accessToken);
+        if (!userContext.isAdmin()) {
+            return false;
+        }
+        request.setAttribute(MEMBER_INFO, userContext);
+        return true;
+    }
+}

--- a/src/main/java/com/example/temp/common/interceptor/AdminInterceptor.java
+++ b/src/main/java/com/example/temp/common/interceptor/AdminInterceptor.java
@@ -34,6 +34,7 @@ public class AdminInterceptor implements HandlerInterceptor {
         String accessToken = accessTokenBeforeProcessing.substring(BEARER.length());
         UserContext userContext = tokenParser.parsedClaims(accessToken);
         if (!userContext.isAdmin()) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
             return false;
         }
         request.setAttribute(MEMBER_INFO, userContext);

--- a/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
@@ -34,6 +34,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         String accessToken = accessTokenBeforeProcessing.substring(BEARER.length());
         UserContext userContext = tokenParser.parsedClaims(accessToken);
         if (!userContext.isNormal()) {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
             return false;
         }
         request.setAttribute(MEMBER_INFO, userContext);

--- a/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/example/temp/common/interceptor/AuthenticationInterceptor.java
@@ -33,6 +33,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
         String accessToken = accessTokenBeforeProcessing.substring(BEARER.length());
         UserContext userContext = tokenParser.parsedClaims(accessToken);
+        if (!userContext.isNormal()) {
+            return false;
+        }
         request.setAttribute(MEMBER_INFO, userContext);
         return true;
     }

--- a/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
+++ b/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
@@ -1,0 +1,52 @@
+package com.example.temp.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.admin.domain.Admin;
+import com.example.temp.admin.dto.request.AdminRegisterRequest;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class AdminServiceTest {
+
+    @Autowired
+    AdminService adminService;
+
+    @Autowired
+    BCryptPasswordEncoder passwordEncoder;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("어드민 가입 시 활성화되지 않은 어드민이 생성된다.")
+    void registerSuccess() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        String username = "kim12";
+        String rawPwd = "qwer123";
+        AdminRegisterRequest request = new AdminRegisterRequest(username, rawPwd);
+
+        // when
+        long registeredId = adminService.register(request, now);
+
+        // then
+        Admin registered = em.find(Admin.class, registeredId);
+        assertThat(registered.getLastLogin()).isEqualTo(now);
+        assertThat(registered.getUsername()).isEqualTo(username);
+        assertThat(registered.getPassword()).isNotEqualTo(rawPwd);
+        assertThat(registered.isActivate()).isFalse();
+
+        boolean isSamePwd = passwordEncoder.matches(rawPwd, registered.getPassword());
+        assertThat(isSamePwd).isTrue();
+    }
+
+}

--- a/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
+++ b/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
@@ -130,8 +130,8 @@ class AdminServiceTest {
         AdminLoginRequest request = new AdminLoginRequest(username, rawPwd);
 
         // when & then
-        assertDoesNotThrow(() -> adminService.login(request, now));
-        Admin loginAdmin = em.find(Admin.class, admin.getId());
+        long loginAdminId = adminService.login(request, now);
+        Admin loginAdmin = em.find(Admin.class, loginAdminId);
         assertThat(loginAdmin.getLastLogin()).isEqualTo(now);
     }
 

--- a/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
+++ b/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
@@ -56,6 +56,24 @@ class AdminServiceTest {
     }
 
     @Test
+    @DisplayName("중복된 아이디로 어드민을 가입할 수 없다.")
+    void registerFailDupUsername() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        String username = "kim12";
+        String rawPwd = "raw@12";
+        AdminRegisterRequest request = new AdminRegisterRequest(username, rawPwd);
+
+        createInactivateAdmin(username, passwordEncoder.encode("pwd@12"), now);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.register(request, now))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.ADMIN_USERNAME_DUPLICATED.getMessage());
+
+    }
+
+    @Test
     @DisplayName("어드민의 비밀번호는 4자리 이상이어야 한다.")
     void registerFailPwdTooShort() throws Exception {
         // given

--- a/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
+++ b/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
@@ -1,13 +1,18 @@
 package com.example.temp.admin.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.temp.admin.domain.Admin;
 import com.example.temp.admin.dto.request.AdminRegisterRequest;
+import com.example.temp.common.exception.ApiException;
+import com.example.temp.common.exception.ErrorCode;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -26,13 +31,13 @@ class AdminServiceTest {
     @Autowired
     EntityManager em;
 
-    @Test
+    @ParameterizedTest
     @DisplayName("어드민 가입 시 활성화되지 않은 어드민이 생성된다.")
-    void registerSuccess() throws Exception {
+    @ValueSource(strings = {"qwer@123", "!@#1a", "$%^1a", "&*-=1a"})
+    void registerSuccess(String rawPwd) throws Exception {
         // given
         LocalDateTime now = LocalDateTime.now();
         String username = "kim12";
-        String rawPwd = "qwer123";
         AdminRegisterRequest request = new AdminRegisterRequest(username, rawPwd);
 
         // when
@@ -49,4 +54,63 @@ class AdminServiceTest {
         assertThat(isSamePwd).isTrue();
     }
 
+    @Test
+    @DisplayName("어드민의 비밀번호는 4자리 이상이어야 한다.")
+    void registerFailPwdTooShort() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        String username = "kim12";
+        String rawPwd = "qwe";
+        AdminRegisterRequest request = new AdminRegisterRequest(username, rawPwd);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.register(request, now))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.ADMIN_PWD_TOO_SHORT.getMessage());
+    }
+
+    @Test
+    @DisplayName("어드민의 비밀번호는 특수문자가 포함되어야 한다.")
+    void registerFailPwdNoSpecialChar() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        String username = "kim12";
+        String rawPwd = "qwer123";
+        AdminRegisterRequest request = new AdminRegisterRequest(username, rawPwd);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.register(request, now))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.ADMIN_PWD_INVALID.getMessage());
+    }
+
+    @Test
+    @DisplayName("어드민의 비밀번호는 영문자가 포함되어야 한다.")
+    void registerFailPwdNoAlphabet() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        String username = "kim12";
+        String rawPwd = "12@3";
+        AdminRegisterRequest request = new AdminRegisterRequest(username, rawPwd);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.register(request, now))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.ADMIN_PWD_INVALID.getMessage());
+    }
+
+    @Test
+    @DisplayName("어드민의 비밀번호는 숫자가 포함되어야 한다.")
+    void registerFailPwdNoNum() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        String username = "kim12";
+        String rawPwd = "qw@e";
+        AdminRegisterRequest request = new AdminRegisterRequest(username, rawPwd);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.register(request, now))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.ADMIN_PWD_INVALID.getMessage());
+    }
 }

--- a/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
+++ b/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
@@ -2,8 +2,10 @@ package com.example.temp.admin.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.example.temp.admin.domain.Admin;
+import com.example.temp.admin.dto.request.AdminLoginRequest;
 import com.example.temp.admin.dto.request.AdminRegisterRequest;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
@@ -112,5 +114,78 @@ class AdminServiceTest {
         assertThatThrownBy(() -> adminService.register(request, now))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.ADMIN_PWD_INVALID.getMessage());
+    }
+
+    @Test
+    @DisplayName("어드민은 id와 pwd를 사용해서 로그인할 수 있다.")
+    void login() throws Exception {
+        // given
+        String username = "username";
+        String rawPwd = "rawPwd";
+        String encodedPwd = passwordEncoder.encode(rawPwd);
+        LocalDateTime past = LocalDateTime.of(2010, 1, 1, 1, 1);
+        Admin admin = createActivateAdmin(username, encodedPwd, past);
+
+        LocalDateTime now = LocalDateTime.now();
+        AdminLoginRequest request = new AdminLoginRequest(username, rawPwd);
+
+        // when & then
+        assertDoesNotThrow(() -> adminService.login(request, now));
+        Admin loginAdmin = em.find(Admin.class, admin.getId());
+        assertThat(loginAdmin.getLastLogin()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 id로는 로그인할 수 없다.")
+    void loginFailUsernameNotFound() throws Exception {
+        // given
+        String username = "username";
+        String rawPwd = "rawPwd";
+
+        LocalDateTime now = LocalDateTime.now();
+        AdminLoginRequest request = new AdminLoginRequest(username, rawPwd);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.login(request, now))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.ADMIN_LOGIN_FAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("비밀번호를 잘못 입력하면 로그인할 수 없다.")
+    void loginFailPwdMismatch() throws Exception {
+        // given
+        String username = "username";
+        String rawPwd = "rawPwd";
+        String encodedPwd = passwordEncoder.encode(rawPwd);
+        LocalDateTime past = LocalDateTime.of(2010, 1, 1, 1, 1);
+        createActivateAdmin(username, encodedPwd, past);
+
+        LocalDateTime now = LocalDateTime.now();
+        AdminLoginRequest request = new AdminLoginRequest(username, "invalidPwd");
+
+        // when & then
+        assertThatThrownBy(() -> adminService.login(request, now))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.ADMIN_LOGIN_FAIL.getMessage());
+    }
+
+    private Admin createActivateAdmin(String username, String encodedPwd, LocalDateTime past) {
+        return createAdminHelper(username, encodedPwd, past, true);
+    }
+
+    private Admin createInactivateAdmin(String username, String encodedPwd, LocalDateTime past) {
+        return createAdminHelper(username, encodedPwd, past, false);
+    }
+
+    private Admin createAdminHelper(String username, String encodedPwd, LocalDateTime past, boolean activate) {
+        Admin admin = Admin.builder()
+            .username(username)
+            .password(encodedPwd)
+            .lastLogin(past)
+            .activate(activate)
+            .build();
+        em.persist(admin);
+        return admin;
     }
 }

--- a/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
+++ b/src/test/java/com/example/temp/admin/application/AdminServiceTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -28,7 +28,7 @@ class AdminServiceTest {
     AdminService adminService;
 
     @Autowired
-    BCryptPasswordEncoder passwordEncoder;
+    PasswordEncoder passwordEncoder;
 
     @Autowired
     EntityManager em;

--- a/src/test/java/com/example/temp/admin/dto/request/AdminRegisterRequestTest.java
+++ b/src/test/java/com/example/temp/admin/dto/request/AdminRegisterRequestTest.java
@@ -1,0 +1,51 @@
+package com.example.temp.admin.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.admin.domain.Admin;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class AdminRegisterRequestTest {
+
+    @Test
+    @DisplayName("생성자 순서를 테스트한다.")
+    void create() throws Exception {
+        // given
+        String username = "username";
+        String pwd = "pwd";
+
+        // when
+        AdminRegisterRequest request = new AdminRegisterRequest(username, pwd);
+
+        // then
+        assertThat(request.username()).isEqualTo(username);
+        assertThat(request.pwd()).isEqualTo(pwd);
+    }
+
+    @Test
+    @DisplayName("AdminRegisterRequest와 PasswordEncoder, 현재 시간을 사용해 Admin 객체를 생성한다.")
+    void toEntityWithEncoderAndTime() throws Exception {
+        // given
+        PasswordEncoder pwdEncoder = new BCryptPasswordEncoder();
+        LocalDateTime now = LocalDateTime.now();
+
+        String username = "username";
+        String rawPwd = "rawPwd";
+        AdminRegisterRequest request = new AdminRegisterRequest(username, rawPwd);
+
+        // when
+        Admin admin = request.toEntityWithEncoderAndTime(pwdEncoder, now);
+
+        // then
+        boolean isSamePwd = pwdEncoder.matches(rawPwd, admin.getPassword());
+        assertThat(isSamePwd).isTrue();
+
+        assertThat(admin.getUsername()).isEqualTo(username);
+        assertThat(admin.getLastLogin()).isEqualTo(now);
+        assertThat(admin.isActivate()).isFalse();
+    }
+}

--- a/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/MemberInfoTest.java
@@ -1,0 +1,70 @@
+package com.example.temp.auth.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.common.entity.Email;
+import com.example.temp.member.domain.FollowStrategy;
+import com.example.temp.member.domain.Member;
+import com.example.temp.member.domain.PrivacyPolicy;
+import com.example.temp.member.domain.nickname.Nickname;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MemberInfoTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("생성자의 순서가 올바른지 테스트한다")
+    void create() throws Exception {
+        // given
+        long id = 1L;
+        String email = "email";
+        String profileUrl = "profile";
+        String nickname = "nick";
+        boolean registered = true;
+
+        // when
+        MemberInfo result = new MemberInfo(id, email, profileUrl, nickname, registered);
+
+        // then
+        assertThat(result.id()).isEqualTo(id);
+        assertThat(result.email()).isEqualTo(email);
+        assertThat(result.profileUrl()).isEqualTo(profileUrl);
+        assertThat(result.nickname()).isEqualTo(nickname);
+        assertThat(result.registered()).isEqualTo(registered);
+    }
+
+    @Test
+    @DisplayName("LoginInfoResponse를 생성한다")
+    void ofSuccess() throws Exception {
+        // given
+        Member member = Member.builder()
+            .email(Email.create("이멜"))
+            .profileUrl("프로필주소")
+            .nickname(Nickname.create("생성된닉네임"))
+            .registered(true)
+            .followStrategy(FollowStrategy.EAGER)
+            .privacyPolicy(PrivacyPolicy.PRIVATE)
+            .build();
+        em.persist(member);
+
+        // when
+        MemberInfo response = MemberInfo.of(member);
+
+        // then
+        assertThat(response.id()).isNotNull();
+        assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
+        assertThat(response.email()).isEqualTo(member.getEmailValue());
+        assertThat(response.nickname()).isEqualTo(member.getNicknameValue());
+        assertThat(response.registered()).isEqualTo(member.isRegistered());
+    }
+
+}

--- a/src/test/java/com/example/temp/auth/dto/response/UserContextTest.java
+++ b/src/test/java/com/example/temp/auth/dto/response/UserContextTest.java
@@ -2,6 +2,8 @@ package com.example.temp.auth.dto.response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.temp.auth.domain.Role;
+import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.entity.Email;
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
@@ -14,56 +16,40 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
 class UserContextTest {
 
-    @Autowired
-    EntityManager em;
-
     @Test
-    @DisplayName("생성자의 순서가 올바른지 테스트한다")
-    void create() throws Exception {
+    @DisplayName("member를 사용해 Normal 권한을 가진 UserContext를 생성한다.")
+    void fromMemberTest() throws Exception {
         // given
-        long id = 1L;
-        String email = "email";
-        String profileUrl = "profile";
-        String nickname = "nick";
-        boolean registered = true;
+        Member member = Member.builder().build();
 
         // when
-        MemberInfo result = new MemberInfo(id, email, profileUrl, nickname, registered);
+        UserContext userContext = UserContext.fromMember(member);
 
         // then
-        assertThat(result.id()).isEqualTo(id);
-        assertThat(result.email()).isEqualTo(email);
-        assertThat(result.profileUrl()).isEqualTo(profileUrl);
-        assertThat(result.nickname()).isEqualTo(nickname);
-        assertThat(result.registered()).isEqualTo(registered);
+        assertThat(userContext.role()).isEqualTo(Role.NORMAL);
     }
 
     @Test
-    @DisplayName("LoginInfoResponse를 생성한다")
-    void ofSuccess() throws Exception {
+    @DisplayName("UserContext가 Normal 권한인지 확인한다.")
+    void testIsNormal() throws Exception {
         // given
-        Member member = Member.builder()
-            .email(Email.create("이멜"))
-            .profileUrl("프로필주소")
-            .nickname(Nickname.create("생성된닉네임"))
-            .registered(true)
-            .followStrategy(FollowStrategy.EAGER)
-            .privacyPolicy(PrivacyPolicy.PRIVATE)
-            .build();
-        em.persist(member);
+        UserContext userContext = new UserContext(1L, Role.NORMAL);
 
-        // when
-        MemberInfo response = MemberInfo.of(member);
+        // when & then
+        assertThat(userContext.isNormal()).isTrue();
+        assertThat(userContext.isAdmin()).isFalse();
+    }
 
-        // then
-        assertThat(response.id()).isNotNull();
-        assertThat(response.profileUrl()).isEqualTo(member.getProfileUrl());
-        assertThat(response.email()).isEqualTo(member.getEmailValue());
-        assertThat(response.nickname()).isEqualTo(member.getNicknameValue());
-        assertThat(response.registered()).isEqualTo(member.isRegistered());
+    @Test
+    @DisplayName("UserContext가 Admin 권한인지 확인한다.")
+    void testIsAdmin() throws Exception {
+        // given
+        UserContext userContext = new UserContext(1L, Role.ADMIN);
+
+        // when & then
+        assertThat(userContext.isAdmin()).isTrue();
+        assertThat(userContext.isNormal()).isFalse();
     }
 }

--- a/src/test/java/com/example/temp/auth/infrastructure/JwtTokenManagerTest.java
+++ b/src/test/java/com/example/temp/auth/infrastructure/JwtTokenManagerTest.java
@@ -163,6 +163,7 @@ class JwtTokenManagerTest {
 
         // then
         assertThat(userContext.id()).isEqualTo(memberId);
+        assertThat(userContext.role()).isEqualTo(role);
     }
 
     private String createToken(Date expired, long subject, Role role) {
@@ -183,7 +184,7 @@ class JwtTokenManagerTest {
         Claims claims = claimsJws.getPayload();
 
         assertThat(claims.getSubject()).isEqualTo(String.valueOf(subject));
-        assertThat(claims.get("role")).isEqualTo(role.name());
+        assertThat(claims).containsEntry("role", role.name());
 
         Instant expiration = claims.getExpiration().toInstant();
         assertThat(expiration).isEqualTo(comparedMachineTime);

--- a/src/test/java/com/example/temp/common/interceptor/AdminInterceptorTest.java
+++ b/src/test/java/com/example/temp/common/interceptor/AdminInterceptorTest.java
@@ -1,0 +1,145 @@
+package com.example.temp.common.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.temp.auth.domain.Role;
+import com.example.temp.auth.infrastructure.TokenParser;
+import com.example.temp.common.dto.UserContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AdminInterceptorTest {
+
+    AdminInterceptor adminInterceptor;
+
+    @Mock
+    TokenParser tokenParser;
+
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    HttpServletResponse response;
+
+    UserContext adminContext;
+
+    @BeforeEach
+    void setUp() {
+        adminInterceptor = new AdminInterceptor(tokenParser);
+        adminContext = UserContext.builder()
+            .id(1L)
+            .role(Role.ADMIN)
+            .build();
+    }
+
+    @Test
+    @DisplayName("사용자가 유효한 토큰을 사용하면 통과한다.")
+    void passSuccess() throws Exception {
+        // given
+        String token = "token";
+        when(tokenParser.parsedClaims(token))
+            .thenReturn(adminContext);
+        when(request.getHeader(HttpHeaders.AUTHORIZATION))
+            .thenReturn("Bearer " + token);
+
+        // when
+        boolean result = adminInterceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isTrue();
+        verify(request, times(1)).setAttribute("memberInfo", adminContext);
+    }
+
+    @Test
+    @DisplayName("인증 헤더에 토큰이 없으면 통과할 수 없다.")
+    void passFailTokenNotFound() throws Exception {
+        // given
+        String token = "token";
+        when(request.getHeader(HttpHeaders.AUTHORIZATION))
+            .thenReturn(null);
+
+        // when
+        boolean result = adminInterceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isFalse();
+        verify(response, times(1)).setStatus(HttpStatus.UNAUTHORIZED.value());
+        verify(request, never()).setAttribute(anyString(), anyLong());
+        verify(tokenParser, never()).parse(anyString());
+    }
+
+    @Test
+    @DisplayName("인증 헤더에 토큰이 Bearer로 시작하지 않으면 통과할 수 없다.")
+    void passFailTokenNotStartBearer() throws Exception {
+        // given
+        String token = "token";
+        when(request.getHeader(HttpHeaders.AUTHORIZATION))
+            .thenReturn(token);
+
+        // when
+        boolean result = adminInterceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isFalse();
+        verify(response, times(1)).setStatus(HttpStatus.UNAUTHORIZED.value());
+        verify(request, never()).setAttribute(anyString(), anyLong());
+        verify(tokenParser, never()).parse(anyString());
+    }
+
+    @Test
+    @DisplayName("어드민이 아닌 사용자는 AdminInterceptor를 통과할 수 없다.")
+    void preHandleFailBecauseUserIsAdmin() throws Exception {
+        UserContext normalUserContext = UserContext.builder()
+            .role(Role.NORMAL)
+            .id(1L)
+            .build();
+
+        String token = "token";
+        when(request.getHeader(HttpHeaders.AUTHORIZATION))
+            .thenReturn("Bearer " + token);
+        when(tokenParser.parsedClaims(token))
+            .thenReturn(normalUserContext);
+
+        // when
+        boolean result = adminInterceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isFalse();
+        verify(request, never()).setAttribute("memberInfo", normalUserContext);
+
+    }
+
+    @Test
+    @DisplayName("Http Method가 OPTIONS일 때, AdminInterceptor를 통과한다")
+    void preHandleSuccessThatMethodIsOptions() throws Exception {
+        UserContext adminContext = UserContext.builder()
+            .role(Role.ADMIN)
+            .id(1L)
+            .build();
+
+        when(request.getMethod())
+            .thenReturn("OPTIONS");
+
+        // when
+        boolean result = adminInterceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+}

--- a/src/test/java/com/example/temp/image/application/ImageServiceTest.java
+++ b/src/test/java/com/example/temp/image/application/ImageServiceTest.java
@@ -3,6 +3,7 @@ package com.example.temp.image.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.temp.auth.domain.Role;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
@@ -38,6 +39,8 @@ class ImageServiceTest {
     @Autowired
     ImageRepository imageRepository;
 
+    UserContext userContext;
+
     @BeforeEach
     void setUp() {
         s3Presigner = S3Presigner.builder()
@@ -45,12 +48,12 @@ class ImageServiceTest {
             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("accessKey", "secretKey")))
             .build();
         imageService = new ImageService(s3Presigner, s3Properties, randomGenerator, imageRepository);
+        userContext = new UserContext(1234L, Role.NORMAL);
     }
 
     @Test
     @DisplayName("presigned url을 생성한다")
     void createPresignedUrl() throws MalformedURLException {
-        UserContext userContext = new UserContext(1L);
         long contentLength = s3Properties.imgMaxContentLength();
         String extValue = "JPEG";
         PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
@@ -82,7 +85,6 @@ class ImageServiceTest {
     @DisplayName("서버에서 지정한 사이즈보다 큰 이미지에 대해서는 presigned url을 생성하지 않는다")
     void createFailImageTooBig() throws Exception {
         // given
-        UserContext userContext = new UserContext(1L);
         long contentLength = s3Properties.imgMaxContentLength() + 1;
         String extValue = "JPEG";
         PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
@@ -97,7 +99,6 @@ class ImageServiceTest {
     @DisplayName("이미지가 아닌 확장자에 대해서는 presigned url을 생성하지 않는다.")
     void createFailInvalidExt() throws Exception {
         // given
-        UserContext userContext = new UserContext(1L);
         long contentLength = s3Properties.imgMaxContentLength();
         String extValue = "TXT";
         PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);
@@ -112,7 +113,6 @@ class ImageServiceTest {
     @DisplayName("존재하지 않는 확장자에 대해서는 presigned url을 생성하지 않는다.")
     void createFailNotExistsExt() throws Exception {
         // given
-        UserContext userContext = new UserContext(1L);
         long contentLength = s3Properties.imgMaxContentLength();
         String extValue = "NOT_FOUND";
         PresignedUrlRequest request = new PresignedUrlRequest(contentLength, extValue);

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -81,7 +81,7 @@ class PostServiceTest {
         savePost(member3, "content2", List.of("image2"));
         savePost(member1, "content3", List.of("image3"));
 
-        UserContext userContext = UserContext.from(member1);
+        UserContext userContext = UserContext.fromMember(member1);
         Pageable pageable = PageRequest.of(0, 5);
 
         // When
@@ -115,7 +115,7 @@ class PostServiceTest {
         savePost(member1, "content3", List.of("image3"));
         savePost(member4, "content4", List.of("image4"));
 
-        UserContext userContext = UserContext.from(member1);
+        UserContext userContext = UserContext.fromMember(member1);
         Pageable pageable = PageRequest.of(0, 5);
 
         // When
@@ -149,7 +149,7 @@ class PostServiceTest {
         savePost(member2, "content3", List.of("image3"));
         savePost(member3, "content4", List.of("image4"));
 
-        UserContext userContext = UserContext.from(member1);
+        UserContext userContext = UserContext.fromMember(member1);
         Pageable pageable = PageRequest.of(0, 10);
 
         // When
@@ -172,7 +172,7 @@ class PostServiceTest {
     void createPost() {
         //given
         Member member = saveMember("email@test.com", "nick");
-        UserContext userContext = UserContext.from(member);
+        UserContext userContext = UserContext.fromMember(member);
         List<String> imageUrls = List.of("imageUrl1", "ImageUrl2");
         List<String> savedImageUrls = saveImagesAndGetUrls(imageUrls);
         List<String> hashtags = List.of("#hashtag1", "#hashtag2");
@@ -196,7 +196,7 @@ class PostServiceTest {
     void createPostWithNonexistentImage() {
         // Given
         Member member = saveMember("email@test.com", "nick");
-        UserContext userContext = UserContext.from(member);
+        UserContext userContext = UserContext.fromMember(member);
 
         List<String> imageUrls = List.of("nonexistent_image");
 
@@ -213,7 +213,7 @@ class PostServiceTest {
     void createPostWithoutImage() {
         //given
         Member member = saveMember("email@test.com", "nick");
-        UserContext userContext = UserContext.from(member);
+        UserContext userContext = UserContext.fromMember(member);
         PostCreateRequest postCreateRequest = new PostCreateRequest("content", null, new ArrayList<>());
 
         //when


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x]  어드민 권한이 있는 사용자만 /admin/**에 접근 가능합니다.
- [x]  어드민 권한이 있는 사용자는 `인증`이 필요한 기능에 접근하지 못합니다.
1. UserContext에 Role이 추가되었습니다.
2. `org.springframework.security:spring-security-crypto` 의존성을 추가했습니다.

## 🏌🏻 리뷰 포인트
없습니다. 지금으로써는 어드민을 등록하고 관리할 일이 많지는 않아서 정말 최소한의 기능만 구현했습니다.

## 🧘🏻 기타 사항

**어드민은 왜 `인증` 기능에 접근하지 못하나요?**
그건 저희 서비스가 SNS이기 때문에 어드민이 글쓰기, 댓글 쓰기 등에 접근하는 게 부자연스럽다고 생각했기 때문입니다.
저는 게시판은 운영자가 글을 작성하는 걸 본 적 있는데, SNS에서는 앱을 사용하며, 단 한 번도 어드민을 보지 못했어요.

**어드민과 회원은 별도로 관리하는 게 적절하다** 라고 결론내리면서 아예 두 개에 대한 연관관계를 없애버렸습니다.
추후 어드민 엔드포인트를 분리하기에도 수월한 구조로 만들었다고 생각합니다.

**org.springframework.security:spring-security-crypto이란?**

- 대칭 암호화, 키 생성, 비밀번호 인코딩을 지원하는 시큐리티 모듈
출처 : https://godekdls.github.io/Spring Security/springsecuritycryptomodule/#google_vignette

왜 해당 기술을 도입했냐면, 먼저 어드민 계정의 경우 OAuth 대신 id, pwd 방식을 사용하기로 결정했습니다.
우리 서버의 코어 기능인데, OAuth를 통해 계정만 있으면 쉽게 접근할 수 있는 구조가 마음에 들지 않았기 때문인데요.

해당 방식을 도입하기로 결정한 뒤, 비밀번호를 어떻게 암호화할 수 있을까를 찾아보았습니다.
대부분 Spring Security를 가져와서 암호화를 진행했고, 저 역시도 해당 흐름을 따라갔는데,,,,
Spring Security를 사용하려면 커스터마이징 해야 하는 부분이 많다는 걸 깨달았습니다.

특히 테스트 도중 **h2에 접근하지 못하는 문제**를 우연히 확인했고, Spring Security 사용하지 말아야겠다고 결론을 내렸습니다.
안그래도 급한 일정인데, 혹시나 예상 못한 문제가 생겨 프론트 개발자들 작업에 딜레이가 걸리겠다는 생각이 드니까 아찔하더라구요.

대안을 찾아보다가 `spring-security-crypto`라는 기술을 찾아 도입하게 되었습니다.

Spring Security로 인해 h2 접근이 막힌 상황을 캡쳐해 함께 첨부합니다.
<img width="1009" alt="스크린샷 2024-02-17 오후 11 43 38" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/63e90d08-5316-4309-979d-e486db04ec14">

close #90