### PR TITLE
[106] refactor: presignedUrl 쿼리파라미터 제외 전체 url 저장하도록 변경

### DIFF
--- a/src/main/java/com/example/temp/image/application/ImageService.java
+++ b/src/main/java/com/example/temp/image/application/ImageService.java
@@ -11,6 +11,7 @@ import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.image.dto.request.PresignedUrlRequest;
 import java.net.URL;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -57,8 +58,15 @@ public class ImageService {
     }
 
     private void saveImageUrl(URL url) {
-        String imageUrl = url.getHost() + url.getPath();
+        String imageUrl = extractImageUrl(url);
         imageRepository.save(Image.create(imageUrl));
+    }
+
+    private String extractImageUrl(URL url) {
+        return Optional.of(url.toString().indexOf("?"))
+            .filter(index -> index != -1)
+            .map(index -> url.toString().substring(0, index))
+            .orElse(url.toString());
     }
 
     private String generateFileName(Long memberId) {

--- a/src/test/java/com/example/temp/image/application/ImageServiceTest.java
+++ b/src/test/java/com/example/temp/image/application/ImageServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.temp.image.application;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -12,6 +13,7 @@ import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.image.dto.request.PresignedUrlRequest;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,7 +62,8 @@ class ImageServiceTest {
 
         // then
         validateUrl(presignedUrl);
-        String imageUrl = presignedUrl.getHost() + presignedUrl.getPath();
+        String imageUrl = extractImageUrl(presignedUrl);
+
         assertThat(imageRepository.existsByUrl(imageUrl)).isTrue();
     }
 
@@ -121,5 +124,12 @@ class ImageServiceTest {
         assertThatThrownBy(() -> imageService.createPresignedUrl(userContext, request))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.EXTENSION_NOT_SUPPORTED.getMessage());
+    }
+
+    private String extractImageUrl(URL url) {
+        return Optional.of(url.toString().indexOf("?"))
+            .filter(index -> index != -1)
+            .map(index -> url.toString().substring(0, index))
+            .orElse(url.toString());
     }
 }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] Image 테이블에 저장되는 url 형식 변경

## 🏌🏻 리뷰 포인트
해당 부분이 Image 테이블에 저장될 때 Host + Path만 하면 쿼리스트르링을 제외한 나머지 url을 전부 갖고 온다고 착각했습니다.
받아온 URL을 protocal부터 String으로 변환할 시 '://' 해당 부분이 빠져서 URL자체를 toStirng으로 변경 후 ? 앞 부분까지 잘라서 가져오도록 했습니다.
쿼리 파라미터가 없을 시에는 받아온 url자체를 toString으로 저장할 수 있도록 변경했습니다.

## 🧘🏻 기타 사항
```java
private void saveImageUrl(URL url) {
        String imageUrl = extractImageUrl(url);
        imageRepository.save(Image.create(imageUrl));
    }

    private String extractImageUrl(URL url) {
        return Optional.of(url.toString().indexOf("?"))
            .filter(index -> index != -1)
            .map(index -> url.toString().substring(0, index))
            .orElse(url.toString());
    }
```
close #106 