### PR TITLE
[#105] refactor: PostImage가 Image 엔티티의 url값만 갖고 있도록 수정

### DIFF
--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -1,7 +1,6 @@
 package com.example.temp.post.domain;
 
 import com.example.temp.common.entity.BaseTimeEntity;
-import com.example.temp.image.domain.Image;
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -69,8 +68,7 @@ public class Post extends BaseTimeEntity {
     public Optional<String> getImageUrl() {
         return postImages.stream()
             .findFirst()
-            .map(PostImage::getImage)
-            .map(Image::getUrl);
+            .map(PostImage::getImageUrl);
     }
 
 }

--- a/src/main/java/com/example/temp/post/domain/PostImage.java
+++ b/src/main/java/com/example/temp/post/domain/PostImage.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,19 +31,17 @@ public class PostImage extends BaseTimeEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "image_id")
-    private Image image;
+    private String imageUrl;
 
     @Builder
-    private PostImage(Image image) {
-        this.image = image;
+    private PostImage(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
     public static PostImage createPostImage(Image image) {
         image.use();
         return PostImage.builder()
-            .image(image)
+            .imageUrl(image.getUrl())
             .build();
     }
 

--- a/src/main/java/com/example/temp/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostCreateResponse.java
@@ -30,7 +30,7 @@ public record PostCreateResponse(
 
     private static List<String> urlFromPostImage(List<PostImage> postImages) {
         return postImages.stream()
-            .map(postImage -> postImage.getImage().getUrl())
+            .map(PostImage::getImageUrl)
             .toList();
     }
 

--- a/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
@@ -1,8 +1,8 @@
 package com.example.temp.post.dto.response;
 
 import com.example.temp.post.domain.Post;
+import com.example.temp.post.domain.PostImage;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import lombok.Builder;
 
@@ -29,7 +29,7 @@ public record PostDetailResponse(
 
     private static List<String> getImageUrls(Post post) {
         return post.getPostImages().stream()
-            .map(postImage -> postImage.getImage().getUrl())
+            .map(PostImage::getImageUrl)
             .toList();
     }
 

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -34,7 +34,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] PostImage, Image OneToOne 연관관계 제거
- [X] PostImage가 Image에서 찾아온 url만 들고 있도록 수정

## 🏌🏻 리뷰 포인트
![image](https://github.com/GymHubCommunity/GymHub-BE/assets/87960006/87abd290-5a95-4a01-a2ec-ceaca75894b2)
- 이슈 부분에 올린 것 처럼 Image와 PostImage가 1:1 연관관계를 맺고 있어 게시글을 조회할 때 게시글에 있는 ImageUrl을 가져오려면 PostImage에서 Image 조회 쿼리가 나가기 때문에 N + 1 문제가 발생했습니다.. 해당 부분을 해결하고자 많이 고민하였는데 현재로썬 연관관계를 끊고 Image의 url부분만 PostImage가 들고 있으면 N + 1 문제를 해결하고 성능이슈도 해결할 수 있다고 판단했습니다.

<img width="962" alt="image" src="https://github.com/GymHubCommunity/GymHub-BE/assets/87960006/26dbf556-436f-4b51-a3f2-e3f4d24243a5">
- 이미지를 조회해오는 쿼리문들이 사라진 것을 확인할 수 있습니다.

## 🧘🏻 기타 사항
아직 많이 부족해서 연관관계를 끊는 방법밖에 생각하지 못했는데... 좀 더 복잡한 구조가 되면 N + 1 문제가 발생하였을 때 어떤식으로 해결해 나갈수 있을 지 많은 경험이 필요한 것 같습니다. 태훈님은 어떤식으로 해결하고 계신지 궁금합니다.

close #105 