### PR TITLE
[#112] 무한스크롤을 위해 Page -> Slice로 변경

### DIFF
--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -20,15 +20,15 @@ import com.example.temp.post.domain.PostHashtag;
 import com.example.temp.post.domain.PostImage;
 import com.example.temp.post.domain.PostRepository;
 import com.example.temp.post.dto.request.PostCreateRequest;
-import com.example.temp.post.dto.response.PagePostResponse;
+import com.example.temp.post.dto.response.SlicePostResponse;
 import com.example.temp.post.dto.response.PostCreateResponse;
 import com.example.temp.post.dto.response.PostDetailResponse;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,11 +57,11 @@ public class PostService {
         return PostCreateResponse.from(savedPost);
     }
 
-    public PagePostResponse findPostsFromFollowings(UserContext userContext, Pageable pageable) {
+    public SlicePostResponse findPostsFromFollowings(UserContext userContext, Pageable pageable) {
         Member member = findMember(userContext);
         List<Member> followings = findFollowingOf(member);
-        Page<Post> posts = postRepository.findByMemberInOrderByRegisteredAtDesc(followings, pageable);
-        return PagePostResponse.from(posts);
+        Slice<Post> posts = postRepository.findByMemberInOrderByRegisteredAtDesc(followings, pageable);
+        return SlicePostResponse.from(posts);
     }
 
     public PostDetailResponse findPost(Long postId, UserContext userContext) {

--- a/src/main/java/com/example/temp/post/domain/PostRepository.java
+++ b/src/main/java/com/example/temp/post/domain/PostRepository.java
@@ -2,13 +2,13 @@ package com.example.temp.post.domain;
 
 import com.example.temp.member.domain.Member;
 import java.util.List;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    Page<Post> findByMemberInOrderByRegisteredAtDesc(List<Member> members, Pageable pageable);
+    Slice<Post> findByMemberInOrderByRegisteredAtDesc(List<Member> members, Pageable pageable);
 }

--- a/src/main/java/com/example/temp/post/dto/response/SlicePostResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/SlicePostResponse.java
@@ -3,19 +3,18 @@ package com.example.temp.post.dto.response;
 import com.example.temp.post.domain.Post;
 import java.util.List;
 import lombok.Builder;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 @Builder
-public record PagePostResponse(
+public record SlicePostResponse(
     List<PostElementResponse> posts,
-    int totalPages,
-    int totalElements
+    boolean hasNext
 ) {
 
-    public static PagePostResponse from(Page<Post> posts) {
+    public static SlicePostResponse from(Slice<Post> posts) {
         List<PostElementResponse> postElements = posts.stream()
             .map(PostElementResponse::from)
             .toList();
-        return new PagePostResponse(postElements, posts.getTotalPages(), (int) posts.getTotalElements());
+        return new SlicePostResponse((postElements), posts.hasNext());
     }
 }

--- a/src/main/java/com/example/temp/post/dto/response/SlicePostResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/SlicePostResponse.java
@@ -15,6 +15,6 @@ public record SlicePostResponse(
         List<PostElementResponse> postElements = posts.stream()
             .map(PostElementResponse::from)
             .toList();
-        return new SlicePostResponse((postElements), posts.hasNext());
+        return new SlicePostResponse(postElements, posts.hasNext());
     }
 }

--- a/src/main/java/com/example/temp/post/presentation/PostController.java
+++ b/src/main/java/com/example/temp/post/presentation/PostController.java
@@ -6,7 +6,7 @@ import com.example.temp.common.annotation.Login;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.post.application.PostService;
 import com.example.temp.post.dto.request.PostCreateRequest;
-import com.example.temp.post.dto.response.PagePostResponse;
+import com.example.temp.post.dto.response.SlicePostResponse;
 import com.example.temp.post.dto.response.PostCreateResponse;
 import com.example.temp.post.dto.response.PostDetailResponse;
 import java.time.LocalDateTime;
@@ -36,9 +36,9 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<PagePostResponse> getFollowingPosts(@Login UserContext userContext,
-        @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
-        PagePostResponse posts = postService.findPostsFromFollowings(userContext, pageable);
+    public ResponseEntity<SlicePostResponse> getFollowingPosts(@Login UserContext userContext,
+        @PageableDefault(sort = "registeredAt", direction = DESC) Pageable pageable) {
+        SlicePostResponse posts = postService.findPostsFromFollowings(userContext, pageable);
         return ResponseEntity.ok(posts);
     }
 

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.temp.post.application;
 
 import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -25,10 +26,10 @@ import com.example.temp.post.domain.Post;
 import com.example.temp.post.domain.PostImage;
 import com.example.temp.post.domain.PostRepository;
 import com.example.temp.post.dto.request.PostCreateRequest;
-import com.example.temp.post.dto.response.PagePostResponse;
 import com.example.temp.post.dto.response.PostCreateResponse;
 import com.example.temp.post.dto.response.PostDetailResponse;
 import com.example.temp.post.dto.response.PostElementResponse;
+import com.example.temp.post.dto.response.SlicePostResponse;
 import com.example.temp.post.dto.response.WriterInfo;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -84,13 +85,14 @@ class PostServiceTest {
         savePost(member1, "content3", List.of("image3"));
 
         UserContext userContext = UserContext.fromMember(member1);
-        Pageable pageable = PageRequest.of(0, 5);
+        Pageable pageable = PageRequest.of(0, 10);
 
         // When
-        PagePostResponse pagePostResponse = postService.findPostsFromFollowings(userContext, pageable);
+        SlicePostResponse slicePostResponse = postService.findPostsFromFollowings(userContext, pageable);
 
         // Then
-        assertThat(pagePostResponse.posts()).hasSize(2)
+        assertThat(slicePostResponse.hasNext()).isFalse();
+        assertThat(slicePostResponse.posts()).hasSize(2)
             .extracting("writerInfo")
             .containsExactlyInAnyOrder(WriterInfo.from(member2), WriterInfo.from(member3));
     }
@@ -121,10 +123,10 @@ class PostServiceTest {
         Pageable pageable = PageRequest.of(0, 5);
 
         // When
-        PagePostResponse pagePostResponse = postService.findPostsFromFollowings(userContext, pageable);
+        SlicePostResponse slicePostResponse = postService.findPostsFromFollowings(userContext, pageable);
 
         // Then
-        assertThat(pagePostResponse.posts()).hasSize(2)
+        assertThat(slicePostResponse.posts()).hasSize(2)
             .extracting(post -> post.writerInfo().writerId())
             .containsExactlyInAnyOrder(member2.getId(), member3.getId())
             .doesNotContain(member4.getId());
@@ -155,7 +157,7 @@ class PostServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // When
-        PagePostResponse postsPage = postService.findPostsFromFollowings(userContext, pageable);
+        SlicePostResponse postsPage = postService.findPostsFromFollowings(userContext, pageable);
         List<PostElementResponse> posts = postsPage.posts();
 
         // Then

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -235,7 +235,7 @@ class PostServiceTest {
     void findPostById() {
         // Given
         Member member = saveMember("email@test.com", "nick");
-        UserContext userContext = UserContext.from(member);
+        UserContext userContext = UserContext.fromMember(member);
         List<String> imageUrls = List.of("imageUrl1", "imageUrl2");
         List<String> savedImageUrls = saveImagesAndGetUrls(imageUrls);
         List<String> hashtags = List.of("#hashtag1", "#hashtag2");
@@ -257,7 +257,7 @@ class PostServiceTest {
     void findPostNotContainsImageAndHashtag() {
         // Given
         Member member = saveMember("email@test.com", "nick");
-        UserContext userContext = UserContext.from(member);
+        UserContext userContext = UserContext.fromMember(member);
         List<String> emptyList = Collections.emptyList();
         PostCreateRequest request = new PostCreateRequest("content1", emptyList, emptyList);
         PostCreateResponse savedPost = postService.createPost(userContext, request, LocalDateTime.now());

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -1,7 +1,6 @@
 package com.example.temp.post.application;
 
 import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;

--- a/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
@@ -17,9 +17,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,8 +56,9 @@ class PostRepositoryTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // When
-        Page<Post> postsPage = postRepository.findByMemberInOrderByRegisteredAtDesc(followMembers, pageable);
-        List<Post> posts = postsPage.getContent();
+        Slice<Post> slicePost = postRepository.findByMemberInOrderByRegisteredAtDesc(
+            followMembers, pageable);
+        List<Post> posts = slicePost.getContent();
 
         // Then
         assertThat(posts).hasSize(2)
@@ -79,10 +80,11 @@ class PostRepositoryTest {
 
         // When
         Pageable pageable = PageRequest.of(0, 10);
-        Page<Post> postsPage = postRepository.findByMemberInOrderByRegisteredAtDesc(List.of(member1, member2), pageable);
+        Slice<Post> slicePost = postRepository.findByMemberInOrderByRegisteredAtDesc(
+            List.of(member1, member2), pageable);
 
         // Then
-        assertThat(postsPage.getContent()).isEmpty();
+        assertThat(slicePost.getContent()).isEmpty();
     }
 
     @DisplayName("게시글을 최근 작성게시글 부터 한 페이지에 5개씩 가져 올 수 있다.")
@@ -100,13 +102,14 @@ class PostRepositoryTest {
         }
 
         // When
-        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
-        Page<Post> postsPage = postRepository.findByMemberInOrderByRegisteredAtDesc(List.of(member1, member2), pageable);
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("registeredAt").descending());
+        Slice<Post> slicePost = postRepository.findByMemberInOrderByRegisteredAtDesc(
+            List.of(member1, member2), pageable);
 
         // Then
-        assertThat(postsPage.getNumber()).isEqualTo(pageNumber);
-        assertThat(postsPage.getSize()).isEqualTo(pageSize);
-        assertThat(postsPage.getContent()).hasSize(pageSize);
+        assertThat(slicePost.getNumber()).isEqualTo(pageNumber);
+        assertThat(slicePost.getSize()).isEqualTo(pageSize);
+        assertThat(slicePost.getContent()).hasSize(pageSize);
     }
 
     @DisplayName("게시글은 최신순으로 조회 된다.")
@@ -126,8 +129,9 @@ class PostRepositoryTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // When
-        Page<Post> postsPage = postRepository.findByMemberInOrderByRegisteredAtDesc(followMembers, pageable);
-        List<Post> posts = postsPage.getContent();
+        Slice<Post> slicePost = postRepository.findByMemberInOrderByRegisteredAtDesc(
+            followMembers, pageable);
+        List<Post> posts = slicePost.getContent();
 
         // Then
         assertThat(posts).hasSize(2)


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] 팔로우한 사람들의 게시글 목록을 Page -> Slice로 반환하도록 변경

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
Response에서 hasNext로 다음 글이 있는지 없는지 판단할 수 있는 부분을 추가했습니다.

close #112 