### PR TITLE
[#110] 게시글 수정

### DIFF
--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -42,7 +42,7 @@ public enum ErrorCode {
     //게시글
     CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "게시글은 최대 2,000자 까지 가능합니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
-    UNAUTHORIZED_POST(HttpStatus.UNAUTHORIZED, "게시글에 대한 권한이 없습니다."),
+    UNAUTHORIZED_POST(HttpStatus.FORBIDDEN, "게시글에 대한 권한이 없습니다."),
 
     // 이미지
     IMAGE_TOO_BIG(HttpStatus.BAD_REQUEST, "이미지의 크기가 너무 큽니다"),

--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     //게시글
     CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "게시글은 최대 2,000자 까지 가능합니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+    UNAUTHORIZED_POST(HttpStatus.UNAUTHORIZED, "게시글에 대한 권한이 없습니다."),
 
     // 이미지
     IMAGE_TOO_BIG(HttpStatus.BAD_REQUEST, "이미지의 크기가 너무 큽니다"),

--- a/src/main/java/com/example/temp/image/domain/Image.java
+++ b/src/main/java/com/example/temp/image/domain/Image.java
@@ -51,4 +51,9 @@ public class Image {
     public void use() {
         this.used = true;
     }
+
+    public void notUse() {
+        this.used = false;
+    }
+
 }

--- a/src/main/java/com/example/temp/image/domain/Image.java
+++ b/src/main/java/com/example/temp/image/domain/Image.java
@@ -48,11 +48,11 @@ public class Image {
             .build();
     }
 
-    public void use() {
+    public void activate() {
         this.used = true;
     }
 
-    public void notUse() {
+    public void deactivate() {
         this.used = false;
     }
 

--- a/src/main/java/com/example/temp/image/domain/ImageRepository.java
+++ b/src/main/java/com/example/temp/image/domain/ImageRepository.java
@@ -1,5 +1,6 @@
 package com.example.temp.image.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +10,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     boolean existsByUrl(String url);
 
     Image findByUrl(String url);
+
+    List<Image> findByUrlIn(List<String> urls);
 
 }

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -144,7 +144,7 @@ public class PostService {
         List<Image> images = imageRepository.findByUrlIn(post.getPostImages().stream()
             .map(PostImage::getImageUrl)
             .toList());
-        images.forEach(Image::notUse);
+        images.forEach(Image::deactivate);
     }
 
     private void validateOwner(UserContext userContext, Post post) {

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -3,6 +3,7 @@ package com.example.temp.post.application;
 import static com.example.temp.common.exception.ErrorCode.AUTHENTICATED_FAIL;
 import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
 import static com.example.temp.common.exception.ErrorCode.POST_NOT_FOUND;
+import static com.example.temp.common.exception.ErrorCode.UNAUTHORIZED_POST;
 
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ApiException;
@@ -20,9 +21,10 @@ import com.example.temp.post.domain.PostHashtag;
 import com.example.temp.post.domain.PostImage;
 import com.example.temp.post.domain.PostRepository;
 import com.example.temp.post.dto.request.PostCreateRequest;
-import com.example.temp.post.dto.response.SlicePostResponse;
+import com.example.temp.post.dto.request.PostUpdateRequest;
 import com.example.temp.post.dto.response.PostCreateResponse;
 import com.example.temp.post.dto.response.PostDetailResponse;
+import com.example.temp.post.dto.response.SlicePostResponse;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -66,9 +68,29 @@ public class PostService {
 
     public PostDetailResponse findPost(Long postId, UserContext userContext) {
         findMember(userContext);
-        Post findPost = postRepository.findById(postId)
-            .orElseThrow(() -> new ApiException(POST_NOT_FOUND));
+        Post findPost = findPost(postId);
         return PostDetailResponse.from(findPost);
+    }
+
+    @Transactional
+    public void updatePost(Long postId, UserContext userContext, PostUpdateRequest request) {
+        Post post = findPost(postId);
+        validateOwner(userContext, post);
+
+        post.updateContent(request.content());
+        updatePostImages(request, post);
+        updatePostHashtags(request, post);
+    }
+
+    private void updatePostImages(PostUpdateRequest request, Post post) {
+        notUseImage(post);
+        post.getPostImages().clear();
+        createPostImages(request.imageUrls(), post);
+    }
+
+    private void updatePostHashtags(PostUpdateRequest request, Post post) {
+        post.getPostHashtags().clear();
+        createPostHashtags(request.hashTags(), post);
     }
 
     private Member findMember(UserContext userContext) {
@@ -106,10 +128,28 @@ public class PostService {
             .forEach(postHashtag -> postHashtag.relatePost(post));
     }
 
+    private Post findPost(Long postId) {
+        return postRepository.findById(postId)
+            .orElseThrow(() -> new ApiException(POST_NOT_FOUND));
+    }
+
     private List<Member> findFollowingOf(Member member) {
         return followRepository.findAllByFromIdAndStatus(
                 member.getId(), FollowStatus.APPROVED).stream()
             .map(Follow::getTo)
             .toList();
+    }
+
+    private void notUseImage(Post post) {
+        List<Image> images = imageRepository.findByUrlIn(post.getPostImages().stream()
+            .map(PostImage::getImageUrl)
+            .toList());
+        images.forEach(Image::notUse);
+    }
+
+    private void validateOwner(UserContext userContext, Post post) {
+        if (!post.isOwner(userContext.id())) {
+            throw new ApiException(UNAUTHORIZED_POST);
+        }
     }
 }

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -83,7 +83,7 @@ public class PostService {
     }
 
     private void updatePostImages(PostUpdateRequest request, Post post) {
-        notUseImage(post);
+        disableImage(post);
         post.getPostImages().clear();
         createPostImages(request.imageUrls(), post);
     }
@@ -140,7 +140,7 @@ public class PostService {
             .toList();
     }
 
-    private void notUseImage(Post post) {
+    private void disableImage(Post post) {
         List<Image> images = imageRepository.findByUrlIn(post.getPostImages().stream()
             .map(PostImage::getImageUrl)
             .toList());

--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -49,7 +49,7 @@ public class Post extends BaseTimeEntity {
     private List<PostImage> postImages = new ArrayList<>();
 
     @BatchSize(size = 100)
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostHashtag> postHashtags = new ArrayList<>();
 
     private LocalDateTime registeredAt;
@@ -71,4 +71,14 @@ public class Post extends BaseTimeEntity {
             .map(PostImage::getImageUrl);
     }
 
+    public boolean isOwner(Long memberId) {
+        if (memberId == null) {
+            return false;
+        }
+        return member.getId().equals(memberId);
+    }
+
+    public void updateContent(String content) {
+        this.content = Content.create(content);
+    }
 }

--- a/src/main/java/com/example/temp/post/domain/PostImage.java
+++ b/src/main/java/com/example/temp/post/domain/PostImage.java
@@ -39,7 +39,7 @@ public class PostImage extends BaseTimeEntity {
     }
 
     public static PostImage createPostImage(Image image) {
-        image.use();
+        image.activate();
         return PostImage.builder()
             .imageUrl(image.getUrl())
             .build();

--- a/src/main/java/com/example/temp/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/example/temp/post/dto/request/PostUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.temp.post.dto.request;
+
+import jakarta.annotation.Nullable;
+import java.util.List;
+
+public record PostUpdateRequest(
+    String content,
+    @Nullable
+    List<String> imageUrls,
+    @Nullable
+    List<String> hashTags
+) {
+
+}

--- a/src/main/java/com/example/temp/post/presentation/PostController.java
+++ b/src/main/java/com/example/temp/post/presentation/PostController.java
@@ -14,9 +14,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,5 +47,12 @@ public class PostController {
     @GetMapping("/{postId}")
     public ResponseEntity<PostDetailResponse> getPost(@PathVariable Long postId, @Login UserContext userContext) {
         return ResponseEntity.ok(postService.findPost(postId, userContext));
+    }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<Void> updatePost(@PathVariable Long postId, @Login UserContext userContext,
+        @Validated @RequestBody PostUpdateRequest request) {
+        postService.updatePost(postId, userContext, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/temp/post/presentation/PostController.java
+++ b/src/main/java/com/example/temp/post/presentation/PostController.java
@@ -6,6 +6,7 @@ import com.example.temp.common.annotation.Login;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.post.application.PostService;
 import com.example.temp.post.dto.request.PostCreateRequest;
+import com.example.temp.post.dto.request.PostUpdateRequest;
 import com.example.temp.post.dto.response.SlicePostResponse;
 import com.example.temp.post.dto.response.PostCreateResponse;
 import com.example.temp.post.dto.response.PostDetailResponse;

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -1,7 +1,6 @@
 package com.example.temp.post.application;
 
 import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -182,7 +181,7 @@ class PostServiceTest {
         List<String> imageUrls = List.of("imageUrl1", "ImageUrl2");
         List<String> savedImageUrls = saveImagesAndGetUrls(imageUrls);
         List<String> hashtags = List.of("#hashtag1", "#hashtag2");
-        List<String> savedHashtags = saveHashtagAndGet(hashtags);
+        List<String> savedHashtags = saveHashtagsAndGet(hashtags);
 
         PostCreateRequest request = new PostCreateRequest("content1", savedImageUrls, savedHashtags);
         LocalDateTime registeredAt = LocalDateTime.now();
@@ -243,7 +242,7 @@ class PostServiceTest {
         List<String> imageUrls = List.of("imageUrl1", "imageUrl2");
         List<String> savedImageUrls = saveImagesAndGetUrls(imageUrls);
         List<String> hashtags = List.of("#hashtag1", "#hashtag2");
-        List<String> savedHashtags = saveHashtagAndGet(hashtags);
+        List<String> savedHashtags = saveHashtagsAndGet(hashtags);
         PostCreateRequest request = new PostCreateRequest("content1", savedImageUrls, savedHashtags);
         PostCreateResponse savedPost = postService.createPost(userContext, request, LocalDateTime.now());
 
@@ -300,7 +299,7 @@ class PostServiceTest {
         List<String> imageUrls = List.of("imageUrl1", "ImageUrl2");
         List<String> savedImageUrls = saveImagesAndGetUrls(imageUrls);
         List<String> hashtags = List.of("#hashtag1", "#hashtag2");
-        List<String> savedHashtags = saveHashtagAndGet(hashtags);
+        List<String> savedHashtags = saveHashtagsAndGet(hashtags);
 
         PostCreateRequest request = new PostCreateRequest("content1", savedImageUrls, savedHashtags);
         LocalDateTime registeredAt = LocalDateTime.now();
@@ -309,7 +308,7 @@ class PostServiceTest {
         List<String> updateImageUrl = List.of("updateImage");
         List<String> savedUpdateUrl = saveImagesAndGetUrls(updateImageUrl);
         List<String> updateHashtag = List.of("#updateHashtag");
-        List<String> savedUpdateHashtag = saveHashtagAndGet(updateHashtag);
+        List<String> savedUpdateHashtag = saveHashtagsAndGet(updateHashtag);
         PostUpdateRequest updateRequest = new PostUpdateRequest("updateContent", savedUpdateUrl, savedUpdateHashtag);
         Post post = postRepository.findById(response.postId()).orElseThrow();
 
@@ -369,7 +368,7 @@ class PostServiceTest {
         return imageUrls;
     }
 
-    private List<String> saveHashtagAndGet(List<String> names) {
+    private List<String> saveHashtagsAndGet(List<String> names) {
         names.forEach(this::saveHashtag);
         return names;
     }

--- a/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
@@ -165,7 +165,7 @@ class PostRepositoryTest {
         imageUrls.stream()
             .map(url -> imageRepository.findByUrl(url))
             .forEach(image -> {
-                image.use();
+                image.activate();
                 PostImage postImage = PostImage.createPostImage(image);
                 postImage.relate(post);
 


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] 게시글 수정 로직 구현
- [X] 게시글 수정 시 Image 데이타 use -> false 처리

## 🏌🏻 리뷰 포인트
시간이 부족해서 쉽지가 않네요. 게시글 수정 부분을 개발하다 보니 안좋은 코드들이 보이기 시작하는데 해당 부분을 리팩토링 할 시간이 부족 한 것 같습니다. 기간에 맞춰 구현을 끝내고 추후 리팩토링을 하는 식으로 갈 생각입니다.
```java
 @Transactional
    public void updatePost(Long postId, UserContext userContext, PostUpdateRequest request) {
        Post post = findPost(postId);
        validateOwner(userContext, post);

        post.updateContent(request.content());
        updatePostImages(request, post);
        updatePostHashtags(request, post);
    }
```
현재 update로직에서 PostImage와 PostHashtag 부분을 따로 업데이트 해주는 로직이 서비스 내에 존재하는데 해당 로직을 Post객체 내로 들고 와서 update 메소드를 만들어 처리해주면 좋겠다는 생각이 들고 있습니다. 그런데 게시글 생성 시 사용하는 메소드를 update메소드 내부에서 사용하고 있기 때문에 건드리기 시작했다가는 큰 작업이 될 거 같아서

```java
 private void updatePostImages(PostUpdateRequest request, Post post) {
        notUseImage(post);
        post.getPostImages().clear();
        createPostImages(request.imageUrls(), post);
    }

    private void updatePostHashtags(PostUpdateRequest request, Post post) {
        post.getPostHashtags().clear();
        createPostHashtags(request.hashTags(), post);
    }
```

해당 방식으로 작성을 했습니다.

여기서 notUseImage(post) 메소드를 보면 이제 PostImage가 들고 있는 url로 Image 객체를 찾아 해당 부분의 used = false 처리해주는 작업도 포함 시켰는데 이 부분에 대해선 어떤식으로 작성하면 좋을지 의견을 듣고 싶습니다.

```java
 private void notUseImage(Post post) {
        List<Image> images = imageRepository.findByUrlIn(post.getPostImages().stream()
            .map(PostImage::getImageUrl)
            .toList());
        images.forEach(Image::notUse);
    }
```

## 🧘🏻 기타 사항

close #110 