### PR TITLE
[#122, #126] 운동 기록 수정, 삭제

### DIFF
--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     // 운동 기록
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 운동기록은 존재하지 않습니다."),
     TRACK_MACHINE_NAME_INVALID(HttpStatus.BAD_REQUEST, "운동기구의 이름은 공백이어서는 안됩니다."),
+    TRACK_CANT_EMPTY(HttpStatus.BAD_REQUEST, "운동기록 내 트랙은 최소 한 개 이상 존재해야 합니다."),
     SET_CANT_EMPTY(HttpStatus.BAD_REQUEST, "트랙 내 세트는 최소 한 개 이상 존재해야 합니다."),
     SET_WEIGHT_INVALID(HttpStatus.BAD_REQUEST, "세트의 무게는 0보다 커야 합니다."),
     SET_REPEAT_CNT_INVALID(HttpStatus.BAD_REQUEST, "세트의 반복 횟수는 0보다 커야 합니다.");

--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
     MACHINE_MAPPED_INVALID_BODY_PART(HttpStatus.BAD_REQUEST, "입력하신 신체부위 중 적절하지 않은 게 있습니다."),
 
     // 운동 기록
+    RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 운동기록은 존재하지 않습니다."),
     TRACK_MACHINE_NAME_INVALID(HttpStatus.BAD_REQUEST, "운동기구의 이름은 공백이어서는 안됩니다."),
     SET_CANT_EMPTY(HttpStatus.BAD_REQUEST, "트랙 내 세트는 최소 한 개 이상 존재해야 합니다."),
     SET_WEIGHT_INVALID(HttpStatus.BAD_REQUEST, "세트의 무게는 0보다 커야 합니다."),

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -38,6 +38,11 @@ public class ExerciseRecordService {
     @Transactional
     public void update(UserContext userContext, long targetId, ExerciseRecordUpdateRequest request) {
         Member member = findMember(userContext);
+        ExerciseRecord exerciseRecord = exerciseRecordRepository.findById(targetId)
+            .orElseThrow(() -> new ApiException(ErrorCode.RECORD_NOT_FOUND));
+        if (!exerciseRecord.isOwnedBy(member)) {
+            throw new ApiException(ErrorCode.AUTHORIZED_FAIL);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -36,6 +36,7 @@ public class ExerciseRecordService {
         if (!exerciseRecord.isOwnedBy(member)) {
             throw new ApiException(ErrorCode.AUTHORIZED_FAIL);
         }
+        exerciseRecordRepository.delete(exerciseRecord);
     }
 
     private Member findMember(UserContext userContext) {

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -31,6 +31,11 @@ public class ExerciseRecordService {
     @Transactional
     public void delete(UserContext userContext, long targetId) {
         Member member = findMember(userContext);
+        ExerciseRecord exerciseRecord = exerciseRecordRepository.findById(targetId)
+            .orElseThrow(() -> new ApiException(ErrorCode.RECORD_NOT_FOUND));
+        if (!exerciseRecord.isOwnedBy(member)) {
+            throw new ApiException(ErrorCode.AUTHORIZED_FAIL);
+        }
     }
 
     private Member findMember(UserContext userContext) {

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -8,6 +8,7 @@ import com.example.temp.member.domain.MemberRepository;
 import com.example.temp.record.domain.ExerciseRecord;
 import com.example.temp.record.domain.ExerciseRecordRepository;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest;
+import com.example.temp.record.dto.request.ExerciseRecordUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,17 @@ public class ExerciseRecordService {
         ExerciseRecord exerciseRecord = request.toEntityWith(member);
         exerciseRecordRepository.save(exerciseRecord);
         return exerciseRecord.getId();
+    }
+
+    /**
+     * 기존 Track과 Set을 모두 지우고 새로운 데이터를 넣는 방식을 사용할 예정입니다. 추후 내부 로직을 리팩토링할 예정입니다.
+     * @param userContext
+     * @param targetId
+     * @param request
+     */
+    @Transactional
+    public void update(UserContext userContext, long targetId, ExerciseRecordUpdateRequest request) {
+        Member member = findMember(userContext);
     }
 
     @Transactional

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -28,6 +28,11 @@ public class ExerciseRecordService {
         return exerciseRecord.getId();
     }
 
+    @Transactional
+    public void delete(UserContext userContext, long targetId) {
+        Member member = findMember(userContext);
+    }
+
     private Member findMember(UserContext userContext) {
         return memberRepository.findById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -31,9 +31,6 @@ public class ExerciseRecordService {
 
     /**
      * 기존 Track과 Set을 모두 지우고 새로운 데이터를 넣는 방식을 사용할 예정입니다. 추후 내부 로직을 리팩토링할 예정입니다.
-     * @param userContext
-     * @param targetId
-     * @param request
      */
     @Transactional
     public void update(UserContext userContext, long targetId, ExerciseRecordUpdateRequest request) {
@@ -43,6 +40,7 @@ public class ExerciseRecordService {
         if (!exerciseRecord.isOwnedBy(member)) {
             throw new ApiException(ErrorCode.AUTHORIZED_FAIL);
         }
+        exerciseRecord.update(request.toEntityWith(member));
     }
 
     @Transactional

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
@@ -1,6 +1,8 @@
 package com.example.temp.record.domain;
 
 import com.example.temp.common.entity.BaseTimeEntity;
+import com.example.temp.common.exception.ApiException;
+import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.member.domain.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -46,11 +48,17 @@ public class ExerciseRecord extends BaseTimeEntity {
 
     @Builder
     private ExerciseRecord(Member member, List<Track> tracks, LocalDate recordDate) {
+        validate(tracks);
         this.member = member;
         this.recordDate = recordDate;
         this.tracks = new ArrayList<>();
-        if (tracks != null) {
-            tracks.forEach(track -> track.relate(this));
+        tracks.forEach(track -> track.relate(this));
+    }
+
+    private void validate(List<Track> tracks) {
+        Objects.requireNonNull(tracks);
+        if (tracks.isEmpty()) {
+            throw new ApiException(ErrorCode.TRACK_CANT_EMPTY);
         }
     }
 

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -58,5 +59,10 @@ public class ExerciseRecord extends BaseTimeEntity {
             .member(member)
             .tracks(tracks)
             .build();
+    }
+
+    public boolean isOwnedBy(Member member) {
+        Objects.requireNonNull(member);
+        return Objects.equals(member, getMember());
     }
 }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
@@ -67,11 +67,11 @@ public class ExerciseRecord extends BaseTimeEntity {
     }
 
     /**
-     * ExerciseRecord를 입력받아, 내부의 Track을 변경합니다.
+     * ExerciseRecord를 입력받아, 내부의 Track을 변경합니다. ConcurrentModificationException 으로 인해 updated의 tracks를 복사한 뒤 사용합니다.
      */
     public void update(ExerciseRecord updated) {
         this.tracks.clear();
-        updated.getTracks()
-            .forEach(track -> track.relate(this));
+        List<Track> copies = List.copyOf(updated.getTracks());
+        copies.forEach(track -> track.relate(this));
     }
 }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
@@ -65,4 +65,13 @@ public class ExerciseRecord extends BaseTimeEntity {
         Objects.requireNonNull(member);
         return Objects.equals(member, getMember());
     }
+
+    /**
+     * ExerciseRecord를 입력받아, 내부의 Track을 변경합니다.
+     */
+    public void update(ExerciseRecord updated) {
+        this.tracks.clear();
+        updated.getTracks()
+            .forEach(track -> track.relate(this));
+    }
 }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
@@ -48,7 +48,9 @@ public class ExerciseRecord extends BaseTimeEntity {
         this.member = member;
         this.recordDate = recordDate;
         this.tracks = new ArrayList<>();
-        tracks.forEach(track -> track.relate(this));
+        if (tracks != null) {
+            tracks.forEach(track -> track.relate(this));
+        }
     }
 
     public static ExerciseRecord create(Member member, List<Track> tracks) {

--- a/src/main/java/com/example/temp/record/dto/request/ExerciseRecordUpdateRequest.java
+++ b/src/main/java/com/example/temp/record/dto/request/ExerciseRecordUpdateRequest.java
@@ -14,35 +14,35 @@ import java.util.List;
 public record ExerciseRecordUpdateRequest(
 
     @NotNull
-    List<@Valid TrackCreateRequest> tracks
+    List<@Valid TrackUpdateRequest> tracks
 ) {
 
     public ExerciseRecord toEntityWith(Member member) {
         List<Track> tracks = this.tracks.stream()
-            .map(TrackCreateRequest::toEntity)
+            .map(TrackUpdateRequest::toEntity)
             .toList();
         return ExerciseRecord.create(member, tracks);
     }
 
-    public record TrackCreateRequest(
+    public record TrackUpdateRequest(
 
         @NotBlank
         String machineName,
 
         @NotNull
-        List<@Valid SetInTrackCreateRequest> sets
+        List<@Valid SetInTrackUpdateRequest> sets
     ) {
 
         public Track toEntity() {
             int order = 1;
             List<SetInTrack> setInTracks = new ArrayList<>();
-            for (SetInTrackCreateRequest set : this.sets) {
+            for (SetInTrackUpdateRequest set : this.sets) {
                 setInTracks.add(set.toEntityWithOrder(order++));
             }
             return Track.createWithoutRecord(machineName, setInTracks);
         }
 
-        public record SetInTrackCreateRequest(
+        public record SetInTrackUpdateRequest(
             @PositiveOrZero
             Integer weight,
 

--- a/src/main/java/com/example/temp/record/dto/request/ExerciseRecordUpdateRequest.java
+++ b/src/main/java/com/example/temp/record/dto/request/ExerciseRecordUpdateRequest.java
@@ -1,0 +1,62 @@
+package com.example.temp.record.dto.request;
+
+import com.example.temp.member.domain.Member;
+import com.example.temp.record.domain.ExerciseRecord;
+import com.example.temp.record.domain.SetInTrack;
+import com.example.temp.record.domain.Track;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.ArrayList;
+import java.util.List;
+
+public record ExerciseRecordUpdateRequest(
+
+    @NotNull
+    List<@Valid TrackCreateRequest> tracks
+) {
+
+    public ExerciseRecord toEntityWith(Member member) {
+        List<Track> tracks = this.tracks.stream()
+            .map(TrackCreateRequest::toEntity)
+            .toList();
+        return ExerciseRecord.create(member, tracks);
+    }
+
+    public record TrackCreateRequest(
+
+        @NotBlank
+        String machineName,
+
+        @NotNull
+        List<@Valid SetInTrackCreateRequest> sets
+    ) {
+
+        public Track toEntity() {
+            int order = 1;
+            List<SetInTrack> setInTracks = new ArrayList<>();
+            for (SetInTrackCreateRequest set : this.sets) {
+                setInTracks.add(set.toEntityWithOrder(order++));
+            }
+            return Track.createWithoutRecord(machineName, setInTracks);
+        }
+
+        public record SetInTrackCreateRequest(
+            @PositiveOrZero
+            Integer weight,
+
+            @PositiveOrZero
+            Integer repeatCnt
+        ) {
+
+            public SetInTrack toEntityWithOrder(int order) {
+                return SetInTrack.builder()
+                    .weight(weight())
+                    .repeatCnt(repeatCnt())
+                    .order(order)
+                    .build();
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
+++ b/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
@@ -5,6 +5,7 @@ import com.example.temp.common.dto.CreatedResponse;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.record.application.ExerciseRecordService;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest;
+import com.example.temp.record.dto.request.ExerciseRecordUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +31,13 @@ public class ExerciseRecordController {
         long createdId = exerciseRecordService.create(userContext, request);
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(CreatedResponse.of(createdId));
+    }
+
+    @PutMapping("/{recordId}")
+    public ResponseEntity<Void> update(@Login UserContext userContext, @PathVariable long recordId,
+        @Validated @RequestBody ExerciseRecordUpdateRequest request) {
+        exerciseRecordService.update(userContext, recordId, request);
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{recordId}")

--- a/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
+++ b/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +29,11 @@ public class ExerciseRecordController {
         long createdId = exerciseRecordService.create(userContext, request);
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(CreatedResponse.of(createdId));
+    }
+
+    @DeleteMapping("/{recordId}")
+    public ResponseEntity<Void> delete(@Login UserContext userContext, @PathVariable long recordId) {
+        exerciseRecordService.delete(userContext, recordId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -199,6 +199,30 @@ class ExerciseRecordServiceTest {
     }
 
     @Test
+    @DisplayName("운동기록 수정 요청을 보내면, 기존에 등록되어 있던 트랙들은 삭제되고 새로운 트랙들로 대체된다.")
+    void updateSuccess() throws Exception {
+        // given
+        Track trackBeforeSaved = createTrack("머신1", List.of(createSetInTrack(1), createSetInTrack(2)));
+        ExerciseRecord record = saveExerciseRecord(loginMember, trackBeforeSaved);
+        ExerciseRecordUpdateRequest request = new ExerciseRecordUpdateRequest(Collections.emptyList());
+
+        Long prevTrackId = record.getTracks().get(0).getId();
+        assertThat(em.find(Track.class, prevTrackId)).isNotNull();
+
+        // when
+        exerciseRecordService.update(loginUserContext, record.getId(), request);
+        em.flush();
+        em.clear();
+
+        // then
+        ExerciseRecord updatedRecord = em.find(ExerciseRecord.class, record.getId());
+
+        assertThat(updatedRecord.getRecordDate()).isEqualTo(record.getRecordDate());
+        assertThat(updatedRecord.getTracks()).hasSize(request.tracks().size());
+        assertThat(em.find(Track.class, prevTrackId)).isNull();
+    }
+
+    @Test
     @DisplayName("로그인한 사용자만 운동기록을 수정할 수 있다.")
     void updateFailNoAuthN() throws Exception {
         // given

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -19,6 +19,7 @@ import com.example.temp.record.domain.Track;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest.TrackCreateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest.TrackCreateRequest.SetInTrackCreateRequest;
+import com.example.temp.record.dto.request.ExerciseRecordUpdateRequest;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.Collections;
@@ -197,6 +198,18 @@ class ExerciseRecordServiceTest {
             .hasMessageContaining(ErrorCode.AUTHORIZED_FAIL.getMessage());
     }
 
+    @Test
+    @DisplayName("로그인한 사용자만 운동기록을 수정할 수 있다.")
+    void updateFailNoAuthN() throws Exception {
+        // given
+        ExerciseRecord record = saveExerciseRecord(loginMember);
+        ExerciseRecordUpdateRequest request = new ExerciseRecordUpdateRequest(Collections.emptyList());
+
+        // when & then
+        assertThatThrownBy(() -> exerciseRecordService.update(noLoginUserContext, record.getId(), request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.AUTHENTICATED_FAIL.getMessage());
+    }
 
     private ExerciseRecord saveExerciseRecord(Member member) {
         ExerciseRecord record = ExerciseRecord.builder()

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -211,6 +211,21 @@ class ExerciseRecordServiceTest {
             .hasMessageContaining(ErrorCode.AUTHENTICATED_FAIL.getMessage());
     }
 
+    @Test
+    @DisplayName("인가 권한이 없는 사용자는 운동기록을 수정할 수 없다.")
+    void updateFailNoAuthZ() throws Exception {
+        // given
+        ExerciseRecord record = saveExerciseRecord(loginMember);
+        Member anotherMember = saveMember("another1");
+        ExerciseRecordUpdateRequest request = new ExerciseRecordUpdateRequest(Collections.emptyList());
+
+        // when & then
+        assertThatThrownBy(() ->
+            exerciseRecordService.update(UserContext.fromMember(anotherMember), record.getId(), request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.AUTHORIZED_FAIL.getMessage());
+    }
+
     private ExerciseRecord saveExerciseRecord(Member member) {
         ExerciseRecord record = ExerciseRecord.builder()
             .member(member)

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -60,7 +60,7 @@ class ExerciseRecordServiceTest {
     @DisplayName("운동 기록을 저장한다.")
     void create() throws Exception {
         // given
-        ExerciseRecordCreateRequest request = new ExerciseRecordCreateRequest(Collections.emptyList());
+        ExerciseRecordCreateRequest request = makeExerciseRecordCreateRequest("머신1", 10, 3);
 
         // when
         long createdId = exerciseRecordService.create(loginUserContext, request);
@@ -278,6 +278,17 @@ class ExerciseRecordServiceTest {
         em.persist(member);
         return member;
     }
+
+    /**
+     * machineName이라는 운동 기구를 사용하는 1세트짜리 트랙을 CREATE하는 요청을 만듭니다.
+     */
+    private ExerciseRecordCreateRequest makeExerciseRecordCreateRequest(String machineName, int weight, int repeatCnt) {
+        SetInTrackCreateRequest setInTrackCreateRequest = new SetInTrackCreateRequest(weight, repeatCnt);
+        List<TrackCreateRequest> trackCreateRequests = List.of(
+            new TrackCreateRequest(machineName, List.of(setInTrackCreateRequest)));
+        return new ExerciseRecordCreateRequest(trackCreateRequests);
+    }
+
 
     /**
      * machineName이라는 운동 기구를 사용하는 1세트짜리 트랙을 UPDATE하는 요청을 만듭니다.

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -48,7 +48,7 @@ class ExerciseRecordServiceTest {
 
     @BeforeEach
     void setUp() {
-        loginMember = saveMember();
+        loginMember = saveMember("loginMember");
         loginUserContext = UserContext.fromMember(loginMember);
         noLoginUserContext = new UserContext(99999999L, Role.NORMAL);
     }
@@ -125,6 +125,20 @@ class ExerciseRecordServiceTest {
             .hasMessageContaining(ErrorCode.AUTHENTICATED_FAIL.getMessage());
     }
 
+    @Test
+    @DisplayName("인가 권한이 없는 사용자는 운동기록을 삭제할 수 없다.")
+    void dd() throws Exception {
+        // given
+        ExerciseRecord record = saveExerciseRecord(loginMember);
+        Member anotherMember = saveMember("another1");
+
+        // when & then
+        assertThatThrownBy(() -> exerciseRecordService.delete(UserContext.fromMember(anotherMember), record.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.AUTHORIZED_FAIL.getMessage());
+    }
+
+
     private ExerciseRecord saveExerciseRecord(Member member) {
         ExerciseRecord record = ExerciseRecord.builder()
             .member(member)
@@ -136,13 +150,13 @@ class ExerciseRecordServiceTest {
     }
 
 
-    private Member saveMember() {
+    private Member saveMember(String nickname) {
         Member member = Member.builder()
             .email(Email.create("test@test.com"))
             .followStrategy(FollowStrategy.EAGER)
             .privacyPolicy(PrivacyPolicy.PUBLIC)
             .profileUrl("https://profileurl")
-            .nickname(Nickname.create("nick"))
+            .nickname(Nickname.create(nickname))
             .build();
         em.persist(member);
         return member;

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -114,6 +114,20 @@ class ExerciseRecordServiceTest {
     }
 
     @Test
+    @DisplayName("운동기록을 삭제한다.")
+    void delete() throws Exception {
+        // given
+        Member member = saveMember("nick1");
+        ExerciseRecord record = saveExerciseRecord(member);
+
+        // when
+        exerciseRecordService.delete(UserContext.fromMember(member), record.getId());
+
+        // then
+        assertThat(em.find(ExerciseRecord.class, record.getId())).isNull();
+    }
+
+    @Test
     @DisplayName("로그인한 사용자만 운동기록을 삭제할 수 있다.")
     void deleteFailNoAuthN() throws Exception {
         // given

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -20,6 +20,7 @@ import com.example.temp.record.dto.request.ExerciseRecordCreateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest.TrackCreateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest.TrackCreateRequest.SetInTrackCreateRequest;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,6 +111,28 @@ class ExerciseRecordServiceTest {
 
         assertThat(em.find(SetInTrack.class, track.getSetsInTrack().get(0).getId())).isNotNull();
         assertThat(em.find(SetInTrack.class, track.getSetsInTrack().get(1).getId())).isNotNull();
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자만 운동기록을 삭제할 수 있다.")
+    void deleteFailNoAuthN() throws Exception {
+        // given
+        ExerciseRecord record = saveExerciseRecord(loginMember);
+
+        // when & then
+        assertThatThrownBy(() -> exerciseRecordService.delete(noLoginUserContext, record.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.AUTHENTICATED_FAIL.getMessage());
+    }
+
+    private ExerciseRecord saveExerciseRecord(Member member) {
+        ExerciseRecord record = ExerciseRecord.builder()
+            .member(member)
+            .tracks(Collections.emptyList())
+            .recordDate(LocalDate.now())
+            .build();
+        em.persist(record);
+        return record;
     }
 
 

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -20,6 +20,8 @@ import com.example.temp.record.dto.request.ExerciseRecordCreateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest.TrackCreateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest.TrackCreateRequest.SetInTrackCreateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordUpdateRequest;
+import com.example.temp.record.dto.request.ExerciseRecordUpdateRequest.TrackUpdateRequest;
+import com.example.temp.record.dto.request.ExerciseRecordUpdateRequest.TrackUpdateRequest.SetInTrackUpdateRequest;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.Collections;
@@ -204,7 +206,7 @@ class ExerciseRecordServiceTest {
         // given
         Track trackBeforeSaved = createTrack("머신1", List.of(createSetInTrack(1), createSetInTrack(2)));
         ExerciseRecord record = saveExerciseRecord(loginMember, trackBeforeSaved);
-        ExerciseRecordUpdateRequest request = new ExerciseRecordUpdateRequest(Collections.emptyList());
+        ExerciseRecordUpdateRequest request = makeExerciseRecordUpdateRequest("변경한_머신", 100, 10);
 
         Long prevTrackId = record.getTracks().get(0).getId();
         assertThat(em.find(Track.class, prevTrackId)).isNotNull();
@@ -251,13 +253,8 @@ class ExerciseRecordServiceTest {
     }
 
     private ExerciseRecord saveExerciseRecord(Member member) {
-        ExerciseRecord record = ExerciseRecord.builder()
-            .member(member)
-            .tracks(Collections.emptyList())
-            .recordDate(LocalDate.now())
-            .build();
-        em.persist(record);
-        return record;
+        Track tracks = createTrack("머신1", List.of(createSetInTrack(1)));
+        return saveExerciseRecord(member, tracks);
     }
 
     private ExerciseRecord saveExerciseRecord(Member member, Track track) {
@@ -281,4 +278,16 @@ class ExerciseRecordServiceTest {
         em.persist(member);
         return member;
     }
+
+    /**
+     * machineName이라는 운동 기구를 사용하는 1세트짜리 트랙을 UPDATE하는 요청을 만듭니다.
+     */
+    private ExerciseRecordUpdateRequest makeExerciseRecordUpdateRequest(String machineName, int weight, int repeatCnt) {
+        SetInTrackUpdateRequest setInTrackUpdateRequest = new SetInTrackUpdateRequest(weight, repeatCnt);
+        List<TrackUpdateRequest> trackUpdateRequests = List.of(
+            new TrackUpdateRequest(machineName, List.of(setInTrackUpdateRequest)));
+        return new ExerciseRecordUpdateRequest(trackUpdateRequests);
+    }
+
+
 }

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
@@ -1,15 +1,60 @@
 package com.example.temp.record.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.example.temp.common.entity.Email;
+import com.example.temp.common.exception.ApiException;
+import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.domain.nickname.Nickname;
-import org.assertj.core.api.Assertions;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class ExerciseRecordTest {
+
+    @Test
+    @DisplayName("ExerciseRecord가 잘 생성되는지 확인한다.")
+    void create() throws Exception {
+        // given
+        Member member = createMember("nick1");
+        Track track = createTrack("머신1");
+
+        // when
+        ExerciseRecord exerciseRecord = ExerciseRecord.create(member, List.of(track));
+
+        // then
+        assertThat(exerciseRecord.getMember()).isEqualTo(member);
+        assertThat(exerciseRecord.getTracks()).hasSize(1)
+            .containsExactlyInAnyOrder(track);
+    }
+
+    @Test
+    @DisplayName("List<Track>이 비어있는 상태의 ExerciseRecord를 만들 수 없다.")
+    void createFailEmptyTrack() throws Exception {
+        // given
+        Member member = createMember("nick1");
+
+        // when & then
+        assertThatThrownBy(() -> ExerciseRecord.create(member, Collections.emptyList()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.TRACK_CANT_EMPTY.getMessage());
+    }
+
+    @Test
+    @DisplayName("List<Track>을 입력하지 않고 ExerciseRecord를 만들 수 없다.")
+    void createFailTrackIsNull() throws Exception {
+        // given
+        Member member = createMember("nick1");
+
+        // when & then
+        assertThatThrownBy(() -> ExerciseRecord.create(member, null))
+            .isInstanceOf(NullPointerException.class);
+    }
 
     @Test
     @DisplayName("해당 운동기록의 소유주가 일치하면 true를 반환한다.")
@@ -33,6 +78,21 @@ class ExerciseRecordTest {
 
         // when & then
         Assertions.assertThat(record.isOwnedBy(another)).isFalse();
+    }
+
+    private Track createTrack(String machineName) {
+        return Track.builder()
+            .machineName(machineName)
+            .setsInTrack(List.of(createSetInTrack(1)))
+            .build();
+    }
+
+    private SetInTrack createSetInTrack(int order) {
+        return SetInTrack.builder()
+            .order(order)
+            .weight(10)
+            .repeatCnt(5)
+            .build();
     }
 
 

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
@@ -1,0 +1,54 @@
+package com.example.temp.record.domain;
+
+import com.example.temp.common.entity.Email;
+import com.example.temp.member.domain.FollowStrategy;
+import com.example.temp.member.domain.Member;
+import com.example.temp.member.domain.PrivacyPolicy;
+import com.example.temp.member.domain.nickname.Nickname;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ExerciseRecordTest {
+
+    @Test
+    @DisplayName("해당 운동기록의 소유주가 일치하면 true를 반환한다.")
+    void isOwnedBy() throws Exception {
+        // given
+        Member member = createMember("nick1");
+        ExerciseRecord record = createExerciseRecord(member);
+
+        // when & then
+        Assertions.assertThat(record.isOwnedBy(member)).isTrue();
+    }
+
+    @Test
+    @DisplayName("해당 운동기록의 소유주가 아니라면 false를 반환한다.")
+    void isNotOwnedBy() throws Exception {
+        // given
+        Member member = createMember("nick1");
+        ExerciseRecord record = createExerciseRecord(member);
+
+        Member another = createMember("another");
+
+        // when & then
+        Assertions.assertThat(record.isOwnedBy(another)).isFalse();
+    }
+
+
+    private ExerciseRecord createExerciseRecord(Member member) {
+        return ExerciseRecord.builder()
+            .member(member)
+            .build();
+    }
+
+    private Member createMember(String nickname) {
+        return Member.builder()
+            .email(Email.create("test@test.com"))
+            .followStrategy(FollowStrategy.EAGER)
+            .privacyPolicy(PrivacyPolicy.PUBLIC)
+            .profileUrl("https://profileurl")
+            .nickname(Nickname.create(nickname))
+            .build();
+    }
+}

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
@@ -64,7 +64,7 @@ class ExerciseRecordTest {
         ExerciseRecord record = createExerciseRecord(member);
 
         // when & then
-        Assertions.assertThat(record.isOwnedBy(member)).isTrue();
+        assertThat(record.isOwnedBy(member)).isTrue();
     }
 
     @Test
@@ -77,7 +77,7 @@ class ExerciseRecordTest {
         Member another = createMember("another");
 
         // when & then
-        Assertions.assertThat(record.isOwnedBy(another)).isFalse();
+        assertThat(record.isOwnedBy(another)).isFalse();
     }
 
     private Track createTrack(String machineName) {
@@ -99,6 +99,7 @@ class ExerciseRecordTest {
     private ExerciseRecord createExerciseRecord(Member member) {
         return ExerciseRecord.builder()
             .member(member)
+            .tracks(List.of(createTrack("머신1")))
             .build();
     }
 


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 운동 기록 수정 기능 구현
- [x] 운동 기록 삭제 기능 구현

## 🏌🏻 리뷰 포인트
**삭제**
삭제는 별 어려움 없이 개발했습니다.
cascade와 orphanRemoval과 함께하니 무서울 게 없네요.
이친구들 앞으로 많이 친해질 거 같습니다 😄 (상황봐서 사용해야겠지만)

수정 부분을 더 집중해서 봐주시면 좋겠어요.
아래 기타 사항에 고민했던 내용을 함께 적어보았습니다.

## 🧘🏻 기타 사항
수정을 개발할 때마다 생기는 의문이 있습니다.

**복잡한 관계를 갖는 엔티티를 수정할 때, 삭제하고 다시 생성하는 게 최선일까?**

예시로 설명드릴게요.
저희 서비스의 ExerciseRecord 엔티티는 Track, SetInTrack 엔티티들이 종속되어서 복잡한 관계를 갖습니다.
예를 들어 저희 서비스를 사용하는 사용자가 아래와 같이 기록을 했어요.
```
["벤치프레스", [1세트, 20Kg, 10회], [2세트, 30Kg, 10회]]
["스쿼트 머신", [1세트, 20Kg, 10회]]
```

그러면 DB에 이렇게 저장이 될 거에요.
```
exercise_records 테이블에 엔티티 1개 저장
tracks 테이블에 엔티티 2개(벤치프레스, 스쿼트 머신) 저장
sets 테이블에 엔티티 3개(벤치프레스 1세트, 벤치프레스 2세트, 스쿼트머신 1세트) 저장
```

이 때, 사용자가 해당 기록을 이렇게 바꾼다면...
```
["데드리프트", [1세트, 200Kg, 100회], [2세트, 300Kg, 100회]]
["스쿼트 머신", [1세트, 20Kg, 10회], [2세트, 20Kg, 10회]]
```
만약 삭제 후 재등록이 아니라면 이런 복잡한 로직을 서버에서 처리해주게 됩니다.
```
1. 벤치프레스 Track과 이에 종속된 걸 삭제
2. 스쿼트 머신 세트 1개 추가
3. 데드리프트 Track 추가
```

그래서 저는 연관 데이터들 삭제 후 재등록해주는 방식을 사용했어요.
이러면 그냥 단순하게 삭제하고, 새롭게 입력된 걸 등록해주니까 편하죠!!
```java
    // ExerciseRecord의 ID는 유지됩니당~
    public void update(ExerciseRecord updated) {
        this.tracks.clear();
        List<Track> copies = List.copyOf(updated.getTracks());
        copies.forEach(track -> track.relate(this));
    }
```

다른 대안이 없는걸까, 실무에서 이정도 성능 저하는 충분히 받아들일 수 있는 수준일까,,, 궁금합니다.
혹시 아시는 게 있을까 하여 적어보았습니다 ㅋㅋ
정우님도 잘 모르시는 부분이라면 그냥 한 번 읽고 넘어가주시면 될 거 같아요!

-> 정우님이 PATCH 쓰는 경우를 거의 못봤다 하셨는데 이런 이유일까 싶네요. 어차피 삭제 후 재등록이면 PUT이 맞으니까요

close #122 
close #126 
