### PR TITLE
[#123, #128] 사용자 정보 조회, 수정 

### DIFF
--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -107,4 +107,9 @@ public class MemberService {
         member.changePrivacy(privacyPolicy);
     }
 
+    public MemberInfo find(long targetId) {
+        Member member = memberRepository.findById(targetId)
+            .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+        return MemberInfo.of(member);
+    }
 }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -116,6 +116,9 @@ public class MemberService {
             memberRepository.existsByNickname(request.nickname())) {
             throw new ApiException(ErrorCode.NICKNAME_DUPLICATED);
         }
+        if (!imageRepository.existsByUrl(request.profileUrl())) {
+            throw new ApiException(ErrorCode.IMAGE_NOT_FOUND);
+        }
         member.setProfileUrl(request.profileUrl());
         member.setNickname(Nickname.create(request.nickname()));
     }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -125,6 +125,7 @@ public class MemberService {
     }
 
     private boolean isMemberOriginalNickname(Member member, String nickname) {
+        Objects.requireNonNull(member);
         Objects.requireNonNull(nickname);
         return Objects.equals(member.getNicknameValue(), nickname);
     }

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -11,6 +11,7 @@ import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.domain.nickname.Nickname;
 import com.example.temp.member.domain.nickname.NicknameGenerator;
 import com.example.temp.member.dto.request.MemberRegisterRequest;
+import com.example.temp.member.dto.request.MemberUpdateRequest;
 import com.example.temp.member.event.MemberDeletedEvent;
 import com.example.temp.member.exception.NicknameDuplicatedException;
 import com.example.temp.oauth.OAuthResponse;
@@ -105,6 +106,14 @@ public class MemberService {
         Member member = memberRepository.findById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
         member.changePrivacy(privacyPolicy);
+    }
+
+    @Transactional
+    public void changeMemberInfo(UserContext userContext, MemberUpdateRequest request) {
+        Member member = memberRepository.findById(userContext.id())
+            .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
+        member.setProfileUrl(request.profileUrl());
+        member.setNickname(Nickname.create(request.nickname()));
     }
 
     public MemberInfo find(long targetId) {

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -112,7 +112,8 @@ public class MemberService {
     public void changeMemberInfo(UserContext userContext, MemberUpdateRequest request) {
         Member member = memberRepository.findById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
-        if (memberRepository.existsByNickname(request.nickname())) {
+        if (!member.getNicknameValue().equals(request.nickname()) &&
+            memberRepository.existsByNickname(request.nickname())) {
             throw new ApiException(ErrorCode.NICKNAME_DUPLICATED);
         }
         member.setProfileUrl(request.profileUrl());

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -112,10 +112,14 @@ public class MemberService {
     public void changeMemberInfo(UserContext userContext, MemberUpdateRequest request) {
         Member member = memberRepository.findById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw new ApiException(ErrorCode.NICKNAME_DUPLICATED);
+        }
         member.setProfileUrl(request.profileUrl());
         member.setNickname(Nickname.create(request.nickname()));
     }
 
+    // Find말고 다른 이름으로 변경해야 할듯
     public MemberInfo find(long targetId) {
         Member member = memberRepository.findById(targetId)
             .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -110,7 +110,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void changeMemberInfo(UserContext userContext, MemberUpdateRequest request) {
+    public void updateMemberInfo(UserContext userContext, MemberUpdateRequest request) {
         Member member = memberRepository.findById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
         if (!isMemberOriginalNickname(member, request.nickname()) &&

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -129,8 +129,7 @@ public class MemberService {
         return Objects.equals(member.getNicknameValue(), nickname);
     }
 
-    // Find말고 다른 이름으로 변경해야 할듯
-    public MemberInfo find(long targetId) {
+    public MemberInfo retrieveMemberInfo(long targetId) {
         Member member = memberRepository.findById(targetId)
             .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
         return MemberInfo.of(member);

--- a/src/main/java/com/example/temp/member/application/MemberService.java
+++ b/src/main/java/com/example/temp/member/application/MemberService.java
@@ -15,6 +15,7 @@ import com.example.temp.member.dto.request.MemberUpdateRequest;
 import com.example.temp.member.event.MemberDeletedEvent;
 import com.example.temp.member.exception.NicknameDuplicatedException;
 import com.example.temp.oauth.OAuthResponse;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -112,7 +113,7 @@ public class MemberService {
     public void changeMemberInfo(UserContext userContext, MemberUpdateRequest request) {
         Member member = memberRepository.findById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));
-        if (!member.getNicknameValue().equals(request.nickname()) &&
+        if (!isMemberOriginalNickname(member, request.nickname()) &&
             memberRepository.existsByNickname(request.nickname())) {
             throw new ApiException(ErrorCode.NICKNAME_DUPLICATED);
         }
@@ -121,6 +122,11 @@ public class MemberService {
         }
         member.setProfileUrl(request.profileUrl());
         member.setNickname(Nickname.create(request.nickname()));
+    }
+
+    private boolean isMemberOriginalNickname(Member member, String nickname) {
+        Objects.requireNonNull(nickname);
+        return Objects.equals(member.getNicknameValue(), nickname);
     }
 
     // Find말고 다른 이름으로 변경해야 할듯

--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -18,6 +18,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "members")
@@ -42,12 +43,14 @@ public class Member {
      */
     private boolean deleted;
 
+    @Setter
     @Embedded
     private Nickname nickname;
 
     @Embedded
     private Email email;
 
+    @Setter
     @Column(nullable = false)
     private String profileUrl;
 

--- a/src/main/java/com/example/temp/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/example/temp/member/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.temp.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberUpdateRequest(
+    @NotNull
+    String profileUrl,
+
+    @NotBlank
+    String nickname
+) {
+
+}

--- a/src/main/java/com/example/temp/member/presentation/MemberController.java
+++ b/src/main/java/com/example/temp/member/presentation/MemberController.java
@@ -47,8 +47,8 @@ public class MemberController {
     }
 
     @GetMapping("/{memberId}")
-    public ResponseEntity<MemberInfo> find(@PathVariable long memberId) {
-        MemberInfo memberInfo = memberService.find(memberId);
+    public ResponseEntity<MemberInfo> retrieveMemberInfo(@PathVariable long memberId) {
+        MemberInfo memberInfo = memberService.retrieveMemberInfo(memberId);
         return ResponseEntity.ok(memberInfo);
     }
 }

--- a/src/main/java/com/example/temp/member/presentation/MemberController.java
+++ b/src/main/java/com/example/temp/member/presentation/MemberController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,5 +44,11 @@ public class MemberController {
         @RequestParam("policy") PrivacyPolicy privacyPolicy) {
         memberService.changePrivacy(userContext, privacyPolicy);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberInfo> find(@PathVariable long memberId) {
+        MemberInfo memberInfo = memberService.find(memberId);
+        return ResponseEntity.ok(memberInfo);
     }
 }

--- a/src/main/java/com/example/temp/member/presentation/MemberController.java
+++ b/src/main/java/com/example/temp/member/presentation/MemberController.java
@@ -6,6 +6,7 @@ import com.example.temp.common.dto.UserContext;
 import com.example.temp.member.application.MemberService;
 import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.dto.request.MemberRegisterRequest;
+import com.example.temp.member.dto.request.MemberUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -50,5 +52,12 @@ public class MemberController {
     public ResponseEntity<MemberInfo> retrieveMemberInfo(@PathVariable long memberId) {
         MemberInfo memberInfo = memberService.retrieveMemberInfo(memberId);
         return ResponseEntity.ok(memberInfo);
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<Void> updateMemberInfo(@Login UserContext userContext,
+        @RequestBody MemberUpdateRequest request) {
+        memberService.updateMemberInfo(userContext, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,12 +1,13 @@
-INSERT INTO members(registered, deleted, nickname, email, profile_url, privacy_policy,
-                    follow_strategy)
-VALUES (true, false, '김태훈', 'first@test.com',
-        'https://avatars.githubusercontent.com/u/67636607?s=80&u=66f65ed6f693c3235b3ba0a4a1ed93b7eeae50cb&v=4',
-        'PUBLIC', 'EAGER'),
-       (true, false, '이정우', 'another@test.org',
-        'https://avatars.githubusercontent.com/u/49686619?v=4', 'PUBLIC', 'EAGER'),
-       (true, false, '남궁수', 'suu@test.org', 'https://avatars.githubusercontent.com/u/52947668?v=4',
-        'PRIVATE', 'LAZY');
+INSERT INTO members(registered, deleted, nickname, email, profile_url, privacy_policy, follow_strategy)
+VALUES (true, false, '김태훈', 'first@test.com', 'https://avatars.githubusercontent.com/u/67636607?s=80&u=66f65ed6f693c3235b3ba0a4a1ed93b7eeae50cb&v=4', 'PUBLIC', 'EAGER'),
+       (true, false, '이정우', 'another@test.org', 'https://avatars.githubusercontent.com/u/49686619?v=4', 'PUBLIC', 'EAGER'),
+       (true, false, '남궁수', 'suu@test.org', 'https://avatars.githubusercontent.com/u/52947668?v=4', 'PRIVATE', 'LAZY');
+
+INSERT INTO images(url, used)
+VALUES ('https://avatars.githubusercontent.com/u/87960006?v=4', true),
+       ('https://avatars.githubusercontent.com/u/67636607?s=80&u=66f65ed6f693c3235b3ba0a4a1ed93b7eeae50cb&v=4', true),
+       ('https://avatars.githubusercontent.com/u/49686619?v=4', true),
+        ('https://avatars.githubusercontent.com/u/52947668?v=4', true);
 
 INSERT INTO machines(name)
 VALUES ('덤벨 벤치 프레스'),

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -318,7 +318,7 @@ class MemberServiceTest {
         Member member = savePublicMember("nick1");
 
         // when
-        MemberInfo memberInfo = memberService.find(member.getId());
+        MemberInfo memberInfo = memberService.retrieveMemberInfo(member.getId());
 
         // then
         assertThat(memberInfo.id()).isEqualTo(member.getId());

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -323,10 +323,11 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("회원 정보를 수정한다.")
-    void update() throws Exception {
+    void updateSuccess() throws Exception {
         // given
         Member member = saveRegisteredMember(Nickname.create("nick1"));
         MemberUpdateRequest request = new MemberUpdateRequest("https://changedUrl", "change");
+
         // when
         memberService.changeMemberInfo(UserContext.fromMember(member), request);
 
@@ -335,6 +336,22 @@ class MemberServiceTest {
 
         assertThat(updatedMember.getNicknameValue()).isEqualTo(request.nickname());
         assertThat(updatedMember.getProfileUrl()).isEqualTo(request.profileUrl());
+    }
+
+    @Test
+    @DisplayName("다른 회원과 중복된 닉네임으로 닉네임을 변경할 수 없다.")
+    void updateFailDuplicatedNickname() throws Exception {
+        // given
+        String duplicatedNickname = "duplicated";
+        Member anotherMember = saveRegisteredMember(Nickname.create(duplicatedNickname));
+
+        Member target = saveRegisteredMember(Nickname.create("nick1"));
+        MemberUpdateRequest request = new MemberUpdateRequest("https://changedUrl", duplicatedNickname);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.changeMemberInfo(UserContext.fromMember(target), request))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(NICKNAME_DUPLICATED.getMessage());
     }
 
     @Test

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -355,6 +355,23 @@ class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("닉네임을 변경하지 않고 회원 정보를 변경한다.")
+    void updateSuccessNotChangeNickname() throws Exception {
+        // given
+        Member member = saveRegisteredMember(Nickname.create("nick1"));
+        MemberUpdateRequest request = new MemberUpdateRequest("https://changedUrl", member.getNicknameValue());
+
+        // when
+        memberService.changeMemberInfo(UserContext.fromMember(member), request);
+
+        // then
+        Member updatedMember = em.find(Member.class, member.getId());
+
+        assertThat(updatedMember.getNicknameValue()).isEqualTo(request.nickname());
+        assertThat(updatedMember.getProfileUrl()).isEqualTo(request.profileUrl());
+    }
+
+    @Test
     @DisplayName("회원이 탈퇴되었을 때, 작성한 게시글이 전부 삭제된다.")
     void deleteAllPostWhenMemberWithdraw() throws Exception {
         // given

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -23,6 +23,7 @@ import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.domain.nickname.Nickname;
 import com.example.temp.member.domain.nickname.NicknameGenerator;
 import com.example.temp.member.dto.request.MemberRegisterRequest;
+import com.example.temp.member.dto.request.MemberUpdateRequest;
 import com.example.temp.member.exception.NicknameDuplicatedException;
 import com.example.temp.oauth.OAuthProviderType;
 import com.example.temp.oauth.OAuthResponse;
@@ -318,6 +319,22 @@ class MemberServiceTest {
         assertThat(memberInfo.email()).isEqualTo(member.getEmailValue());
         assertThat(memberInfo.nickname()).isEqualTo(member.getNicknameValue());
         assertThat(memberInfo.profileUrl()).isEqualTo(member.getProfileUrl());
+    }
+
+    @Test
+    @DisplayName("회원 정보를 수정한다.")
+    void update() throws Exception {
+        // given
+        Member member = saveRegisteredMember(Nickname.create("nick1"));
+        MemberUpdateRequest request = new MemberUpdateRequest("https://changedUrl", "change");
+        // when
+        memberService.changeMemberInfo(UserContext.fromMember(member), request);
+
+        // then
+        Member updatedMember = em.find(Member.class, member.getId());
+
+        assertThat(updatedMember.getNicknameValue()).isEqualTo(request.nickname());
+        assertThat(updatedMember.getProfileUrl()).isEqualTo(request.profileUrl());
     }
 
     @Test

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -303,6 +303,23 @@ class MemberServiceTest {
         assertThat(em.find(Follow.class, notRelatedFollow.getId())).isNotNull();
     }
 
+
+    @Test
+    @DisplayName("회원을 조회한다.")
+    void find() throws Exception {
+        // given
+        Member member = savePublicMember("nick1");
+
+        // when
+        MemberInfo memberInfo = memberService.find(member.getId());
+
+        // then
+        assertThat(memberInfo.id()).isEqualTo(member.getId());
+        assertThat(memberInfo.email()).isEqualTo(member.getEmailValue());
+        assertThat(memberInfo.nickname()).isEqualTo(member.getNicknameValue());
+        assertThat(memberInfo.profileUrl()).isEqualTo(member.getProfileUrl());
+    }
+
     @Test
     @DisplayName("회원이 탈퇴되었을 때, 작성한 게시글이 전부 삭제된다.")
     void deleteAllPostWhenMemberWithdraw() throws Exception {
@@ -386,6 +403,14 @@ class MemberServiceTest {
 
     private Member saveNotInitializedMember(Nickname nickname) {
         return saveMember(nickname, false, PrivacyPolicy.PRIVATE);
+    }
+
+    private Member savePublicMember(String nickname) {
+        return saveMember(Nickname.create(nickname), true, PrivacyPolicy.PUBLIC);
+    }
+
+    private Member savePrivateMember(String nickname) {
+        return saveMember(Nickname.create(nickname), true, PrivacyPolicy.PRIVATE);
     }
 
     private Member saveMember(Nickname nickname, boolean registered, PrivacyPolicy privacyPolicy) {

--- a/src/test/java/com/example/temp/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/temp/member/application/MemberServiceTest.java
@@ -335,7 +335,7 @@ class MemberServiceTest {
         MemberUpdateRequest request = new MemberUpdateRequest(savedImage.getUrl(), "change");
 
         // when
-        memberService.changeMemberInfo(UserContext.fromMember(member), request);
+        memberService.updateMemberInfo(UserContext.fromMember(member), request);
 
         // then
         Member updatedMember = em.find(Member.class, member.getId());
@@ -355,7 +355,7 @@ class MemberServiceTest {
         MemberUpdateRequest request = new MemberUpdateRequest(savedImage.getUrl(), duplicatedNickname);
 
         // when & then
-        assertThatThrownBy(() -> memberService.changeMemberInfo(UserContext.fromMember(target), request))
+        assertThatThrownBy(() -> memberService.updateMemberInfo(UserContext.fromMember(target), request))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(NICKNAME_DUPLICATED.getMessage());
     }
@@ -368,7 +368,7 @@ class MemberServiceTest {
         MemberUpdateRequest request = new MemberUpdateRequest(savedImage.getUrl(), member.getNicknameValue());
 
         // when
-        memberService.changeMemberInfo(UserContext.fromMember(member), request);
+        memberService.updateMemberInfo(UserContext.fromMember(member), request);
 
         // then
         Member updatedMember = em.find(Member.class, member.getId());
@@ -385,7 +385,7 @@ class MemberServiceTest {
         MemberUpdateRequest request = new MemberUpdateRequest("https://notfound", "changed");
 
         // when & then
-        assertThatThrownBy(() -> memberService.changeMemberInfo(UserContext.fromMember(member), request))
+        assertThatThrownBy(() -> memberService.updateMemberInfo(UserContext.fromMember(member), request))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(IMAGE_NOT_FOUND.getMessage());
     }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 회원 정보 조회 기능 구현
- [x] 프로필 주소와 닉네임을 바꿀 수 있는 기능 구현

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
```java
    @PutMapping("/me")
    public ResponseEntity<Void> updateMemberInfo(@Login UserContext userContext,
        @RequestBody MemberUpdateRequest request) {
        memberService.updateMemberInfo(userContext, request);
        return ResponseEntity.noContent().build();
    }
```
회원 정보 수정 API를 `PUT /members/me` 로 변경했습니다.
기존 `PUT /members/:memberId`는 상대적으로 직관적이지 못하다 느꼈습니다.
로그인한 사용자는 결국 자신의 정보밖에 바꿀 수 없는데,
사용자가 memberId를 입력받으면 오히려 혼란스럽지 않을까 생각했어욥

close #123 
close #128 