### PR TITLE
[#138] 댓글 조회 기능

### DIFF
--- a/src/main/java/com/example/temp/comment/application/CommentService.java
+++ b/src/main/java/com/example/temp/comment/application/CommentService.java
@@ -6,6 +6,7 @@ import static com.example.temp.common.exception.ErrorCode.POST_NOT_FOUND;
 import com.example.temp.comment.domain.Comment;
 import com.example.temp.comment.domain.CommentRepository;
 import com.example.temp.comment.dto.request.CommentCreateRequest;
+import com.example.temp.comment.dto.response.SliceCommentResponse;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.member.domain.Member;
@@ -14,6 +15,8 @@ import com.example.temp.post.domain.Post;
 import com.example.temp.post.domain.PostRepository;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +39,14 @@ public class CommentService {
         Comment savedComment = commentRepository.save(comment);
 
         return savedComment.getId();
+    }
+
+    public SliceCommentResponse findCommentsByPost(Long postId, UserContext userContext, Pageable pageable) {
+        findMemberBy(userContext.id());
+        Post post = findPostBy(postId);
+        Slice<Comment> sliceComments = commentRepository.findByPostId(post.getId(), pageable);
+        return SliceCommentResponse.from(sliceComments);
+
     }
 
     private Post findPostBy(Long postId) {

--- a/src/main/java/com/example/temp/comment/application/CommentService.java
+++ b/src/main/java/com/example/temp/comment/application/CommentService.java
@@ -46,7 +46,6 @@ public class CommentService {
         Post post = findPostBy(postId);
         Slice<Comment> sliceComments = commentRepository.findByPostId(post.getId(), pageable);
         return SliceCommentResponse.from(sliceComments);
-
     }
 
     private Post findPostBy(Long postId) {

--- a/src/main/java/com/example/temp/comment/domain/CommentRepository.java
+++ b/src/main/java/com/example/temp/comment/domain/CommentRepository.java
@@ -1,9 +1,15 @@
 package com.example.temp.comment.domain;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member JOIN FETCH c.post WHERE c.post.id = :postId ORDER BY c.registeredAt DESC")
+    Slice<Comment> findByPostId(@Param("postId") Long postId, Pageable pageable);
 }

--- a/src/main/java/com/example/temp/comment/dto/response/CommentElementResponse.java
+++ b/src/main/java/com/example/temp/comment/dto/response/CommentElementResponse.java
@@ -1,0 +1,24 @@
+package com.example.temp.comment.dto.response;
+
+import com.example.temp.comment.domain.Comment;
+import com.example.temp.post.dto.response.WriterInfo;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record CommentElementResponse(
+    Long commentId,
+    WriterInfo writerInfo,
+    String content,
+    LocalDateTime registeredAt
+) {
+
+    public static CommentElementResponse from(Comment comment) {
+        return CommentElementResponse.builder()
+            .commentId(comment.getId())
+            .writerInfo(WriterInfo.from(comment.getMember()))
+            .content(comment.getContent())
+            .registeredAt(comment.getRegisteredAt())
+            .build();
+    }
+}

--- a/src/main/java/com/example/temp/comment/dto/response/SliceCommentResponse.java
+++ b/src/main/java/com/example/temp/comment/dto/response/SliceCommentResponse.java
@@ -1,0 +1,18 @@
+package com.example.temp.comment.dto.response;
+
+import com.example.temp.comment.domain.Comment;
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceCommentResponse(
+    List<CommentElementResponse> comments,
+    boolean hasNext
+) {
+
+    public static SliceCommentResponse from(Slice<Comment> comments) {
+        List<CommentElementResponse> commentElements = comments.stream()
+            .map(CommentElementResponse::from)
+            .toList();
+        return new SliceCommentResponse(commentElements, comments.hasNext());
+    }
+}

--- a/src/main/java/com/example/temp/comment/presentation/CommentController.java
+++ b/src/main/java/com/example/temp/comment/presentation/CommentController.java
@@ -1,13 +1,19 @@
 package com.example.temp.comment.presentation;
 
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
 import com.example.temp.comment.application.CommentService;
 import com.example.temp.comment.dto.request.CommentCreateRequest;
+import com.example.temp.comment.dto.response.SliceCommentResponse;
 import com.example.temp.common.annotation.Login;
 import com.example.temp.common.dto.CreatedResponse;
 import com.example.temp.common.dto.UserContext;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,5 +32,15 @@ public class CommentController {
         LocalDateTime registeredAt = LocalDateTime.now();
         Long commentId = commentService.createComment(postId, userContext, commentCreateRequest, registeredAt);
         return ResponseEntity.ok(CreatedResponse.of(commentId));
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<SliceCommentResponse> getCommentsByPost(
+        @PathVariable Long postId,
+        @Login UserContext userContext,
+        @PageableDefault(sort = "registeredAt", direction = DESC) Pageable pageable
+    ) {
+        SliceCommentResponse sliceComments = commentService.findCommentsByPost(postId, userContext, pageable);
+        return ResponseEntity.ok(sliceComments);
     }
 }

--- a/src/test/java/com/example/temp/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/example/temp/comment/application/CommentServiceTest.java
@@ -2,6 +2,7 @@ package com.example.temp.comment.application;
 
 import static com.example.temp.common.exception.ErrorCode.AUTHENTICATED_FAIL;
 import static com.example.temp.common.exception.ErrorCode.POST_NOT_FOUND;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -9,6 +10,7 @@ import com.example.temp.auth.domain.Role;
 import com.example.temp.comment.domain.Comment;
 import com.example.temp.comment.domain.CommentRepository;
 import com.example.temp.comment.dto.request.CommentCreateRequest;
+import com.example.temp.comment.dto.response.SliceCommentResponse;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.entity.Email;
 import com.example.temp.common.exception.ApiException;
@@ -21,10 +23,12 @@ import com.example.temp.post.domain.Content;
 import com.example.temp.post.domain.Post;
 import com.example.temp.post.domain.PostRepository;
 import java.time.LocalDateTime;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -95,6 +99,102 @@ class CommentServiceTest {
             .hasMessage(AUTHENTICATED_FAIL.getMessage());
     }
 
+    @DisplayName("게시글에 포함된 댓글 목록을 가져 올 수 있다.")
+    @Test
+    void findCommentsByPost() {
+        //given
+        Member member1 = createMember("유저1", "user1@gymhub.run");
+        Member member2 = createMember("유저2", "user2@gymhub.run");
+        Post post = createPost(member1, "게시글1");
+        UserContext userContext = UserContext.fromMember(member2);
+        createComment(member2, "댓글1", post);
+        createComment(member2, "댓글2", post);
+        createComment(member2, "댓글3", post);
+
+        //when
+        SliceCommentResponse commentResponse = commentService.findCommentsByPost(post.getId(), userContext,
+            PageRequest.of(0, 10));
+
+        //then
+        assertThat(commentResponse.hasNext()).isFalse();
+        assertThat(commentResponse.comments()).hasSize(3)
+            .extracting("writerInfo.writerId", "content")
+            .containsExactly(
+                Tuple.tuple(member2.getId(), "댓글3"),
+                Tuple.tuple(member2.getId(), "댓글2"),
+                Tuple.tuple(member2.getId(), "댓글1")
+            );
+    }
+
+    @DisplayName("가져올 댓글이 남아 있으면 hashNext가 true를 반환한다.")
+    @Test
+    void findCommentsByPostHashNext() {
+        //given
+        Member member1 = createMember("유저1", "user1@gymhub.run");
+        Member member2 = createMember("유저2", "user2@gymhub.run");
+        Post post = createPost(member1, "게시글1");
+        UserContext userContext = UserContext.fromMember(member2);
+        createComment(member2, "댓글1", post);
+        createComment(member2, "댓글2", post);
+
+        //when
+        SliceCommentResponse commentResponse = commentService.findCommentsByPost(post.getId(), userContext,
+            PageRequest.of(0, 1));
+
+        //then
+        assertThat(commentResponse.hasNext()).isTrue();
+    }
+
+    @DisplayName("댓글이 없으면 response가 비어 있다.")
+    @Test
+    void findCommentsByPostNoComment() {
+        //given
+        Member member1 = createMember("유저1", "user1@gymhub.run");
+        Member member2 = createMember("유저2", "user2@gymhub.run");
+        Post post = createPost(member1, "게시글1");
+        UserContext userContext = UserContext.fromMember(member2);
+
+        //when
+        SliceCommentResponse commentResponse = commentService.findCommentsByPost(post.getId(), userContext,
+            PageRequest.of(0, 1));
+
+        //then
+        assertThat(commentResponse.comments()).isEmpty();
+    }
+
+    @DisplayName("로그인에 문제가 생기면 댓글을 조회할 수 없다.")
+    @Test
+    void findCommentsByPostWithInvalidUserContext() {
+        //given
+        Member member1 = createMember("user1", "user1@gymhub.run");
+        Post post = createPost(member1, "게시글1");
+        UserContext userContext = UserContext.builder()
+            .id(2L)
+            .role(Role.NORMAL)
+            .build();
+        createComment(member1, "댓글1", post);
+
+        //when, then
+        assertThatThrownBy(() -> commentService.findCommentsByPost(
+            post.getId(), userContext, PageRequest.of(0, 1)))
+            .isInstanceOf(ApiException.class)
+            .hasMessage(AUTHENTICATED_FAIL.getMessage());
+    }
+
+    @DisplayName("존재하지 않는 게시글의 댓글을 조회할 수 없다.")
+    @Test
+    void findCommentsByPostWithInvalidPost() {
+        //given
+        Member member = createMember("유저1", "user1@gymhub.run");
+        UserContext userContext = UserContext.fromMember(member);
+        CommentCreateRequest request = new CommentCreateRequest("댓글 내용");
+
+        //when, then
+        assertThatThrownBy(() -> commentService.findCommentsByPost(1L, userContext, PageRequest.of(0, 1)))
+            .isInstanceOf(ApiException.class)
+            .hasMessage(POST_NOT_FOUND.getMessage());
+    }
+
     private Post createPost(Member savedMember, String content) {
         Post post = Post.builder()
             .member(savedMember)
@@ -114,5 +214,11 @@ class CommentServiceTest {
             .privacyPolicy(PrivacyPolicy.PUBLIC)
             .build();
         return memberRepository.save(member);
+    }
+
+    private Comment createComment(Member member, String content, Post post) {
+        return commentRepository.save(
+            Comment.create(member, content, post, LocalDateTime.now())
+        );
     }
 }

--- a/src/test/java/com/example/temp/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/example/temp/comment/domain/CommentRepositoryTest.java
@@ -49,9 +49,7 @@ class CommentRepositoryTest {
         commentRepository.saveAll(List.of(comment1, comment2, comment3));
 
         //when
-        System.out.println("==========================================");
         Slice<Comment> comments = commentRepository.findByPostId(post.getId(), PageRequest.of(0, 10));
-        System.out.println("==========================================");
 
         //then
         assertThat(comments.hasNext()).isFalse();

--- a/src/test/java/com/example/temp/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/example/temp/comment/domain/CommentRepositoryTest.java
@@ -1,0 +1,87 @@
+package com.example.temp.comment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.common.entity.Email;
+import com.example.temp.member.domain.FollowStrategy;
+import com.example.temp.member.domain.Member;
+import com.example.temp.member.domain.MemberRepository;
+import com.example.temp.member.domain.PrivacyPolicy;
+import com.example.temp.member.domain.nickname.Nickname;
+import com.example.temp.post.domain.Content;
+import com.example.temp.post.domain.Post;
+import com.example.temp.post.domain.PostRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @DisplayName("게시글에 포함된 댓글 리스트를 가져올 수 있다.")
+    @Test
+    void findCommentsByPost() {
+        //given
+        Member member1 = createMember("user1", "user1@gymhub.run");
+        Member member2 = createMember("user2", "user2@gymhub.run");
+        Post post = createPost(member1, "게시글1");
+
+        Comment comment1 = Comment.create(member2, "댓글1", post, LocalDateTime.now());
+        Comment comment2 = Comment.create(member1, "댓글2", post, LocalDateTime.now());
+        Comment comment3 = Comment.create(member2, "댓글3", post, LocalDateTime.now());
+        commentRepository.saveAll(List.of(comment1, comment2, comment3));
+
+        //when
+        System.out.println("==========================================");
+        Slice<Comment> comments = commentRepository.findByPostId(post.getId(), PageRequest.of(0, 10));
+        System.out.println("==========================================");
+
+        //then
+        assertThat(comments.hasNext()).isFalse();
+        assertThat(comments).hasSize(3)
+            .extracting("post.id", "member.nickname.value", "content")
+            .containsExactly(
+                Tuple.tuple(post.getId(), "user2", "댓글3"),
+                Tuple.tuple(post.getId(), "user1", "댓글2"),
+                Tuple.tuple(post.getId(), "user2", "댓글1")
+            );
+    }
+
+    private Post createPost(Member savedMember, String content) {
+        Post post = Post.builder()
+            .member(savedMember)
+            .content(Content.create(content))
+            .registeredAt(LocalDateTime.now())
+            .build();
+        return postRepository.save(post);
+    }
+
+    private Member createMember(String nickName, String email) {
+        Member member = Member.builder()
+            .registered(true)
+            .email(Email.create(email))
+            .profileUrl("프로필")
+            .nickname(Nickname.create(nickName))
+            .followStrategy(FollowStrategy.EAGER)
+            .privacyPolicy(PrivacyPolicy.PUBLIC)
+            .build();
+        return memberRepository.save(member);
+    }
+}


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] 댓글 조회 기능 추가

## 🏌🏻 리뷰 포인트
페이지 처리 할때 ManyToOne 연관관계는 fetch join으로 N + 1 문제를 해결할 수 있다고 하여 해당 방식으로 해결했습니다. 이 부분 위주로 리뷰해주시면 될 것 같습니다.

```java
@Repository
public interface CommentRepository extends JpaRepository<Comment, Long> {

    @Query("SELECT c FROM Comment c JOIN FETCH c.member JOIN FETCH c.post WHERE c.post.id = :postId ORDER BY c.registeredAt DESC")
    Slice<Comment> findByPostId(@Param("postId") Long postId, Pageable pageable);
}
```

## 🧘🏻 기타 사항

close #138 