### PR TITLE
[#145] 게시글 조회 시 댓글 갯수 표시

### DIFF
--- a/src/main/java/com/example/temp/comment/application/CommentService.java
+++ b/src/main/java/com/example/temp/comment/application/CommentService.java
@@ -37,6 +37,7 @@ public class CommentService {
 
         Comment comment = Comment.create(member, commentCreateRequest.content(), post, registeredAt);
         Comment savedComment = commentRepository.save(comment);
+        post.addCommentCount();
 
         return savedComment.getId();
     }

--- a/src/main/java/com/example/temp/post/domain/Post.java
+++ b/src/main/java/com/example/temp/post/domain/Post.java
@@ -54,6 +54,8 @@ public class Post extends BaseTimeEntity {
 
     private LocalDateTime registeredAt;
 
+    private int commentCount;
+
     @Builder
     public Post(Member member, Content content, LocalDateTime registeredAt) {
         this.member = member;
@@ -80,5 +82,9 @@ public class Post extends BaseTimeEntity {
 
     public void updateContent(String content) {
         this.content = Content.create(content);
+    }
+
+    public void addCommentCount() {
+        this.commentCount++;
     }
 }

--- a/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostDetailResponse.java
@@ -13,6 +13,7 @@ public record PostDetailResponse(
     String content,
     List<String> imageUrls,
     List<String> hashtags,
+    int commentCount,
     LocalDateTime registeredAt
 ) {
 
@@ -23,6 +24,7 @@ public record PostDetailResponse(
             .content(post.getContent())
             .imageUrls(getImageUrls(post))
             .hashtags(getHashtags(post))
+            .commentCount(post.getCommentCount())
             .registeredAt(post.getRegisteredAt())
             .build();
     }

--- a/src/main/java/com/example/temp/post/dto/response/PostElementResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostElementResponse.java
@@ -10,6 +10,7 @@ public record PostElementResponse(
     WriterInfo writerInfo,
     String content,
     String imageUrl,
+    int commentCount,
     LocalDateTime registeredAt
 ) {
 
@@ -19,6 +20,7 @@ public record PostElementResponse(
             .writerInfo(WriterInfo.from(post.getMember()))
             .content(post.getContent())
             .imageUrl(post.getImageUrl().orElse(null))
+            .commentCount(post.getCommentCount())
             .registeredAt(post.getRegisteredAt())
             .build();
     }

--- a/src/test/java/com/example/temp/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/example/temp/comment/application/CommentServiceTest.java
@@ -59,9 +59,10 @@ class CommentServiceTest {
 
         //when
         Long commentId = commentService.createComment(post.getId(), userContext, request, LocalDateTime.now());
+        Comment comment = commentRepository.findById(commentId).orElseThrow();
 
         //then
-        Comment comment = commentRepository.findById(commentId).orElseThrow();
+        assertThat(post.getCommentCount()).isEqualTo(1);
         assertThat(comment.getPost()).isEqualTo(post);
         assertThat(comment.getMember()).isEqualTo(member);
         assertThat(comment.getContent()).isEqualTo(request.content());

--- a/src/test/java/com/example/temp/post/application/PostServiceTest.java
+++ b/src/test/java/com/example/temp/post/application/PostServiceTest.java
@@ -2,6 +2,7 @@ package com.example.temp.post.application;
 
 import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
 import static com.example.temp.common.exception.ErrorCode.POST_NOT_FOUND;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -343,6 +344,17 @@ class PostServiceTest {
         assertThatThrownBy(() -> postService.findPost(post.getId(), userContext))
             .isInstanceOf(ApiException.class)
             .hasMessage(POST_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("게시글을 작성하면 최초 댓글 수는 0개이다")
+    @Test
+    void createPostInitialCommentCountEqualsZero() {
+        //given
+        Member member = saveMember("user1@gymhub.run", "user1");
+        Post post = savePost(member, "게시글1", new ArrayList<>());
+
+        //when, then
+        assertThat(post.getCommentCount()).isZero();
     }
 
     private Member saveMember(String email, String nickname) {


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] 댓글 작성시 게시글에 CommentCount ++
- [X] 게시글 조회 시 댓글갯수 표시

## 🏌🏻 리뷰 포인트
여러 고민을 많이 했습니다.. 성능고려도 해야해서 직접 쿼리도 작성해보고 jpql도 사용해보고 했지만 현재 구조에서는 당장 해결하기 힘들다고 판단했습니다. 그래서 동시성 문제가 터질 가능성은 있지만 초기 서비스라 이용자가 많지 않을 것 같아 댓글 갯수 같은 경우는 댓글 작성시 Post에 CommentCount에 1씩 더해주는 방식으로 구현했습니다.

```java
private int commentCount;
```

```java
@Transactional
    public Long createComment(Long postId, UserContext userContext, CommentCreateRequest commentCreateRequest,
        LocalDateTime registeredAt) {
        Post post = findPostBy(postId);
        Member member = findMemberBy(userContext.id());

        Comment comment = Comment.create(member, commentCreateRequest.content(), post, registeredAt);
        Comment savedComment = commentRepository.save(comment);
        post.addCommentCount();

        return savedComment.getId();
    }
```

아마 삭제 구현 시 - 해주는 방식으로 할 것 같습니다.


## 🧘🏻 기타 사항

close #145 