### PR TITLE
[#153] 팔로워/팔로잉 목록을 보여줄 때, 대상의 이름을 함께 반환하도록 API 변경

### DIFF
--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -25,7 +25,9 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
      * @param lastId   입력된 lastId보다 id가 큰 Follow만 조회가 가능합니다.
      * @param pageable page는 0이어야 합니다.(PageRequest.ofSize를 사용해 객체를 만들어주세요)
      */
-    @Query("SELECT f FROM Follow f JOIN FETCH f.to "
+    @Query("SELECT f FROM Follow f "
+        + "JOIN FETCH f.from "
+        + "JOIN FETCH f.to "
         + "WHERE f.from.id = :fromId "
         + "AND f.status = :status "
         + "AND f.id > :lastId "
@@ -46,7 +48,9 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
      * @param lastId   입력된 lastId보다 id가 큰 Follow만 조회가 가능합니다.
      * @param pageable page는 0이어야 합니다.(PageRequest.ofSize를 사용해 객체를 만들어주세요)
      */
-    @Query("SELECT f FROM Follow f JOIN FETCH f.from "
+    @Query("SELECT f FROM Follow f "
+        + "JOIN FETCH f.from "
+        + "JOIN FETCH f.to "
         + "WHERE f.to.id = :toId "
         + "AND f.status = :status "
         + "AND f.id > :lastId "

--- a/src/main/java/com/example/temp/follow/dto/response/FollowInfo.java
+++ b/src/main/java/com/example/temp/follow/dto/response/FollowInfo.java
@@ -5,10 +5,11 @@ import com.example.temp.member.domain.Member;
 public record FollowInfo(
     Long id,
     Long memberId,
+    String nickname,
     String profileUrl
 ) {
 
     public static FollowInfo of(Member member, Long id) {
-        return new FollowInfo(id, member.getId(), member.getProfileUrl());
+        return new FollowInfo(id, member.getId(), member.getNicknameValue(), member.getProfileUrl());
     }
 }

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.example.temp.follow.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 
 import com.example.temp.common.entity.Email;
 import com.example.temp.member.domain.FollowStrategy;
@@ -148,13 +149,22 @@ class FollowRepositoryTest {
         Follow follow2 = saveFollow(fromMember, toMember2, targetStatus);
 
         Pageable pageable = PageRequest.ofSize(2);
+
+        em.flush();
+        em.clear();
         // when
         Slice<Follow> result = followRepository.findAllByFromIdAndStatus(
             fromMember.getId(), targetStatus, -1, pageable);
 
         // then
         assertThat(result).hasSize((int) pageable.getPageSize())
-            .containsExactly(follow1, follow2);
+            .extracting(Follow::getId,
+                x -> x.getFrom().getId(),
+                x -> x.getTo().getId(),
+                Follow::getStatus)
+            .containsExactlyInAnyOrder(
+                tuple(follow1.getId(), fromMember.getId(), toMember1.getId(), targetStatus),
+                tuple(follow2.getId(), fromMember.getId(), toMember2.getId(), targetStatus));
     }
 
     @Test
@@ -217,8 +227,14 @@ class FollowRepositoryTest {
             toMember.getId(), targetStatus, -1, pageable);
 
         // then
-        assertThat(result).hasSize(2)
-            .containsExactly(follow1, follow2);
+        assertThat(result).hasSize((int) pageable.getPageSize())
+            .extracting(Follow::getId,
+                x -> x.getFrom().getId(),
+                x -> x.getTo().getId(),
+                Follow::getStatus)
+            .containsExactlyInAnyOrder(
+                tuple(follow1.getId(), fromMember1.getId(), toMember.getId(), targetStatus),
+                tuple(follow2.getId(), fromMember2.getId(), toMember.getId(), targetStatus));
     }
 
     @Test

--- a/src/test/java/com/example/temp/follow/dto/response/FollowInfoResultTest.java
+++ b/src/test/java/com/example/temp/follow/dto/response/FollowInfoResultTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.temp.follow.domain.Follow;
 import com.example.temp.member.domain.Member;
+import com.example.temp.member.domain.nickname.Nickname;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,8 +17,8 @@ class FollowInfoResultTest {
     @DisplayName("Following 목록 생성 테스트")
     void createFollowings() throws Exception {
         // given
-        Member member1 = Member.builder().build();
-        Member member2 = Member.builder().build();
+        Member member1 = createMember("nick1");
+        Member member2 = createMember("nick2");
 
         Follow follow1 = createFollow(member1, member2);
         Follow follow2 = createFollow(member2, member1);
@@ -32,12 +33,19 @@ class FollowInfoResultTest {
         assertThat(result.hasNext()).isFalse();
     }
 
+    private static Member createMember(String nickname) {
+        return Member.builder()
+            .nickname(Nickname.create(nickname))
+            .build();
+    }
+
     @Test
     @DisplayName("Follower 목록 생성 테스트")
     void createFollowers() throws Exception {
         // given
-        Member member1 = Member.builder().build();
-        Member member2 = Member.builder().build();
+        Member member1 = createMember("nick1");
+        Member member2 = createMember("nick2");
+
 
         Follow follow1 = createFollow(member1, member2);
         Follow follow2 = createFollow(member2, member1);

--- a/src/test/java/com/example/temp/follow/dto/response/FollowInfosTest.java
+++ b/src/test/java/com/example/temp/follow/dto/response/FollowInfosTest.java
@@ -12,8 +12,8 @@ class FollowInfosTest {
     @DisplayName("FollowInfos를 생성한다")
     void create() throws Exception {
         // given
-        FollowInfo followInfo1 = new FollowInfo(1L, 1L, "url");
-        FollowInfo followInfo2 = new FollowInfo(2L, 2L, "url");
+        FollowInfo followInfo1 = new FollowInfo(1L, 1L, "nick1", "url");
+        FollowInfo followInfo2 = new FollowInfo(2L, 2L, "nick2", "url");
         // when
         FollowInfos result = FollowInfos.from(List.of(followInfo1, followInfo2));
 


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 팔로워/팔로잉 목록을 보여줄 때, 대상의 이름을 함께 반환하도록 API 변경

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
Fetch Join을 사용해서 N+1이 일어나지 않도록 만들었습니당
```
Hibernate: 
    select
        f1_0.follow_id,
        f1_0.from_id,
        f2_0.member_id,
        f2_0.deleted,
        f2_0.email,
        f2_0.follow_strategy,
        f2_0.nickname,
        f2_0.privacy_policy,
        f2_0.profile_url,
        f2_0.registered,
        f1_0.status,
        f1_0.to_id,
        t1_0.member_id,
        t1_0.deleted,
        t1_0.email,
        t1_0.follow_strategy,
        t1_0.nickname,
        t1_0.privacy_policy,
        t1_0.profile_url,
        t1_0.registered 
    from
        follows f1_0 
    join
        members f2_0 
            on f2_0.member_id=f1_0.from_id 
    join
        members t1_0 
            on t1_0.member_id=f1_0.to_id 
    where
        f1_0.from_id=? 
        and f1_0.status=? 
        and f1_0.follow_id>? 
    order by
        f1_0.follow_id 
    offset
        ? rows 
    fetch
        first ? rows only

```
close #153 