### PR TITLE
[#150] 해시태그로 게시글 검색

### DIFF
--- a/src/main/java/com/example/temp/comment/domain/CommentRepository.java
+++ b/src/main/java/com/example/temp/comment/domain/CommentRepository.java
@@ -10,6 +10,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("SELECT c FROM Comment c JOIN FETCH c.member JOIN FETCH c.post WHERE c.post.id = :postId ORDER BY c.registeredAt DESC")
+    @Query("SELECT c "
+        + "FROM Comment c "
+        + "JOIN FETCH c.member "
+        + "JOIN FETCH c.post "
+        + "WHERE c.post.id = :postId "
+        + "ORDER BY c.registeredAt DESC")
     Slice<Comment> findAllByPostId(@Param("postId") Long postId, Pageable pageable);
 }

--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
 
     // 해시태그
     HASHTAG_PATTERN_MISMATCH(HttpStatus.BAD_REQUEST, "해시태그 형식에 맞지 않습니다."),
+    HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 해시태그 입니다."),
 
     // 신체 부위 & 운동 기구
     BODY_PART_ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "이미 등록된 신체 부위입니다"),

--- a/src/main/java/com/example/temp/post/domain/PostHashtagRepository.java
+++ b/src/main/java/com/example/temp/post/domain/PostHashtagRepository.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
 
-    @Query("DELETE FROM PostHashtag p WHERE p.post IN :posts")
+    @Query("DELETE FROM PostHashtag p "
+        + "WHERE p.post "
+        + "IN :posts")
     @Modifying
     void deleteAllInBatchByPostIn(@Param("posts") List<Post> posts);
 }

--- a/src/main/java/com/example/temp/post/domain/PostRepository.java
+++ b/src/main/java/com/example/temp/post/domain/PostRepository.java
@@ -2,16 +2,22 @@ package com.example.temp.post.domain;
 
 import com.example.temp.member.domain.Member;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    Slice<Post> findByMemberInOrderByRegisteredAtDesc(List<Member> members, Pageable pageable);
+    Slice<Post> findAllByMemberInOrderByRegisteredAtDesc(List<Member> members, Pageable pageable);
 
     List<Post> findAllByMemberId(@Param("memberId") Long memberId);
+
+    @Query("SELECT p FROM Post p JOIN p.postHashtags ph JOIN ph.hashtag h WHERE h.id = :hashtagId AND p.member.privacyPolicy = 'PUBLIC' ORDER BY p.registeredAt DESC")
+    Page<Post> findAllPostByHashtag(@Param("hashtagId") Long hashtagId, Pageable pageable);
+
 }

--- a/src/main/java/com/example/temp/post/domain/PostRepository.java
+++ b/src/main/java/com/example/temp/post/domain/PostRepository.java
@@ -17,7 +17,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByMemberId(@Param("memberId") Long memberId);
 
-    @Query("SELECT p FROM Post p JOIN p.postHashtags ph JOIN ph.hashtag h WHERE h.id = :hashtagId AND p.member.privacyPolicy = 'PUBLIC' ORDER BY p.registeredAt DESC")
+    @Query("SELECT p "
+        + "FROM Post p "
+        + "JOIN p.postHashtags ph "
+        + "JOIN ph.hashtag h "
+        + "WHERE h.id = :hashtagId "
+        + "AND p.member.privacyPolicy = 'PUBLIC' "
+        + "ORDER BY p.registeredAt DESC")
     Page<Post> findAllPostByHashtag(@Param("hashtagId") Long hashtagId, Pageable pageable);
 
 }

--- a/src/main/java/com/example/temp/post/dto/response/PostSearchResponse.java
+++ b/src/main/java/com/example/temp/post/dto/response/PostSearchResponse.java
@@ -1,0 +1,19 @@
+package com.example.temp.post.dto.response;
+
+import com.example.temp.post.domain.Post;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PostSearchResponse(
+    List<PostElementResponse> posts,
+    long totalPostCount,
+    boolean hasNext
+) {
+
+    public static PostSearchResponse from(Page<Post> posts) {
+        List<PostElementResponse> postElements = posts.stream()
+            .map(PostElementResponse::from)
+            .toList();
+        return new PostSearchResponse(postElements, posts.getTotalElements(), posts.hasNext());
+    }
+}

--- a/src/main/java/com/example/temp/post/presentation/PostController.java
+++ b/src/main/java/com/example/temp/post/presentation/PostController.java
@@ -10,6 +10,7 @@ import com.example.temp.post.dto.request.PostCreateRequest;
 import com.example.temp.post.dto.request.PostUpdateRequest;
 import com.example.temp.post.dto.response.PostDetailResponse;
 import com.example.temp.post.dto.response.PostResponse;
+import com.example.temp.post.dto.response.PostSearchResponse;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -63,5 +65,14 @@ public class PostController {
     public ResponseEntity<Void> deletePost(@PathVariable Long postId, @Login UserContext userContext) {
         postService.deletePost(postId, userContext);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<PostSearchResponse> getPostsByHashtag(
+        @RequestParam String hashtag,
+        @Login UserContext userContext,
+        @PageableDefault(sort = "registeredAt", direction = DESC) Pageable pageable) {
+        PostSearchResponse posts = postService.findPostsByHashtag(hashtag, userContext, pageable);
+        return ResponseEntity.ok(posts);
     }
 }

--- a/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
@@ -1,11 +1,11 @@
 package com.example.temp.post.domain;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.*;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import com.example.temp.common.entity.Email;
+import com.example.temp.hashtag.domain.Hashtag;
+import com.example.temp.hashtag.domain.HashtagRepository;
 import com.example.temp.image.domain.Image;
 import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.member.domain.FollowStrategy;
@@ -15,12 +15,13 @@ import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.domain.nickname.Nickname;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -40,6 +41,9 @@ class PostRepositoryTest {
     @Autowired
     private ImageRepository imageRepository;
 
+    @Autowired
+    private HashtagRepository hashtagRepository;
+
     @DisplayName("팔로우 리스트에 들어 있는 사용자의 게시글만 조회할 수 있다.")
     @Test
     void findByMemberIn() {
@@ -52,15 +56,15 @@ class PostRepositoryTest {
         saveImage("image2");
         saveImage("image3");
 
-        savePost(member1, "내용1", List.of("image1"));
-        savePost(member2, "내용2", List.of("image2"));
-        savePost(member3, "내용3", List.of("image3"));
+        savePost(member1, "내용1", List.of("image1"), new ArrayList<>());
+        savePost(member2, "내용2", List.of("image2"), new ArrayList<>());
+        savePost(member3, "내용3", List.of("image3"), new ArrayList<>());
 
         List<Member> followMembers = List.of(member1, member2);
         Pageable pageable = PageRequest.of(0, 10);
 
         // When
-        Slice<Post> slicePost = postRepository.findByMemberInOrderByRegisteredAtDesc(
+        Slice<Post> slicePost = postRepository.findAllByMemberInOrderByRegisteredAtDesc(
             followMembers, pageable);
         List<Post> posts = slicePost.getContent();
 
@@ -80,11 +84,11 @@ class PostRepositoryTest {
 
         saveImage("image1");
 
-        savePost(member3, "content", List.of("image1"));
+        savePost(member3, "content", List.of("image1"), new ArrayList<>());
 
         // When
         Pageable pageable = PageRequest.of(0, 10);
-        Slice<Post> slicePost = postRepository.findByMemberInOrderByRegisteredAtDesc(
+        Slice<Post> slicePost = postRepository.findAllByMemberInOrderByRegisteredAtDesc(
             List.of(member1, member2), pageable);
 
         // Then
@@ -102,12 +106,12 @@ class PostRepositoryTest {
 
         for (int i = 0; i < 20; i++) {
             saveImage("image" + i);
-            savePost(member1, "content" + i, List.of("image" + i));
+            savePost(member1, "content" + i, List.of("image" + i), new ArrayList<>());
         }
 
         // When
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("registeredAt").descending());
-        Slice<Post> slicePost = postRepository.findByMemberInOrderByRegisteredAtDesc(
+        Slice<Post> slicePost = postRepository.findAllByMemberInOrderByRegisteredAtDesc(
             List.of(member1, member2), pageable);
 
         // Then
@@ -126,14 +130,14 @@ class PostRepositoryTest {
         saveImage("image1");
         saveImage("image2");
 
-        savePost(member1, "내용1", List.of("image1"));
-        savePost(member2, "내용2", List.of("image2"));
+        savePost(member1, "내용1", List.of("image1"), new ArrayList<>());
+        savePost(member2, "내용2", List.of("image2"), new ArrayList<>());
 
         List<Member> followMembers = List.of(member1, member2);
         Pageable pageable = PageRequest.of(0, 10);
 
         // When
-        Slice<Post> slicePost = postRepository.findByMemberInOrderByRegisteredAtDesc(
+        Slice<Post> slicePost = postRepository.findAllByMemberInOrderByRegisteredAtDesc(
             followMembers, pageable);
         List<Post> posts = slicePost.getContent();
 
@@ -152,8 +156,8 @@ class PostRepositoryTest {
         //given
         Member member = saveMember("email1@naver.com", "작성자");
         saveImage("이미지1");
-        savePost(member, "게시글1", List.of("이미지1"));
-        savePost(member, "게시글2", new ArrayList<>());
+        savePost(member, "게시글1", List.of("이미지1"), new ArrayList<>());
+        savePost(member, "게시글2", new ArrayList<>(), new ArrayList<>());
 
         //when
         List<Post> posts = postRepository.findAllByMemberId(member.getId());
@@ -162,6 +166,86 @@ class PostRepositoryTest {
         assertThat(posts).hasSize(2)
             .extracting("content")
             .containsExactly("게시글1", "게시글2");
+    }
+
+    @DisplayName("공개계정의 게시글을 해시태그로 검색할 수 있다.")
+    @Test
+    void findAllPostsByHashTag() {
+        //given
+        Member member = saveMember("email1@naver.com", "작성자");
+        saveImage("이미지1");
+        saveImage("이미지2");
+        saveImage("이미지3");
+        saveHashtag("#해시태그1");
+        Hashtag hashtag = saveHashtag("#해시태그2");
+        saveHashtag("#해시태그3");
+        saveHashtag("#해시태그4");
+        savePost(member, "게시글1", List.of("이미지1"), List.of("#해시태그1", "#해시태그2"));
+        savePost(member, "게시글2", List.of("이미지2", "이미지3"), List.of("#해시태그1", "#해시태그2", "#해시태그3"));
+        savePost(member, "게시글3", List.of("이미지1", "이미지2", "이미지3"), List.of("#해시태그1", "#해시태그4"));
+
+        //when
+        Page<Post> posts = postRepository.findAllPostByHashtag(hashtag.getId(), PageRequest.of(0, 5));
+        List<Post> postContents = posts.getContent();
+
+        //then
+        assertThat(posts.hasNext()).isFalse();
+        assertThat(postContents).hasSize(2)
+            .extracting("content")
+            .containsExactly("게시글2", "게시글1");
+    }
+
+    @DisplayName("비공개 계정의 게시글은 검색되지 않는다.")
+    @Test
+    void notFoundPrivateAccountPost() {
+        //given
+        Member privateMember = saveMember("private@naver.com", "비공개계정");
+        privateMember.changePrivacy(PrivacyPolicy.PRIVATE);
+        Hashtag hashtag = saveHashtag("#privateHashtag");
+        saveImage("이미지1");
+        savePost(privateMember, "비공개계정 게시글", List.of("이미지1"), List.of("#privateHashtag"));
+
+        //when
+        Page<Post> posts = postRepository.findAllPostByHashtag(hashtag.getId(), PageRequest.of(0, 5));
+
+        //then
+        assertThat(posts.getTotalElements()).isZero();
+    }
+
+    @DisplayName("해시태그가 없는 게시글은 검색되지 않는다.")
+    @Test
+    void notFoundPostWithoutHashtag() {
+        //given
+        Member member = saveMember("email2@naver.com", "작성자2");
+        saveImage("이미지4");
+        savePost(member, "게시글4", List.of("이미지4"), List.of());
+
+        //when
+        Page<Post> posts = postRepository.findAllPostByHashtag(999L, PageRequest.of(0, 5)); // 존재하지 않는 해시태그 ID
+
+        //then
+        assertThat(posts.getTotalElements()).isZero();
+    }
+
+    @DisplayName("게시글은 등록일자 내림차순으로 정렬된다.")
+    @Test
+    void postsAreOrderedByRegisteredAtDesc() {
+        //given
+        Member member = saveMember("email3@naver.com", "작성자3");
+        Hashtag hashtag = saveHashtag("#hashtag5");
+        saveImage("이미지5");
+        saveImage("이미지6");
+        saveImage("이미지7");
+        savePost(member, "게시글5", List.of("이미지5"), List.of("#hashtag5"));
+        savePost(member, "게시글6", List.of("이미지6"), List.of("#hashtag5"));
+        savePost(member, "게시글7", List.of("이미지7"), List.of("#hashtag5"));
+
+        //when
+        Page<Post> posts = postRepository.findAllPostByHashtag(hashtag.getId(), PageRequest.of(0, 5));
+        List<Post> postContents = posts.getContent();
+
+        //then
+        assertThat(postContents).isSortedAccordingTo(Comparator.comparing(Post::getRegisteredAt).reversed());
     }
 
     private Member saveMember(String email, String nickname) {
@@ -175,7 +259,7 @@ class PostRepositoryTest {
         return memberRepository.save(member);
     }
 
-    private void savePost(Member member, String content, List<String> imageUrls) {
+    private void savePost(Member member, String content, List<String> imageUrls, List<String> hashtags) {
         Post post = Post.builder()
             .member(member)
             .content(Content.builder()
@@ -192,11 +276,23 @@ class PostRepositoryTest {
                 postImage.relate(post);
 
             });
+
+        hashtags.stream()
+            .map(name -> hashtagRepository.findByName(name).orElseThrow())
+            .forEach(hashtag -> {
+                PostHashtag postHashtag = PostHashtag.createPostHashtag(hashtag);
+                postHashtag.relatePost(post);
+            });
         postRepository.save(post);
     }
 
-    private void saveImage(String url) {
+    private Image saveImage(String url) {
         Image image = Image.create(url);
-        imageRepository.save(image);
+        return imageRepository.save(image);
+    }
+
+    private Hashtag saveHashtag(String name) {
+        Hashtag hashtag = Hashtag.create(name);
+        return hashtagRepository.save(hashtag);
     }
 }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] 해시태그로 게시글 검색
- [X] 공개된 계정만 검색 리스트에 추가
- [X] 검색 결과 시 검색된 게시글 총 갯수 포함

## 🏌🏻 리뷰 포인트
hashtag로 검색 시 비즈니스로직에 대한 책임을 hashtag와 post중 어디서 갖고 있을 지에 대해 고민했고 추가적으로 계획된 서비스가 실시간 추천 서비스 정도 뿐이라서 두 컨트롤러 간의 책임 구분이 모호하다고 판단해서 더 큰 범위의 도메인인 Post에 두기로 결정했습니다.

또한 게시글 검색 역시 저희 쪽에서는 무한 스크롤로 제공되지만, 검색결과 갯수를 표시해야 하기때문에 Slice대신 Page를 사용했습니다. 

Page도 결국 Slice를 상속하여 구현했기 때문에 Slice의 기능을 전부 사용할 수 있었습니다.

Page로 조회 시 count 쿼리가 추가적으로 나가기 때문에 무한스크롤을 구현 시 성능 상 이점 을 위해 Slice를 사용하지만 이번 기능은 전체 게시글 갯수가 필요해서 Page로 받아서 무한스크롤로 구현할 수 있도록 Response DTO에는 hashNext를 넘기도록 구현했습니다.

## 🧘🏻 기타 사항

close #150 