### PR TITLE
[#135] 운동기록 스냅샷

### DIFF
--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -149,7 +149,7 @@ public class ExerciseRecordService {
 
     public RecordSnapshotsResponse retrieveSnapshots(UserContext userContext, Long lastId, Pageable pageable) {
         Member member = findMember(userContext);
-        Slice<ExerciseRecord> snapshots = exerciseRecordRepository.findPrevSnapshotsByMember(lastId, pageable, member);
+        Slice<ExerciseRecord> snapshots = exerciseRecordRepository.findNextSnapshotsByMember(lastId, pageable, member);
         return RecordSnapshotsResponse.create(snapshots);
     }
 

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -120,6 +120,18 @@ public class ExerciseRecordService {
         exerciseRecordRepository.delete(exerciseRecord);
     }
 
+    @Transactional
+    public void createSnapshot(UserContext userContext, long targetId) {
+        Member member = findMember(userContext);
+        ExerciseRecord exerciseRecord = exerciseRecordRepository.findById(targetId)
+            .orElseThrow(() -> new ApiException(ErrorCode.RECORD_NOT_FOUND));
+        if (!exerciseRecord.isOwnedBy(member)) {
+            throw new ApiException(ErrorCode.AUTHORIZED_FAIL);
+        }
+        ExerciseRecord snapshot = exerciseRecord.createSnapshot(member);
+        exerciseRecordRepository.save(snapshot);
+    }
+
     private Member findMember(UserContext userContext) {
         return memberRepository.findById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -16,6 +16,7 @@ import com.example.temp.record.dto.request.ExerciseRecordCreateRequest.TrackCrea
 import com.example.temp.record.dto.request.ExerciseRecordUpdateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordUpdateRequest.TrackUpdateRequest;
 import com.example.temp.record.dto.response.ExerciseRecordInfo;
+import com.example.temp.record.dto.response.RecordSnapshotsResponse;
 import com.example.temp.record.dto.response.RetrievePeriodExerciseRecordsResponse;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -24,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -142,6 +145,12 @@ public class ExerciseRecordService {
             throw new ApiException(ErrorCode.AUTHORIZED_FAIL);
         }
         exerciseRecordRepository.delete(snapshot);
+    }
+
+    public RecordSnapshotsResponse retrieveSnapshots(UserContext userContext, Long lastId, Pageable pageable) {
+        Member member = findMember(userContext);
+        Slice<ExerciseRecord> snapshots = exerciseRecordRepository.findPrevSnapshotsByMember(lastId, pageable, member);
+        return RecordSnapshotsResponse.create(snapshots);
     }
 
     private Member findMember(UserContext userContext) {

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -133,6 +133,17 @@ public class ExerciseRecordService {
         return snapshot.getId();
     }
 
+    @Transactional
+    public void deleteSnapshot(UserContext userContext, long targetId) {
+        Member member = findMember(userContext);
+        ExerciseRecord snapshot = exerciseRecordRepository.findSnapshotById(targetId)
+            .orElseThrow(() -> new ApiException(ErrorCode.RECORD_NOT_FOUND));
+        if (!snapshot.isOwnedBy(member)) {
+            throw new ApiException(ErrorCode.AUTHORIZED_FAIL);
+        }
+        exerciseRecordRepository.delete(snapshot);
+    }
+
     private Member findMember(UserContext userContext) {
         return memberRepository.findById(userContext.id())
             .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATED_FAIL));

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -121,7 +121,7 @@ public class ExerciseRecordService {
     }
 
     @Transactional
-    public void createSnapshot(UserContext userContext, long targetId) {
+    public long createSnapshot(UserContext userContext, long targetId) {
         Member member = findMember(userContext);
         ExerciseRecord exerciseRecord = exerciseRecordRepository.findById(targetId)
             .orElseThrow(() -> new ApiException(ErrorCode.RECORD_NOT_FOUND));
@@ -130,6 +130,7 @@ public class ExerciseRecordService {
         }
         ExerciseRecord snapshot = exerciseRecord.createSnapshot(member);
         exerciseRecordRepository.save(snapshot);
+        return snapshot.getId();
     }
 
     private Member findMember(UserContext userContext) {

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
@@ -45,13 +45,16 @@ public class ExerciseRecord extends BaseTimeEntity {
 
     private LocalDate recordDate;
 
+    private boolean isSnapshot;
+
     @Builder
-    private ExerciseRecord(Member member, List<Track> tracks, LocalDate recordDate) {
+    private ExerciseRecord(Member member, List<Track> tracks, LocalDate recordDate, boolean isSnapshot) {
         validate(tracks);
         this.member = member;
         this.recordDate = recordDate;
         this.tracks = new ArrayList<>();
         tracks.forEach(track -> track.relate(this));
+        this.isSnapshot = isSnapshot;
     }
 
     private void validate(List<Track> tracks) {
@@ -66,6 +69,16 @@ public class ExerciseRecord extends BaseTimeEntity {
             .member(member)
             .recordDate(LocalDate.now())
             .tracks(tracks)
+            .isSnapshot(false)
+            .build();
+    }
+
+    public static ExerciseRecord createSnapshot(Member member, List<Track> tracks) {
+        return ExerciseRecord.builder()
+            .member(member)
+            .recordDate(LocalDate.now())
+            .tracks(tracks)
+            .isSnapshot(true)
             .build();
     }
 

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
@@ -23,7 +23,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Table(name = "records")
@@ -73,11 +72,14 @@ public class ExerciseRecord extends BaseTimeEntity {
             .build();
     }
 
-    public static ExerciseRecord createSnapshot(Member member, List<Track> tracks) {
+    public ExerciseRecord createSnapshot(Member member) {
+        List<Track> tracksCopy = this.tracks.stream()
+            .map(Track::copy)
+            .toList();
         return ExerciseRecord.builder()
             .member(member)
-            .recordDate(LocalDate.now())
-            .tracks(tracks)
+            .recordDate(this.recordDate)
+            .tracks(tracksCopy)
             .isSnapshot(true)
             .build();
     }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
@@ -15,7 +15,7 @@ public interface ExerciseRecordRepository extends JpaRepository<ExerciseRecord, 
     @Query("SELECT er FROM ExerciseRecord er "
         + "WHERE er.isSnapshot = false "
         + "AND er.id = :targetId")
-    Optional<ExerciseRecord> findById(@Param("targetId") long targetId);
+    Optional<ExerciseRecord> findById(@Param("targetId") Long targetId);
 
     @Query("SELECT er FROM ExerciseRecord er "
         + "WHERE er.isSnapshot = false "

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
@@ -35,7 +35,8 @@ public interface ExerciseRecordRepository extends JpaRepository<ExerciseRecord, 
 
     @Query("SELECT er FROM ExerciseRecord er "
         + "WHERE er.isSnapshot = true "
-        + "AND er.id > :lastId "
-        + "AND er.member = :member")
-    Slice<ExerciseRecord> findNextSnapshotsByMember(long lastId, Pageable pageable, @Param("member") Member member);
+        + "AND (:lastId IS NULL OR er.id < :lastId) "
+        + "AND er.member = :member "
+        + "ORDER BY er.id DESC")
+    Slice<ExerciseRecord> findPrevSnapshotsByMember(Long lastId, Pageable pageable, @Param("member") Member member);
 }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
@@ -38,5 +38,5 @@ public interface ExerciseRecordRepository extends JpaRepository<ExerciseRecord, 
         + "AND (:lastId IS NULL OR er.id < :lastId) "
         + "AND er.member = :member "
         + "ORDER BY er.id DESC")
-    Slice<ExerciseRecord> findPrevSnapshotsByMember(Long lastId, Pageable pageable, @Param("member") Member member);
+    Slice<ExerciseRecord> findNextSnapshotsByMember(Long lastId, Pageable pageable, @Param("member") Member member);
 }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
@@ -4,6 +4,8 @@ import com.example.temp.member.domain.Member;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -30,4 +32,10 @@ public interface ExerciseRecordRepository extends JpaRepository<ExerciseRecord, 
         + "WHERE er.isSnapshot = true "
         + "AND er.id = :targetId")
     Optional<ExerciseRecord> findSnapshotById(@Param("targetId") long targetId);
+
+    @Query("SELECT er FROM ExerciseRecord er "
+        + "WHERE er.isSnapshot = true "
+        + "AND er.id > :lastId "
+        + "AND er.member = :member")
+    Slice<ExerciseRecord> findNextSnapshotsByMember(long lastId, Pageable pageable, @Param("member") Member member);
 }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
@@ -25,4 +25,9 @@ public interface ExerciseRecordRepository extends JpaRepository<ExerciseRecord, 
     List<ExerciseRecord> findAllByMemberAndPeriod(@Param("member") Member member,
         @Param("startDate") LocalDate startDate, @Param("lastDate") LocalDate lastDate);
 
+
+    @Query("SELECT er FROM ExerciseRecord er "
+        + "WHERE er.isSnapshot = true "
+        + "AND er.id = :targetId")
+    Optional<ExerciseRecord> findSnapshotById(@Param("targetId") long targetId);
 }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
@@ -3,6 +3,7 @@ package com.example.temp.record.domain;
 import com.example.temp.member.domain.Member;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,11 +12,17 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ExerciseRecordRepository extends JpaRepository<ExerciseRecord, Long> {
 
-    @Query("SELECT er FROM ExerciseRecord er"
-        + " WHERE er.member = :member"
-        + " AND er.isSnapshot = false"
-        + " AND :startDate <= er.recordDate"
-        + " AND er.recordDate <= :lastDate")
+    @Query("SELECT er FROM ExerciseRecord er "
+        + "WHERE er.isSnapshot = false "
+        + "AND er.id = :targetId")
+    Optional<ExerciseRecord> findById(@Param("targetId") long targetId);
+
+    @Query("SELECT er FROM ExerciseRecord er "
+        + "WHERE er.isSnapshot = false "
+        + "AND er.member = :member "
+        + "AND :startDate <= er.recordDate "
+        + "AND er.recordDate <= :lastDate")
     List<ExerciseRecord> findAllByMemberAndPeriod(@Param("member") Member member,
         @Param("startDate") LocalDate startDate, @Param("lastDate") LocalDate lastDate);
+
 }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
@@ -13,6 +13,7 @@ public interface ExerciseRecordRepository extends JpaRepository<ExerciseRecord, 
 
     @Query("SELECT er FROM ExerciseRecord er"
         + " WHERE er.member = :member"
+        + " AND er.isSnapshot = false"
         + " AND :startDate <= er.recordDate"
         + " AND er.recordDate <= :lastDate")
     List<ExerciseRecord> findAllByMemberAndPeriod(@Param("member") Member member,

--- a/src/main/java/com/example/temp/record/domain/SetInTrack.java
+++ b/src/main/java/com/example/temp/record/domain/SetInTrack.java
@@ -71,4 +71,11 @@ public class SetInTrack {
         this.track.getSetsInTrack().add(this);
     }
 
+    public SetInTrack copy() {
+        return SetInTrack.builder()
+            .order(this.order)
+            .repeatCnt(this.repeatCnt)
+            .weight(this.weight)
+            .build();
+    }
 }

--- a/src/main/java/com/example/temp/record/domain/Track.java
+++ b/src/main/java/com/example/temp/record/domain/Track.java
@@ -48,7 +48,7 @@ public class Track {
     private List<SetInTrack> setsInTrack = new ArrayList<>();
 
     @Builder
-    public Track(ExerciseRecord exerciseRecord, String machineName, BodyPart majorBodyPart,
+    private Track(ExerciseRecord exerciseRecord, String machineName, BodyPart majorBodyPart,
         List<SetInTrack> setsInTrack) {
         machineName = machineName.trim();
         validate(machineName, setsInTrack);
@@ -106,5 +106,12 @@ public class Track {
         }
         this.exerciseRecord = exerciseRecord;
         this.exerciseRecord.getTracks().add(this);
+    }
+
+    public Track copy() {
+        List<SetInTrack> setsInTrackCopy = this.setsInTrack.stream()
+            .map(SetInTrack::copy)
+            .toList();
+        return Track.createWithoutRecord(this.machineName, this.majorBodyPart, setsInTrackCopy);
     }
 }

--- a/src/main/java/com/example/temp/record/dto/response/ExerciseRecordInfo.java
+++ b/src/main/java/com/example/temp/record/dto/response/ExerciseRecordInfo.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record ExerciseRecordInfo(
+    Long recordId,
     LocalDate recordDate,
     List<TrackInfo> tracks
 ) {
@@ -15,7 +16,7 @@ public record ExerciseRecordInfo(
         List<TrackInfo> tracks = exerciseRecord.getTracks().stream()
             .map(TrackInfo::from)
             .toList();
-        return new ExerciseRecordInfo(exerciseRecord.getRecordDate(), tracks);
+        return new ExerciseRecordInfo(exerciseRecord.getId(), exerciseRecord.getRecordDate(), tracks);
     }
 
     public record TrackInfo(

--- a/src/main/java/com/example/temp/record/dto/response/RecordSnapshotsResponse.java
+++ b/src/main/java/com/example/temp/record/dto/response/RecordSnapshotsResponse.java
@@ -1,0 +1,18 @@
+package com.example.temp.record.dto.response;
+
+import com.example.temp.record.domain.ExerciseRecord;
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record RecordSnapshotsResponse(
+    List<ExerciseRecordInfo> snapshots,
+    boolean hasNext
+) {
+
+    public static RecordSnapshotsResponse create(Slice<ExerciseRecord> snapshots) {
+        List<ExerciseRecordInfo> exerciseRecordInfos = snapshots.stream()
+            .map(ExerciseRecordInfo::from)
+            .toList();
+        return new RecordSnapshotsResponse(exerciseRecordInfos, snapshots.hasNext());
+    }
+}

--- a/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
+++ b/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
@@ -57,4 +57,11 @@ public class ExerciseRecordController {
             userContext, MonthlyDatePeriod.of(year, month));
         return ResponseEntity.ok(response);
     }
+
+    @PostMapping("/{recordId}/snapshot")
+    public ResponseEntity<CreatedResponse> createSnapshot(@Login UserContext userContext, @PathVariable long recordId) {
+        long createdId = exerciseRecordService.createSnapshot(userContext, recordId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(CreatedResponse.of(createdId));
+    }
 }

--- a/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
+++ b/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
@@ -64,4 +64,11 @@ public class ExerciseRecordController {
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(CreatedResponse.of(createdId));
     }
+
+    @DeleteMapping("/snapshot/{snapshotId}")
+    public ResponseEntity<CreatedResponse> deleteSnapshot(@Login UserContext userContext,
+        @PathVariable long snapshotId) {
+        exerciseRecordService.deleteSnapshot(userContext, snapshotId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
+++ b/src/main/java/com/example/temp/record/presentation/ExerciseRecordController.java
@@ -7,8 +7,10 @@ import com.example.temp.common.dto.UserContext;
 import com.example.temp.record.application.ExerciseRecordService;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordUpdateRequest;
+import com.example.temp.record.dto.response.RecordSnapshotsResponse;
 import com.example.temp.record.dto.response.RetrievePeriodExerciseRecordsResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -58,14 +60,22 @@ public class ExerciseRecordController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/{recordId}/snapshot")
+    @PostMapping("/{recordId}/snapshots")
     public ResponseEntity<CreatedResponse> createSnapshot(@Login UserContext userContext, @PathVariable long recordId) {
         long createdId = exerciseRecordService.createSnapshot(userContext, recordId);
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(CreatedResponse.of(createdId));
     }
 
-    @DeleteMapping("/snapshot/{snapshotId}")
+    @GetMapping("/snapshots")
+    public ResponseEntity<RecordSnapshotsResponse> retrieveSnapshots(@Login UserContext userContext,
+        @RequestParam(required = false) Long lastId, @RequestParam int size) {
+        RecordSnapshotsResponse response = exerciseRecordService.retrieveSnapshots(userContext,
+            lastId, Pageable.ofSize(size));
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/snapshots/{snapshotId}")
     public ResponseEntity<CreatedResponse> deleteSnapshot(@Login UserContext userContext,
         @PathVariable long snapshotId) {
         exerciseRecordService.deleteSnapshot(userContext, snapshotId);

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -276,9 +276,24 @@ class ExerciseRecordServiceTest {
         validateAllTrackMachineNameIsSame(tracksInCopy, tracksInOriginal);
     }
 
+    @Test
+    @DisplayName("존재하지 않는 운동기록의 스냅샷은 생성할 수 없다.")
+    void createSnapshotFailExerciseRecordNotFound() throws Exception {
+        // given
+        Member member = saveMember("nick");
+        long notExistExerciseRecordId = 999_999_999L;
+
+        // when & then
+        assertThatThrownBy(
+            () -> exerciseRecordService.createSnapshot(UserContext.fromMember(member), notExistExerciseRecordId))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.RECORD_NOT_FOUND.getMessage());
+    }
+
     private void validateAllTrackMachineNameIsSame(List<Track> tracksInCopy, List<Track> tracksInOriginal) {
         Set<String> machineNamesInCopy = tracksInCopy.stream().map(Track::getMachineName).collect(Collectors.toSet());
-        Set<String> trackNamesInOriginal = tracksInOriginal.stream().map(Track::getMachineName).collect(Collectors.toSet());
+        Set<String> trackNamesInOriginal = tracksInOriginal.stream().map(Track::getMachineName)
+            .collect(Collectors.toSet());
         for (String trackNameInCopy : machineNamesInCopy) {
             assertThat(trackNamesInOriginal).contains(trackNameInCopy);
         }

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -290,6 +290,20 @@ class ExerciseRecordServiceTest {
     }
 
     @Test
+    @DisplayName("자신이 작성하지 않은 운동기록을 사용해서 스냅샷을 만들 수 없다.")
+    void createSnapshotFailExerciseRecordNoAuthZ() throws Exception {
+        // given
+        Member member = saveMember("nick");
+        ExerciseRecord original = saveExerciseRecord(member);
+
+        // when & then
+        assertThatThrownBy(
+            () -> exerciseRecordService.createSnapshot(loginUserContext, original.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.AUTHORIZED_FAIL.getMessage());
+    }
+
+    @Test
     @DisplayName("존재하지 않는 운동기록의 스냅샷은 생성할 수 없다.")
     void createSnapshotFailExerciseRecordNotFound() throws Exception {
         // given

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -277,6 +277,19 @@ class ExerciseRecordServiceTest {
     }
 
     @Test
+    @DisplayName("인증되지 않은 사용자는 운동기록 스냅샷을 만들 수 없다.")
+    void createSnapshotFailExerciseRecordNoAuthN() throws Exception {
+        // given
+        ExerciseRecord original = saveExerciseRecord(loginMember);
+
+        // when & then
+        assertThatThrownBy(
+            () -> exerciseRecordService.createSnapshot(noLoginUserContext, original.getId()))
+            .isInstanceOf(ApiException.class)
+            .hasMessageContaining(ErrorCode.AUTHENTICATED_FAIL.getMessage());
+    }
+
+    @Test
     @DisplayName("존재하지 않는 운동기록의 스냅샷은 생성할 수 없다.")
     void createSnapshotFailExerciseRecordNotFound() throws Exception {
         // given

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
@@ -32,10 +32,10 @@ class ExerciseRecordRepositoryTest {
     void findAllByMemberAndPeriodSuccessInRange() throws Exception {
         // given
         Member member = saveMember("회원");
-        saveExerciseRecord(member, LocalDate.of(2019, 12, 31));
-        ExerciseRecord record1 = saveExerciseRecord(member, LocalDate.of(2020, 1, 1));
-        ExerciseRecord record2 = saveExerciseRecord(member, LocalDate.of(2020, 1, 2));
-        saveExerciseRecord(member, LocalDate.of(2020, 1, 3));
+        saveExerciseRecord(member, LocalDate.of(2019, 12, 31), false);
+        ExerciseRecord record1 = saveExerciseRecord(member, LocalDate.of(2020, 1, 1), false);
+        ExerciseRecord record2 = saveExerciseRecord(member, LocalDate.of(2020, 1, 2), false);
+        saveExerciseRecord(member, LocalDate.of(2020, 1, 3), false);
 
         em.flush();
         em.clear();
@@ -52,6 +52,28 @@ class ExerciseRecordRepositoryTest {
     }
 
     @Test
+    @DisplayName("특정 기한 내에 등록된 운동기록 목록을 조회할 때, 스냅샷은 가져오지 않는다.")
+    void findAllByMemberAndPeriodNoSnapshot() throws Exception {
+        // given
+        Member member = saveMember("회원");
+        ExerciseRecord record = saveExerciseRecord(member, LocalDate.of(2020, 1, 1), false);
+        ExerciseRecord snapshot = saveExerciseRecord(member, LocalDate.of(2020, 1, 1), true);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<ExerciseRecord> results = exerciseRecordRepository.findAllByMemberAndPeriod(member,
+            LocalDate.of(2020, 1, 1),
+            LocalDate.of(2020, 1, 2));
+
+        // then
+        assertThat(results).hasSize(1)
+            .extracting(ExerciseRecord::getId)
+            .containsExactlyInAnyOrder(record.getId());
+    }
+
+    @Test
     @DisplayName("특정 기한 내에 등록된 운동기록들이 없으면 비어있는 리스트를 반환한다.")
     void findAllByMemberAndPeriodSuccessEmpty() throws Exception {
         // given
@@ -64,15 +86,16 @@ class ExerciseRecordRepositoryTest {
         // then
         assertThat(results).isEmpty();
     }
+
     @Test
     @DisplayName("일치하는 회원의 운동 기록만을 가져온다.")
     void findAllByMemberAndPeriodSuccessOnSameMember() throws Exception {
         // given
         Member member = saveMember("회원");
-        ExerciseRecord record = saveExerciseRecord(member, LocalDate.of(2019, 12, 31));
+        ExerciseRecord record = saveExerciseRecord(member, LocalDate.of(2019, 12, 31), false);
 
         Member another = saveMember("다른사람");
-        saveExerciseRecord(another, LocalDate.of(2019, 12, 31));
+        saveExerciseRecord(another, LocalDate.of(2019, 12, 31), false);
 
         em.flush();
         em.clear();
@@ -99,11 +122,12 @@ class ExerciseRecordRepositoryTest {
         return member;
     }
 
-    private ExerciseRecord saveExerciseRecord(Member member, LocalDate recordDate) {
+    private ExerciseRecord saveExerciseRecord(Member member, LocalDate recordDate, boolean isSnapshot) {
         ExerciseRecord exerciseRecord = ExerciseRecord.builder()
             .member(member)
             .tracks(List.of(Mockito.mock(Track.class)))
             .recordDate(recordDate)
+            .isSnapshot(isSnapshot)
             .build();
         em.persist(exerciseRecord);
         return exerciseRecord;

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
@@ -180,12 +180,12 @@ class ExerciseRecordRepositoryTest {
         ExerciseRecord snapshot2 = saveExerciseRecord(member, date, true);
         ExerciseRecord snapshot3 = saveExerciseRecord(member, date, true);
 
-        Slice<ExerciseRecord> result = exerciseRecordRepository.findNextSnapshotsByMember(
-            -1, Pageable.ofSize(2), member);
+        Slice<ExerciseRecord> result = exerciseRecordRepository.findPrevSnapshotsByMember(
+            null, Pageable.ofSize(2), member);
 
         assertThat(result.hasNext()).isTrue();
         assertThat(result.getContent()).hasSize(2)
-            .containsExactlyInAnyOrder(snapshot1, snapshot2);
+            .containsExactly(snapshot3, snapshot2);
     }
 
     @Test
@@ -195,12 +195,12 @@ class ExerciseRecordRepositoryTest {
         ExerciseRecord snapshot1 = saveExerciseRecord(member, date, true);
         ExerciseRecord snapshot2 = saveExerciseRecord(member, date, true);
 
-        Slice<ExerciseRecord> result = exerciseRecordRepository.findNextSnapshotsByMember(
-            -1, Pageable.ofSize(2), member);
+        Slice<ExerciseRecord> result = exerciseRecordRepository.findPrevSnapshotsByMember(
+            null, Pageable.ofSize(2), member);
 
         assertThat(result.hasNext()).isFalse();
         assertThat(result.getContent()).hasSize(2)
-            .containsExactlyInAnyOrder(snapshot1, snapshot2);
+            .containsExactly(snapshot2, snapshot1);
     }
 
     @Test
@@ -209,8 +209,8 @@ class ExerciseRecordRepositoryTest {
         Member member = saveMember("회원");
         ExerciseRecord snapshot1 = saveExerciseRecord(member, date, false);
 
-        Slice<ExerciseRecord> result = exerciseRecordRepository.findNextSnapshotsByMember(
-            -1, Pageable.ofSize(2), member);
+        Slice<ExerciseRecord> result = exerciseRecordRepository.findPrevSnapshotsByMember(
+            null, Pageable.ofSize(2), member);
 
         assertThat(result.hasNext()).isFalse();
         assertThat(result.getContent()).isEmpty();

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
@@ -10,6 +10,7 @@ import com.example.temp.member.domain.nickname.Nickname;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -99,6 +100,7 @@ class ExerciseRecordRepositoryTest {
 
         em.flush();
         em.clear();
+
         // when
         List<ExerciseRecord> results = exerciseRecordRepository.findAllByMemberAndPeriod(member,
             LocalDate.of(2019, 12, 31),
@@ -108,6 +110,34 @@ class ExerciseRecordRepositoryTest {
         assertThat(results).hasSize(1)
             .extracting(ExerciseRecord::getId)
             .containsExactlyInAnyOrder(record.getId());
+    }
+
+    @Test
+    @DisplayName("id를 사용해 snapshot 타입의 운동기록을 찾는다.")
+    void findSnapshotById() throws Exception {
+        // given
+        Member member = saveMember("회원");
+        ExerciseRecord snapshot = saveExerciseRecord(member, LocalDate.of(2019, 12, 31), true);
+
+        // when
+        Optional<ExerciseRecord> resultOpt = exerciseRecordRepository.findSnapshotById(snapshot.getId());
+
+        // then
+        assertThat(resultOpt).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("운동 기록이 snapshot 타입이 아니라면, findSnapshotById로 해당 엔티티를 가져올 수 없다.")
+    void findSnapshotByIdFailNoSnapshot() throws Exception {
+        // given
+        Member member = saveMember("회원");
+        ExerciseRecord exerciseRecord = saveExerciseRecord(member, LocalDate.of(2019, 12, 31), false);
+
+        // when
+        Optional<ExerciseRecord> resultOpt = exerciseRecordRepository.findSnapshotById(exerciseRecord.getId());
+
+        // then
+        assertThat(resultOpt).isEmpty();
     }
 
     private Member saveMember(String nickname) {

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
@@ -180,7 +180,7 @@ class ExerciseRecordRepositoryTest {
         ExerciseRecord snapshot2 = saveExerciseRecord(member, date, true);
         ExerciseRecord snapshot3 = saveExerciseRecord(member, date, true);
 
-        Slice<ExerciseRecord> result = exerciseRecordRepository.findPrevSnapshotsByMember(
+        Slice<ExerciseRecord> result = exerciseRecordRepository.findNextSnapshotsByMember(
             null, Pageable.ofSize(2), member);
 
         assertThat(result.hasNext()).isTrue();
@@ -195,7 +195,7 @@ class ExerciseRecordRepositoryTest {
         ExerciseRecord snapshot1 = saveExerciseRecord(member, date, true);
         ExerciseRecord snapshot2 = saveExerciseRecord(member, date, true);
 
-        Slice<ExerciseRecord> result = exerciseRecordRepository.findPrevSnapshotsByMember(
+        Slice<ExerciseRecord> result = exerciseRecordRepository.findNextSnapshotsByMember(
             null, Pageable.ofSize(2), member);
 
         assertThat(result.hasNext()).isFalse();
@@ -209,7 +209,7 @@ class ExerciseRecordRepositoryTest {
         Member member = saveMember("회원");
         ExerciseRecord snapshot1 = saveExerciseRecord(member, date, false);
 
-        Slice<ExerciseRecord> result = exerciseRecordRepository.findPrevSnapshotsByMember(
+        Slice<ExerciseRecord> result = exerciseRecordRepository.findNextSnapshotsByMember(
             null, Pageable.ofSize(2), member);
 
         assertThat(result.hasNext()).isFalse();

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordRepositoryTest.java
@@ -140,6 +140,35 @@ class ExerciseRecordRepositoryTest {
         assertThat(resultOpt).isEmpty();
     }
 
+    @Test
+    @DisplayName("id를 사용해 운동기록을 찾는다.")
+    void findById() throws Exception {
+        // given
+        Member member = saveMember("회원");
+        ExerciseRecord snapshot = saveExerciseRecord(member, LocalDate.of(2019, 12, 31), false);
+
+        // when
+        Optional<ExerciseRecord> resultOpt = exerciseRecordRepository.findById(snapshot.getId());
+
+        // then
+        assertThat(resultOpt).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("운동 기록이 snapshot이라면, findById로 해당 엔티티를 가져올 수 없다.")
+    void findByIdThatIsSnapshot() throws Exception {
+        // given
+        Member member = saveMember("회원");
+        ExerciseRecord snapshot = saveExerciseRecord(member, LocalDate.of(2019, 12, 31), true);
+
+        // when
+        Optional<ExerciseRecord> resultOpt = exerciseRecordRepository.findById(snapshot.getId());
+
+        // then
+        assertThat(resultOpt).isEmpty();
+    }
+
+
     private Member saveMember(String nickname) {
         Member member = Member.builder()
             .email(Email.create("이메일"))

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
@@ -11,7 +11,9 @@ import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.domain.nickname.Nickname;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -80,6 +82,27 @@ class ExerciseRecordTest {
         assertThat(record.isOwnedBy(another)).isFalse();
     }
 
+    @Test
+    @DisplayName("운동기록의 스냅샷을 만든다.")
+    void createSnapshot() throws Exception {
+        // given
+        Member member = createMember("nick1");
+        Track track = createTrack("머신1");
+        ExerciseRecord original = ExerciseRecord.create(member, List.of(track));
+        assertThat(original.isSnapshot()).isFalse();
+
+        // when
+        ExerciseRecord snapshot = original.createSnapshot(member);
+
+        // then
+        assertThat(snapshot.isSnapshot()).isTrue();
+        assertThat(snapshot.getRecordDate()).isEqualTo(original.getRecordDate());
+
+        assertThat(snapshot.getTracks()).hasSize(1)
+            .extracting(Track::getMachineName)
+            .containsExactlyInAnyOrder("머신1");
+    }
+
     private Track createTrack(String machineName) {
         return Track.builder()
             .machineName(machineName)
@@ -94,7 +117,6 @@ class ExerciseRecordTest {
             .repeatCnt(5)
             .build();
     }
-
 
     private ExerciseRecord createExerciseRecord(Member member) {
         return ExerciseRecord.builder()

--- a/src/test/java/com/example/temp/record/domain/SetInTrackTest.java
+++ b/src/test/java/com/example/temp/record/domain/SetInTrackTest.java
@@ -69,6 +69,24 @@ class SetInTrackTest {
             .hasMessageContaining(ErrorCode.SET_REPEAT_CNT_INVALID.getMessage());
     }
 
+    @Test
+    @DisplayName("세트를 복사한다.")
+    void copy() throws Exception {
+        // given
+        int order = 1;
+        int weight = 1;
+        int repeatCnt = 1;
+        SetInTrack original = createSet(order, weight, repeatCnt);
+
+        // when
+        SetInTrack copy = original.copy();
+
+        // then
+        assertThat(copy.getOrder()).isEqualTo(original.getOrder());
+        assertThat(copy.getWeight()).isEqualTo(original.getWeight());
+        assertThat(copy.getRepeatCnt()).isEqualTo(original.getRepeatCnt());
+    }
+
     private SetInTrack createSet(int order, int weight, int repeatCnt) {
         return SetInTrack.builder()
             .order(order)

--- a/src/test/java/com/example/temp/record/domain/TrackTest.java
+++ b/src/test/java/com/example/temp/record/domain/TrackTest.java
@@ -8,6 +8,7 @@ import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.machine.domain.BodyPart;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,37 @@ class TrackTest {
         assertThatThrownBy(() -> Track.createWithoutRecord(machineName, BodyPart.HIP, setInTracks))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("트랙 내 세트들의 순서는 1부터 순차적으로 올라가야 합니다.");
+    }
+
+    @Test
+    @DisplayName("트랙을 복사한다.")
+    void copy() throws Exception {
+        // given
+        String machineName = "스쿼트 머신";
+        List<SetInTrack> setInTracks = List.of(createSet(1));
+        Track original = Track.createWithoutRecord(machineName, BodyPart.HIP, setInTracks);
+
+        // when
+        Track copy = original.copy();
+
+        // then
+        assertThat(copy.getMachineName()).isEqualTo(original.getMachineName());
+        assertThat(copy.getMajorBodyPart()).isEqualTo(original.getMajorBodyPart());
+
+        Comparator<SetInTrack> comparator = Comparator
+            .comparing(SetInTrack::getWeight)
+            .thenComparing(SetInTrack::getRepeatCnt)
+            .thenComparing(SetInTrack::getOrder);
+        copy.getSetsInTrack().sort(comparator);
+        original.getSetsInTrack().sort(comparator);
+
+        for (int i = 0; i < copy.getSetsInTrack().size(); i++) {
+            SetInTrack setInTrackAboutCopy = copy.getSetsInTrack().get(i);
+            SetInTrack setInTrackAboutOriginal = original.getSetsInTrack().get(i);
+            assertThat(setInTrackAboutCopy.getRepeatCnt()).isEqualTo(setInTrackAboutOriginal.getRepeatCnt());
+            assertThat(setInTrackAboutCopy.getWeight()).isEqualTo(setInTrackAboutOriginal.getWeight());
+            assertThat(setInTrackAboutCopy.getOrder()).isEqualTo(setInTrackAboutOriginal.getOrder());
+        }
     }
 
     SetInTrack createSet(int order) {


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 운동 기록 스냅샷 만들기
- [x] 무한 스크롤 조회
- [x] 스냅샷 삭제

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
스냅샷을 어떻게 구현할까... 고민을 좀 했는데요.

ExerciseRecord와 해당 스냅샷을 동일한 테이블에서 관리하는 전략을 채택했습니다.
```java
public class ExerciseRecord extends BaseTimeEntity {
    ... 생략 ...

    private boolean isSnapshot;
```
ExerciseRecord 엔티티에 연관된 엔티티(테이블)가 많다는 점에서 관리하기 가장 수월할 거라고 생각했어요.
만약 스냅샷을 별도의 테이블로 관리한다면...
ExerciseRecord, Track, SetInTrack 중 하나의 테이블을 변경할 때, @@@Snapshot 엔티티를 함께 바꿔야 한다는 점에서 관리가 불편할 거라 생각했습니다.
또한 별도의 테이블을 만드는 거 자체가 리소스라고 판단하였습니다.

가장 간단한 방법은 ExerciseRecord 테이블에 isSnapshot필드를 만들어두는 방식이라 생각해서 해당 방식으로 구현했습니다.



close #135 