### PR TITLE
[#170] 해시태그 검색 결과 리팩터링

### DIFF
--- a/src/main/java/com/example/temp/post/domain/PostRepository.java
+++ b/src/main/java/com/example/temp/post/domain/PostRepository.java
@@ -19,11 +19,16 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p "
         + "FROM Post p "
+        + "WHERE p.member.privacyPolicy = 'PUBLIC' "
+        + "ORDER BY p.registeredAt DESC")
+    Page<Post> findAllPost(Pageable pageable);
+
+    @Query("SELECT p "
+        + "FROM Post p "
         + "JOIN p.postHashtags ph "
         + "JOIN ph.hashtag h "
-        + "WHERE h.id = :hashtagId "
+        + "WHERE h.name = :hashtag "
         + "AND p.member.privacyPolicy = 'PUBLIC' "
         + "ORDER BY p.registeredAt DESC")
-    Page<Post> findAllPostByHashtag(@Param("hashtagId") Long hashtagId, Pageable pageable);
-
+    Page<Post> findAllPostByHashtag(@Param("hashtag") String hashtag, Pageable pageable);
 }

--- a/src/main/java/com/example/temp/post/presentation/PostController.java
+++ b/src/main/java/com/example/temp/post/presentation/PostController.java
@@ -69,7 +69,7 @@ public class PostController {
 
     @GetMapping("/search")
     public ResponseEntity<PostSearchResponse> getPostsByHashtag(
-        @RequestParam String hashtag,
+        @RequestParam(required = false) String hashtag,
         @Login UserContext userContext,
         @PageableDefault(sort = "registeredAt", direction = DESC) Pageable pageable) {
         PostSearchResponse posts = postService.findPostsByHashtag(hashtag, userContext, pageable);

--- a/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
@@ -227,6 +227,26 @@ class PostRepositoryTest {
         assertThat(posts.getTotalElements()).isZero();
     }
 
+    @DisplayName("공개 계정의 글을 전부 조회할 수 있다.")
+    @Test
+    void findAllPostByPublic() {
+        Member member1 = saveMember("email1@naver.com", "작성자1");
+        Member member2 = saveMember("email2@naver.com", "작성자2");
+        member2.changePrivacy(PrivacyPolicy.PRIVATE);
+        saveImage("이미지1");
+        saveImage("이미지2");
+        saveImage("이미지3");
+        savePost(member1, "게시글1", List.of("이미지1"), List.of());
+        savePost(member1, "게시글2", List.of("이미지2"), List.of());
+        savePost(member2, "게시글3", List.of("이미지3"), List.of());
+
+        //when
+        Page<Post> posts = postRepository.findAllPost(PageRequest.of(0, 5));
+
+        //then
+        assertThat(posts.getTotalElements()).isEqualTo(2);
+    }
+
     @DisplayName("게시글은 등록일자 내림차순으로 정렬된다.")
     @Test
     void postsAreOrderedByRegisteredAtDesc() {

--- a/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
@@ -185,7 +185,7 @@ class PostRepositoryTest {
         savePost(member, "게시글3", List.of("이미지1", "이미지2", "이미지3"), List.of("#해시태그1", "#해시태그4"));
 
         //when
-        Page<Post> posts = postRepository.findAllPostByHashtag(hashtag.getId(), PageRequest.of(0, 5));
+        Page<Post> posts = postRepository.findAllPostByHashtag(hashtag.getName(), PageRequest.of(0, 5));
         List<Post> postContents = posts.getContent();
 
         //then
@@ -206,7 +206,7 @@ class PostRepositoryTest {
         savePost(privateMember, "비공개계정 게시글", List.of("이미지1"), List.of("#privateHashtag"));
 
         //when
-        Page<Post> posts = postRepository.findAllPostByHashtag(hashtag.getId(), PageRequest.of(0, 5));
+        Page<Post> posts = postRepository.findAllPostByHashtag(hashtag.getName(), PageRequest.of(0, 5));
 
         //then
         assertThat(posts.getTotalElements()).isZero();
@@ -221,7 +221,7 @@ class PostRepositoryTest {
         savePost(member, "게시글4", List.of("이미지4"), List.of());
 
         //when
-        Page<Post> posts = postRepository.findAllPostByHashtag(999L, PageRequest.of(0, 5)); // 존재하지 않는 해시태그 ID
+        Page<Post> posts = postRepository.findAllPostByHashtag("#해시태그2", PageRequest.of(0, 5));
 
         //then
         assertThat(posts.getTotalElements()).isZero();
@@ -241,7 +241,7 @@ class PostRepositoryTest {
         savePost(member, "게시글7", List.of("이미지7"), List.of("#hashtag5"));
 
         //when
-        Page<Post> posts = postRepository.findAllPostByHashtag(hashtag.getId(), PageRequest.of(0, 5));
+        Page<Post> posts = postRepository.findAllPostByHashtag(hashtag.getName(), PageRequest.of(0, 5));
         List<Post> postContents = posts.getContent();
 
         //then


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] 해시태그 id 검색에서 name으로 검색
- [X] 존재하지 않는 해시태그 검색 시 404에서 검색결과 없음을 반환하도록 수정

## 🏌🏻 리뷰 포인트
오전 회의 때 말씀 드린 것 처럼 동적쿼리 처리를 하기 위해 querydsl을 도입하려고 했습니다. 
장기적으로 봤을 때 querydsl을 도입하는게 맞지만 현재 비즈니스 로직만 풀어가는데는 쿼리문을 한줄 더 작성하는게 훨씬 적은 리소스를 소모해서 해결할 수 있다고 판단했습니다.

또한 추가적으로 db에 hashtag가 있는지 검증 후 존재하지 않는 해시태그면 404 NotFound를 던지도록 설계했지만 프론트 측 요구사항에 맞춰 결과를 반환하려면 문자로 검색을 하고 해당 결과를 반환해주는 게 맞는 방식이라고 판단하여 리팩토링 했습니다.



## 🧘🏻 기타 사항

close #170 