### PR TITLE
[#172] 회원 삭제 시 연관된 게시물, 댓글이 삭제되지 않는 이슈

### DIFF
--- a/src/main/java/com/example/temp/comment/application/CommentService.java
+++ b/src/main/java/com/example/temp/comment/application/CommentService.java
@@ -14,10 +14,13 @@ import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.MemberRepository;
+import com.example.temp.member.event.MemberDeletedEvent;
 import com.example.temp.post.domain.Post;
 import com.example.temp.post.domain.PostRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -70,6 +73,16 @@ public class CommentService {
         validateOwner(userContext, comment);
         commentRepository.delete(comment);
         post.decreaseCommentCount();
+    }
+
+
+    /**
+     * 회원이 삭제되었을 때, 해당 회원이 달았던 모든 댓글을 삭제합니다.
+     */
+    @EventListener
+    public void handleMemberDeletedEvent(MemberDeletedEvent event) {
+        List<Comment> comments = commentRepository.findAllByMemberId(event.getMemberId());
+        commentRepository.deleteAllInBatch(comments);
     }
 
     private Member findMemberBy(Long userContextId) {

--- a/src/main/java/com/example/temp/comment/domain/CommentRepository.java
+++ b/src/main/java/com/example/temp/comment/domain/CommentRepository.java
@@ -25,4 +25,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("DELETE FROM Comment c WHERE c.post IN :posts")
     void deleteAllInBatchByPosts(@Param("posts") List<Post> posts);
 
+    List<Comment> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/temp/comment/domain/CommentRepository.java
+++ b/src/main/java/com/example/temp/comment/domain/CommentRepository.java
@@ -1,8 +1,11 @@
 package com.example.temp.comment.domain;
 
+import com.example.temp.post.domain.Post;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -17,4 +20,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         + "WHERE c.post.id = :postId "
         + "ORDER BY c.registeredAt DESC")
     Slice<Comment> findAllByPostId(@Param("postId") Long postId, Pageable pageable);
+
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.post IN :posts")
+    void deleteAllInBatchByPosts(@Param("posts") List<Post> posts);
+
 }

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -5,6 +5,7 @@ import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
 import static com.example.temp.common.exception.ErrorCode.POST_NOT_FOUND;
 import static com.example.temp.common.exception.ErrorCode.UNAUTHORIZED_POST;
 
+import com.example.temp.comment.domain.CommentRepository;
 import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.follow.domain.Follow;
@@ -55,6 +56,7 @@ public class PostService {
     private final PostHashtagRepository postHashtagRepository;
     private final HashtagRepository hashtagRepository;
     private final HashtagService hashtagService;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public Long createPost(UserContext userContext, PostCreateRequest postCreateRequest,
@@ -187,10 +189,10 @@ public class PostService {
     /**
      * 회원이 삭제되었을 때, 해당 회원이 작성한 게시글을 삭제합니다.
      */
-    @Transactional
     @EventListener
     public void handleMemberDeletedEvent(MemberDeletedEvent event) {
         List<Post> posts = postRepository.findAllByMemberId(event.getMemberId());
+        commentRepository.deleteAllInBatchByPosts(posts);
         postHashtagRepository.deleteAllInBatchByPostIn(posts);
         postImageRepository.deleteAllInBatchByPostIn(posts);
         postRepository.deleteAllInBatch(posts);


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 회원이 삭제되었을 때, 해당 회원이 작성한 게시물과 댓글 전체 삭제

**게시물 삭제 시 해당 게시물에 달려있는 댓글을 삭제하지 않았다**
기존 로직에서는 1번 회원에 대한 삭제 이벤트가 발생했을 때, 1번 회원이 작성한 모든 게시물을 삭제하도록 구현해뒀습니다.
하지만 해당 게시물이 삭제되는 과정에서 댓글을 삭제해주지 않았습니다.
따라서 데이터 정합성에 문제가 발생해 서버에서 500번대 에러를 반환했습니다.

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
추가로 회원 삭제 이벤트 발생 시, 해당 회원이 작성한 댓글이 삭제되고 있지 않아 해당 작업을 함께 진행했습니다.

close #172 