### PR TITLE
[#174] "대기 상태인 팔로우 요청" 무한스크롤 조회

### DIFF
--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -77,6 +77,12 @@ public class FollowService {
         return FollowInfoResult.createFollowersResult(follows);
     }
 
+    public FollowInfoResult getPendingStatusFollows(UserContext userContext, Long lastId, Pageable pageable) {
+        Slice<Follow> follows = followRepository.findAllByToIdAndStatus(userContext.id(),
+            FollowStatus.PENDING, lastId, pageable);
+        return FollowInfoResult.createFollowersResult(follows);
+    }
+
     private void validateViewAuthorization(long targetId, long executorId) {
         if (isMyAccount(targetId, executorId)) {
             return;

--- a/src/main/java/com/example/temp/follow/application/FollowService.java
+++ b/src/main/java/com/example/temp/follow/application/FollowService.java
@@ -44,7 +44,7 @@ public class FollowService {
      * @return FollowInfo 객체 리스트를 반환합니다. 각 FollowInfo 객체는 팔로잉 대상의 정보와 팔로우 ID를 포함하고 있습니다.
      * @throws ApiException AUTHORIZED_FAIL: 팔로잉 목록을 볼 권한이 없을 때 발생합니다.
      */
-    public FollowInfoResult getFollowings(UserContext userContext, Long targetId, long lastId, Pageable pageable) {
+    public FollowInfoResult getFollowings(UserContext userContext, Long targetId, Long lastId, Pageable pageable) {
         Member target = memberRepository.findById(targetId)
             .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
         if (!target.isPublicAccount()) {
@@ -66,7 +66,7 @@ public class FollowService {
      * @return FollowInfo 객체 리스트를 반환합니다. 각 FollowInfo 객체는 팔로워 대상의 정보와 팔로우 ID를 포함하고 있습니다.
      * @throws ApiException AUTHORIZED_FAIL: 팔로워 목록을 볼 권한이 없을 때 발생합니다.
      */
-    public FollowInfoResult getFollowers(UserContext userContext, long targetId, long lastId, Pageable pageable) {
+    public FollowInfoResult getFollowers(UserContext userContext, long targetId, Long lastId, Pageable pageable) {
         Member target = memberRepository.findById(targetId)
             .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
         if (!target.isPublicAccount()) {

--- a/src/main/java/com/example/temp/follow/domain/FollowRepository.java
+++ b/src/main/java/com/example/temp/follow/domain/FollowRepository.java
@@ -30,11 +30,11 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
         + "JOIN FETCH f.to "
         + "WHERE f.from.id = :fromId "
         + "AND f.status = :status "
-        + "AND f.id > :lastId "
+        + "AND (:lastId IS NULL OR f.id > :lastId) "
         + "ORDER BY f.id ASC")
     Slice<Follow> findAllByFromIdAndStatus(@Param("fromId") long fromId,
         @Param("status") FollowStatus status,
-        @Param("lastId") long lastId,
+        @Param("lastId") Long lastId,
         Pageable pageable);
 
     @Query("SELECT f FROM Follow f JOIN FETCH f.from WHERE f.to.id = :toId AND f.status = :status")
@@ -53,11 +53,11 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
         + "JOIN FETCH f.to "
         + "WHERE f.to.id = :toId "
         + "AND f.status = :status "
-        + "AND f.id > :lastId "
+        + "AND (:lastId IS NULL OR f.id > :lastId) "
         + "ORDER BY f.id ASC")
     Slice<Follow> findAllByToIdAndStatus(@Param("toId") long toId,
         @Param("status") FollowStatus status,
-        @Param("lastId") long lastId,
+        @Param("lastId") Long lastId,
         Pageable pageable);
 
 

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -35,6 +35,13 @@ public class FollowController {
         return ResponseEntity.ok(result);
     }
 
+    @GetMapping("/follows/pending")
+    public ResponseEntity<FollowInfoResult> getPendingStatusFollows(@Login UserContext userContext,
+        @RequestParam(required = false) Long lastId, @RequestParam int size) {
+        FollowInfoResult result = followService.getPendingStatusFollows(userContext, lastId, PageRequest.ofSize(size));
+        return ResponseEntity.ok(result);
+    }
+
     @PostMapping("/members/{memberId}/follow")
     public ResponseEntity<FollowResponse> follow(@Login UserContext userContext, @PathVariable Long memberId) {
         FollowResponse response = followService.follow(userContext, memberId);

--- a/src/main/java/com/example/temp/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/temp/follow/presentation/FollowController.java
@@ -23,14 +23,14 @@ public class FollowController {
 
     @GetMapping("/members/{memberId}/followings")
     public ResponseEntity<FollowInfoResult> getFollowings(@Login UserContext userContext, @PathVariable Long memberId,
-        @RequestParam(defaultValue = "-1") Long lastId, @RequestParam int size) {
+        @RequestParam(required = false) Long lastId, @RequestParam int size) {
         FollowInfoResult result = followService.getFollowings(userContext, memberId, lastId, PageRequest.ofSize(size));
         return ResponseEntity.ok(result);
     }
 
     @GetMapping("/members/{memberId}/followers")
     public ResponseEntity<FollowInfoResult> getFollowers(@Login UserContext userContext, @PathVariable Long memberId,
-        @RequestParam(defaultValue = "-1") Long lastId, @RequestParam int size) {
+        @RequestParam(required = false) Long lastId, @RequestParam int size) {
         FollowInfoResult result = followService.getFollowers(userContext, memberId, lastId, PageRequest.ofSize(size));
         return ResponseEntity.ok(result);
     }

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -597,6 +597,25 @@ class FollowServiceTest {
             .containsExactly(follow1.getId());
     }
 
+    @Test
+    @DisplayName("PENDING 상태의 팔로우 요청들을 조회했을 때, 마지막 데이터가 포함되지 않았다면 hasNext에 true를 반환한다.")
+    void getPendingStatusFollowsThatHasNextTrue() throws Exception {
+        // given
+        Member member = saveMember();
+        Member another1 = saveMember();
+        Member another2 = saveMember();
+        UserContext userContext = UserContext.fromMember(member);
+
+        saveFollow(another1, member, FollowStatus.PENDING);
+        saveFollow(another2, member, FollowStatus.PENDING);
+
+        // when
+        FollowInfoResult result = followService.getPendingStatusFollows(userContext, null, PageRequest.ofSize(1));
+
+        // then
+        assertThat(result.hasNext()).isTrue();
+    }
+
     private List<Follow> saveTargetFollowings(FollowStatus followStatus, Member target, List<Member> members, int start,
         int repeatCnt) {
         List<Follow> follows = new ArrayList<>();

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -575,6 +575,28 @@ class FollowServiceTest {
             .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }
 
+    @Test
+    @DisplayName("PENDING 상태의 팔로우 요청들을 조회한다. 이 때, lastId에 값이 없다면 가장 최신 팔로우 요청들을 반환한다.")
+    void getPendingStatusFollows() throws Exception {
+        // given
+        Member member = saveMember();
+        Member another1 = saveMember();
+        Member another2 = saveMember();
+        UserContext userContext = UserContext.fromMember(member);
+
+        Follow follow1 = saveFollow(another1, member, FollowStatus.PENDING);
+        saveFollow(another2, member, FollowStatus.APPROVED);
+
+        // when
+        FollowInfoResult result = followService.getPendingStatusFollows(userContext, null, pageable);
+
+        // then
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.follows()).hasSize(1)
+            .extracting("id")
+            .containsExactly(follow1.getId());
+    }
+
     private List<Follow> saveTargetFollowings(FollowStatus followStatus, Member target, List<Member> members, int start,
         int repeatCnt) {
         List<Follow> follows = new ArrayList<>();

--- a/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
+++ b/src/test/java/com/example/temp/follow/application/FollowServiceTest.java
@@ -247,7 +247,8 @@ class FollowServiceTest {
         Member anotherMember = saveMember();
 
         // when & then
-        assertThatThrownBy(() -> followService.acceptFollowRequest(UserContext.fromMember(anotherMember), follow.getId()))
+        assertThatThrownBy(
+            () -> followService.acceptFollowRequest(UserContext.fromMember(anotherMember), follow.getId()))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }
@@ -293,7 +294,8 @@ class FollowServiceTest {
         Member anotherMember = saveMember();
 
         // when & then
-        assertThatThrownBy(() -> followService.rejectFollowRequest(UserContext.fromMember(anotherMember), follow.getId()))
+        assertThatThrownBy(
+            () -> followService.rejectFollowRequest(UserContext.fromMember(anotherMember), follow.getId()))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }
@@ -312,7 +314,8 @@ class FollowServiceTest {
             .toList();
 
         // when
-        FollowInfoResult result = followService.getFollowings(UserContext.fromMember(target), target.getId(), -1, pageable);
+        FollowInfoResult result = followService.getFollowings(UserContext.fromMember(target), target.getId(), null,
+            pageable);
 
         // then
         List<FollowInfo> infos = result.follows();
@@ -343,7 +346,8 @@ class FollowServiceTest {
         saveTargetFollowings(FollowStatus.APPROVED, target, members, idx, approvedCnt);
 
         // when
-        FollowInfoResult result = followService.getFollowings(UserContext.fromMember(target), target.getId(), -1, pageable);
+        FollowInfoResult result = followService.getFollowings(UserContext.fromMember(target), target.getId(), null,
+            pageable);
 
         // then
         assertThat(result.follows()).hasSize(approvedCnt);
@@ -360,7 +364,7 @@ class FollowServiceTest {
 
         // when & then
         assertDoesNotThrow(
-            () -> followService.getFollowings(UserContext.fromMember(anotherMember), publicAccountMember.getId(), -1,
+            () -> followService.getFollowings(UserContext.fromMember(anotherMember), publicAccountMember.getId(), null,
                 pageable));
     }
 
@@ -372,7 +376,8 @@ class FollowServiceTest {
         Member member = saveMember();
 
         // when
-        FollowInfoResult result = followService.getFollowings(UserContext.fromMember(member), member.getId(), -1, pageable);
+        FollowInfoResult result = followService.getFollowings(UserContext.fromMember(member), member.getId(), null,
+            pageable);
 
         // then
         assertThat(result.hasNext()).isFalse();
@@ -390,7 +395,8 @@ class FollowServiceTest {
         saveFollow(member, other2, FollowStatus.APPROVED);
 
         // when
-        FollowInfoResult result = followService.getFollowings(UserContext.fromMember(member), member.getId(), -1, pageable);
+        FollowInfoResult result = followService.getFollowings(UserContext.fromMember(member), member.getId(), null,
+            pageable);
 
         // then
         assertThat(result.hasNext()).isTrue();
@@ -408,7 +414,8 @@ class FollowServiceTest {
 
         // when & then
         assertDoesNotThrow(
-            () -> followService.getFollowings(UserContext.fromMember(anotherMember), privateMember.getId(), -1, pageable));
+            () -> followService.getFollowings(UserContext.fromMember(anotherMember), privateMember.getId(), null,
+                pageable));
     }
 
     @Test
@@ -423,7 +430,8 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(
-            () -> followService.getFollowings(UserContext.fromMember(anotherMember), privateMember.getId(), -1, pageable))
+            () -> followService.getFollowings(UserContext.fromMember(anotherMember), privateMember.getId(), null,
+                pageable))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }
@@ -445,14 +453,14 @@ class FollowServiceTest {
         em.clear();
 
         // when
-        FollowInfoResult result = followService.getFollowers(UserContext.fromMember(target), target.getId(), -1, pageable);
+        FollowInfoResult result = followService.getFollowers(UserContext.fromMember(target), target.getId(), null,
+            pageable);
 
         // then
         List<FollowInfo> infos = result.follows();
         assertThat(infos).hasSize(approvedCnt)
             .containsAnyElementsOf(targetFollowInfos);
         assertThat(infos.get(0).memberId()).isNotEqualTo(target.getId());
-
     }
 
     @Test
@@ -477,7 +485,8 @@ class FollowServiceTest {
         saveTargetFollowers(FollowStatus.APPROVED, target, members, idx, approvedCnt);
 
         // when
-        FollowInfoResult result = followService.getFollowers(UserContext.fromMember(target), target.getId(), -1, pageable);
+        FollowInfoResult result = followService.getFollowers(UserContext.fromMember(target), target.getId(), null,
+            pageable);
 
         // then
         assertThat(result.follows()).hasSize(approvedCnt);
@@ -494,7 +503,7 @@ class FollowServiceTest {
 
         // when & then
         assertDoesNotThrow(
-            () -> followService.getFollowers(UserContext.fromMember(anotherMember), publicAccountMember.getId(), -1,
+            () -> followService.getFollowers(UserContext.fromMember(anotherMember), publicAccountMember.getId(), null,
                 pageable));
     }
 
@@ -509,8 +518,9 @@ class FollowServiceTest {
         saveFollow(anotherMember, privateMember, FollowStatus.APPROVED);
 
         // when & then
-        assertDoesNotThrow(() -> followService.getFollowers(UserContext.fromMember(anotherMember), privateMember.getId(), -1,
-            pageable));
+        assertDoesNotThrow(
+            () -> followService.getFollowers(UserContext.fromMember(anotherMember), privateMember.getId(), null,
+                pageable));
     }
 
     @Test
@@ -521,7 +531,8 @@ class FollowServiceTest {
         Member member = saveMember();
 
         // when
-        FollowInfoResult result = followService.getFollowers(UserContext.fromMember(member), member.getId(), -1, pageable);
+        FollowInfoResult result = followService.getFollowers(UserContext.fromMember(member), member.getId(), null,
+            pageable);
 
         // then
         assertThat(result.hasNext()).isFalse();
@@ -539,7 +550,8 @@ class FollowServiceTest {
         saveFollow(other2, member, FollowStatus.APPROVED);
 
         // when
-        FollowInfoResult result = followService.getFollowers(UserContext.fromMember(member), member.getId(), -1, pageable);
+        FollowInfoResult result = followService.getFollowers(UserContext.fromMember(member), member.getId(), null,
+            pageable);
 
         // then
         assertThat(result.hasNext()).isTrue();
@@ -556,8 +568,9 @@ class FollowServiceTest {
         saveFollow(privateMember, anotherMember, FollowStatus.PENDING);
 
         // when & then
-        assertThatThrownBy(() -> followService.getFollowers(UserContext.fromMember(anotherMember), privateMember.getId(),
-            -1, pageable))
+        assertThatThrownBy(
+            () -> followService.getFollowers(UserContext.fromMember(anotherMember), privateMember.getId(),
+                null, pageable))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(AUTHORIZED_FAIL.getMessage());
     }

--- a/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/example/temp/follow/domain/FollowRepositoryTest.java
@@ -154,7 +154,7 @@ class FollowRepositoryTest {
         em.clear();
         // when
         Slice<Follow> result = followRepository.findAllByFromIdAndStatus(
-            fromMember.getId(), targetStatus, -1, pageable);
+            fromMember.getId(), targetStatus, null, pageable);
 
         // then
         assertThat(result).hasSize((int) pageable.getPageSize())
@@ -181,7 +181,7 @@ class FollowRepositoryTest {
 
         // when
         Slice<Follow> result = followRepository.findAllByFromIdAndStatus(target.getId(), targetStatus,
-            -1, pageable);
+            null, pageable);
 
         // then
         assertThat(result).isEmpty();
@@ -224,7 +224,7 @@ class FollowRepositoryTest {
 
         // when
         Slice<Follow> result = followRepository.findAllByToIdAndStatus(
-            toMember.getId(), targetStatus, -1, pageable);
+            toMember.getId(), targetStatus, null, pageable);
 
         // then
         assertThat(result).hasSize((int) pageable.getPageSize())
@@ -252,7 +252,7 @@ class FollowRepositoryTest {
 
         // when
         Slice<Follow> result = followRepository.findAllByToIdAndStatus(
-            target.getId(), targetStatus, -1, pageable);
+            target.getId(), targetStatus, null, pageable);
 
         // then
         assertThat(result).isEmpty();


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 팔로우 목록 조회 기능 구현

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
내부 로직은 "팔로워 목록 가져오는 메서드"와 동일합니다.
팔로워 목록 가져오는 메서드가 APPROVED 상태의 팔로우를 가져왔다면, 해당 메서드는 PENDING 상태의 팔로우를 가져옵니다.

Follow 엔티티의 필드 명칭을 from & target 으로 변경하는 게 가장 가독성이 좋겠다 생각이 드네요.
(지금은 from & to 를 사용중, 서비스 로직에서는 followers, following를 쓰는중)

---
저는 presentation 계층에 대해 SonarCloud가 테스트 커버리지 검사를 안하고 있다 생각했어요.
그런데 엥? 이제서야 알았는데 검사를 하고 있더라구요.
Jacoco에서만 특정 파일의 경로를 제거하면 될거라 생각했는데 그게 아니었네요.

우선 SonarCloud에서 추가적인 설정을 해서 해당 경로를 제거하기는 했는데요.
명확한 동작 원리를 파악해봐야겠어요. 저는 Jacoco에게 모든 테스트 커버리지를 위임한다고 생각했는데 그게 아니었네요.

close #174 