### PR TITLE
[#176] 500 서버 에러 발생 시 알림 보내주기 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,3 +93,7 @@ sonar {
         property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
     }
 }
+
+test {
+    environment 'spring.profiles.active', 'test'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     // WebClient 관련 의존성
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // MockWebServer 종속성 추가
+    testImplementation 'com.squareup.okhttp3:okhttp:5.0.0-alpha.12'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:5.0.0-alpha.12'
+
     // jwt 관련 의존성
     // https://github.com/jwtk/jjwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'

--- a/src/main/java/com/example/temp/common/config/DiscordConfig.java
+++ b/src/main/java/com/example/temp/common/config/DiscordConfig.java
@@ -4,20 +4,33 @@ import com.example.temp.common.infrastructure.exceptionsender.DiscordExceptionSe
 import com.example.temp.common.infrastructure.exceptionsender.ExceptionSender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @Profile("!test")
 @RequiredArgsConstructor
-public class WebhookConfig {
+public class DiscordConfig {
 
     private final ObjectMapper objectMapper;
 
+
+    @Value("${webhookUrl}")
+    private String webhookUrl;
+
+    @Bean
+    public WebClient discordWebClient() {
+        return WebClient.builder()
+            .baseUrl(webhookUrl)
+            .build();
+    }
+
     @Bean
     ExceptionSender discordExceptionSender() {
-        return new DiscordExceptionSender(objectMapper);
+        return new DiscordExceptionSender(objectMapper, discordWebClient());
     }
 
 }

--- a/src/main/java/com/example/temp/common/config/WebhookConfig.java
+++ b/src/main/java/com/example/temp/common/config/WebhookConfig.java
@@ -2,17 +2,22 @@ package com.example.temp.common.config;
 
 import com.example.temp.common.infrastructure.exceptionsender.DiscordExceptionSender;
 import com.example.temp.common.infrastructure.exceptionsender.ExceptionSender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
 @Profile("!test")
+@RequiredArgsConstructor
 public class WebhookConfig {
+
+    private final ObjectMapper objectMapper;
 
     @Bean
     ExceptionSender discordExceptionSender() {
-        return new DiscordExceptionSender();
+        return new DiscordExceptionSender(objectMapper);
     }
 
 }

--- a/src/main/java/com/example/temp/common/config/WebhookConfig.java
+++ b/src/main/java/com/example/temp/common/config/WebhookConfig.java
@@ -1,0 +1,18 @@
+package com.example.temp.common.config;
+
+import com.example.temp.common.infrastructure.exceptionsender.DiscordExceptionSender;
+import com.example.temp.common.infrastructure.exceptionsender.ExceptionSender;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("!test")
+public class WebhookConfig {
+
+    @Bean
+    ExceptionSender discordExceptionSender() {
+        return new DiscordExceptionSender();
+    }
+
+}

--- a/src/main/java/com/example/temp/common/exception/ExceptionInfo.java
+++ b/src/main/java/com/example/temp/common/exception/ExceptionInfo.java
@@ -1,0 +1,31 @@
+package com.example.temp.common.exception;
+
+import com.example.temp.common.dto.UserContext;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ExceptionInfo {
+
+    private String clazz;
+    private String message;
+    private String endpoint;
+    private Optional<UserContext> userContextOpt;
+
+    @Builder
+    private ExceptionInfo(String clazz, String message, String requestUri, String method,
+        Optional<UserContext> userContextOpt) {
+        Objects.requireNonNull(clazz);
+        Objects.requireNonNull(message);
+        Objects.requireNonNull(requestUri);
+        Objects.requireNonNull(method);
+
+        this.clazz = clazz;
+        this.message = message;
+        this.endpoint = String.format("%s %s", method, requestUri);
+        this.userContextOpt = userContextOpt;
+    }
+
+}

--- a/src/main/java/com/example/temp/common/exception/ExceptionSenderNotWorkingException.java
+++ b/src/main/java/com/example/temp/common/exception/ExceptionSenderNotWorkingException.java
@@ -1,0 +1,9 @@
+package com.example.temp.common.exception;
+
+public class ExceptionSenderNotWorkingException extends RuntimeException {
+
+    public ExceptionSenderNotWorkingException(Throwable cause) {
+        super("ExceptionSender 객체가 정상적으로 동작하지 않습니다.", cause);
+    }
+
+}

--- a/src/main/java/com/example/temp/common/exception/ExceptionSenderNotWorkingException.java
+++ b/src/main/java/com/example/temp/common/exception/ExceptionSenderNotWorkingException.java
@@ -2,8 +2,13 @@ package com.example.temp.common.exception;
 
 public class ExceptionSenderNotWorkingException extends RuntimeException {
 
+    public static final String EXCEPTION_SENDER_NOT_WORKING_MSG = "ExceptionSender 객체가 정상적으로 동작하지 않습니다.";
+
     public ExceptionSenderNotWorkingException(Throwable cause) {
-        super("ExceptionSender 객체가 정상적으로 동작하지 않습니다.", cause);
+        super(EXCEPTION_SENDER_NOT_WORKING_MSG, cause);
     }
 
+    public ExceptionSenderNotWorkingException() {
+        super(EXCEPTION_SENDER_NOT_WORKING_MSG);
+    }
 }

--- a/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package com.example.temp.common.exception;
 
 import com.example.temp.member.exception.NicknameDuplicatedException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
@@ -12,10 +15,15 @@ import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+
+    @Value("${webhookUrl}")
+    String webhookUrl;
 
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<ErrorResponse> handleApiException(ApiException exception) {
@@ -66,9 +74,20 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleServerException(Exception exception) {
+    public ResponseEntity<ErrorResponse> handleServerException(Exception exception, HttpServletRequest request) {
         log.warn(exception.getMessage());
+        String message = "예외 발생: " + exception.getMessage();
+        WebClient client = WebClient.builder()
+            .baseUrl(webhookUrl)
+            .build();
+        client.post()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(BodyInserters.fromValue("{\"content\":\"" + message + "\"}"))
+            .retrieve()
+            .bodyToMono(Void.class)
+            .block();
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ErrorResponse.createServerError());
     }
+
 }

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
@@ -1,0 +1,27 @@
+package com.example.temp.common.infrastructure.exceptionsender;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+public class DiscordExceptionSender implements ExceptionSender {
+
+    @Value("${webhookUrl}")
+    String webhookUrl;
+
+    @Override
+    public void send(Exception exception, HttpServletRequest request) {
+        String message = "예외 발생: " + exception.getMessage();
+        WebClient client = WebClient.builder()
+            .baseUrl(webhookUrl)
+            .build();
+        client.post()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(BodyInserters.fromValue("{\"content\":\"" + message + "\"}"))
+            .retrieve()
+            .bodyToMono(Void.class)
+            .block();
+    }
+}

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
@@ -1,27 +1,77 @@
 package com.example.temp.common.infrastructure.exceptionsender;
 
+import com.example.temp.common.dto.UserContext;
 import com.example.temp.common.exception.ExceptionInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
+@RequiredArgsConstructor
 public class DiscordExceptionSender implements ExceptionSender {
 
     @Value("${webhookUrl}")
-    String webhookUrl;
+    private String webhookUrl;
+
+    private final ObjectMapper objectMapper;
 
     @Override
-    public void send(ExceptionInfo exceptionInfo) {
-        String message = "예외 발생: " + exceptionInfo.getMessage();
+    public void send(ExceptionInfo exceptionInfo) throws JsonProcessingException {
+        String body = objectMapper.writeValueAsString(new BodyValue(exceptionInfo));
         WebClient client = WebClient.builder()
             .baseUrl(webhookUrl)
             .build();
         client.post()
             .contentType(MediaType.APPLICATION_JSON)
-            .body(BodyInserters.fromValue("{\"content\":\"" + message + "\"}"))
+            .body(BodyInserters.fromValue(body))
             .retrieve()
             .bodyToMono(Void.class)
             .block();
+    }
+
+    @Getter
+    static class BodyValue implements Serializable {
+
+        private final List<Embed> embeds;
+
+        public BodyValue(ExceptionInfo exceptionInfo) {
+            embeds = List.of(new Embed(exceptionInfo));
+        }
+
+        @Getter
+        static class Embed implements Serializable {
+
+            private final String title;
+            private final String description;
+
+            public Embed(ExceptionInfo exceptionInfo) {
+                this.title = exceptionInfo.getClazz();
+                this.description = getDescription(exceptionInfo);
+            }
+
+            private String getDescription(ExceptionInfo exceptionInfo) {
+                Optional<UserContext> userContextOpt = exceptionInfo.getUserContextOpt();
+                return String.format(
+                    """
+                        **Endpoint**
+                        %s
+                        **Message**
+                        %s
+                        **Login User Info**
+                        %s
+                        """, exceptionInfo.getEndpoint(), exceptionInfo.getMessage(), getUserInfo(userContextOpt));
+            }
+
+            private String getUserInfo(Optional<UserContext> userContextOpt) {
+                return userContextOpt.isPresent() ? userContextOpt.get().toString() : "로그인하지 않은 사용자";
+            }
+        }
     }
 }

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public class DiscordExceptionSender implements ExceptionSender {
@@ -36,6 +37,11 @@ public class DiscordExceptionSender implements ExceptionSender {
             .contentType(MediaType.APPLICATION_JSON)
             .body(BodyInserters.fromValue(body))
             .retrieve()
+            .onStatus(
+                response -> !response.isSameCodeAs(HttpStatus.NO_CONTENT),
+                clientResponse -> {
+                    throw new ExceptionSenderNotWorkingException();
+                })
             .bodyToMono(Void.class)
             .block();
     }

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -18,10 +18,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 public class DiscordExceptionSender implements ExceptionSender {
 
-    @Value("${webhookUrl}")
-    private String webhookUrl;
-
     private final ObjectMapper objectMapper;
+
+    @Qualifier("discordWebClient")
+    private final WebClient discordWebClient;
 
     /**
      * 등록된 디스코드 서버로 발생한 예외에 대한 정보를 전달합니다.
@@ -32,10 +32,7 @@ public class DiscordExceptionSender implements ExceptionSender {
     @Override
     public void send(ExceptionInfo exceptionInfo) {
         String body = serialize(exceptionInfo);
-        WebClient client = WebClient.builder()
-            .baseUrl(webhookUrl)
-            .build();
-        client.post()
+        discordWebClient.post()
             .contentType(MediaType.APPLICATION_JSON)
             .body(BodyInserters.fromValue(body))
             .retrieve()

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
@@ -1,6 +1,6 @@
 package com.example.temp.common.infrastructure.exceptionsender;
 
-import jakarta.servlet.http.HttpServletRequest;
+import com.example.temp.common.exception.ExceptionInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -12,8 +12,8 @@ public class DiscordExceptionSender implements ExceptionSender {
     String webhookUrl;
 
     @Override
-    public void send(Exception exception, HttpServletRequest request) {
-        String message = "예외 발생: " + exception.getMessage();
+    public void send(ExceptionInfo exceptionInfo) {
+        String message = "예외 발생: " + exceptionInfo.getMessage();
         WebClient client = WebClient.builder()
             .baseUrl(webhookUrl)
             .build();

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSender.java
@@ -11,10 +11,10 @@ import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public class DiscordExceptionSender implements ExceptionSender {
@@ -48,18 +48,18 @@ public class DiscordExceptionSender implements ExceptionSender {
 
     private String serialize(ExceptionInfo exceptionInfo) {
         try {
-            return objectMapper.writeValueAsString(new BodyValue(exceptionInfo));
+            return objectMapper.writeValueAsString(new DiscordBodyValue(exceptionInfo));
         } catch (JsonProcessingException e) {
             throw new ExceptionSenderNotWorkingException(e);
         }
     }
 
     @Getter
-    static class BodyValue implements Serializable {
+    static class DiscordBodyValue implements Serializable {
 
         private final List<Embed> embeds;
 
-        public BodyValue(ExceptionInfo exceptionInfo) {
+        public DiscordBodyValue(ExceptionInfo exceptionInfo) {
             embeds = List.of(new Embed(exceptionInfo));
         }
 

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/ExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/ExceptionSender.java
@@ -1,9 +1,8 @@
 package com.example.temp.common.infrastructure.exceptionsender;
 
 import com.example.temp.common.exception.ExceptionInfo;
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface ExceptionSender {
 
-    void send(ExceptionInfo exceptionInfo) throws JsonProcessingException;
+    void send(ExceptionInfo exceptionInfo);
 }

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/ExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/ExceptionSender.java
@@ -1,0 +1,8 @@
+package com.example.temp.common.infrastructure.exceptionsender;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface ExceptionSender {
+
+    void send(Exception exception, HttpServletRequest request);
+}

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/ExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/ExceptionSender.java
@@ -1,8 +1,8 @@
 package com.example.temp.common.infrastructure.exceptionsender;
 
-import jakarta.servlet.http.HttpServletRequest;
+import com.example.temp.common.exception.ExceptionInfo;
 
 public interface ExceptionSender {
 
-    void send(Exception exception, HttpServletRequest request);
+    void send(ExceptionInfo exceptionInfo);
 }

--- a/src/main/java/com/example/temp/common/infrastructure/exceptionsender/ExceptionSender.java
+++ b/src/main/java/com/example/temp/common/infrastructure/exceptionsender/ExceptionSender.java
@@ -1,8 +1,9 @@
 package com.example.temp.common.infrastructure.exceptionsender;
 
 import com.example.temp.common.exception.ExceptionInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface ExceptionSender {
 
-    void send(ExceptionInfo exceptionInfo);
+    void send(ExceptionInfo exceptionInfo) throws JsonProcessingException;
 }

--- a/src/test/java/com/example/temp/TestConfig.java
+++ b/src/test/java/com/example/temp/TestConfig.java
@@ -1,0 +1,19 @@
+package com.example.temp;
+
+import com.example.temp.common.infrastructure.exceptionsender.ExceptionSender;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+
+@Configuration
+@ActiveProfiles("test")
+public class TestConfig {
+
+    @Bean
+    ExceptionSender dummyExceptionSender() {
+        return (exception, request) -> {
+
+        };
+    }
+
+}

--- a/src/test/java/com/example/temp/TestConfig.java
+++ b/src/test/java/com/example/temp/TestConfig.java
@@ -11,7 +11,7 @@ public class TestConfig {
 
     @Bean
     ExceptionSender dummyExceptionSender() {
-        return (exception, request) -> {
+        return (exceptionInfo) -> {
 
         };
     }

--- a/src/test/java/com/example/temp/common/exception/ExceptionInfoTest.java
+++ b/src/test/java/com/example/temp/common/exception/ExceptionInfoTest.java
@@ -1,0 +1,85 @@
+package com.example.temp.common.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.temp.auth.domain.Role;
+import com.example.temp.common.dto.UserContext;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ExceptionInfoTest {
+
+    String clazz = "RuntimeException";
+    String method = "POST";
+    String message = "예외입니다.";
+    String requestUri = "/hello";
+    UserContext userContext = UserContext.builder().id(1L).role(Role.NORMAL).build();
+
+    @Test
+    @DisplayName("클래스 필드는 값이 들어있어야 한다.")
+    void clazzFieldCantNull() throws Exception {
+        // when & then
+        assertThatThrownBy(() -> createExceptionInfo(null, message, message, requestUri, userContext))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("메세지 필드는 값이 들어있어야 한다.")
+    void messageFieldCantNull() throws Exception {
+        // when & then
+        assertThatThrownBy(() -> createExceptionInfo(clazz, null, message, requestUri, userContext))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("URI 필드는 값이 들어있어야 한다.")
+    void uriFieldCantNull() throws Exception {
+        // when & then
+        assertThatThrownBy(() -> createExceptionInfo(clazz, message, null, requestUri, userContext))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("메서드 필드는 값이 들어있어야 한다.")
+    void methodFieldCantNull() throws Exception {
+        // when & then
+        assertThatThrownBy(() -> createExceptionInfo(clazz, message, requestUri, null, userContext))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("UserContext 필드는 값이 없어도 된다")
+    void userContextFieldCanNull() throws Exception {
+        // when & then
+        ExceptionInfo exceptionInfo = createExceptionInfo(clazz, message, requestUri, method, null);
+        assertThat(exceptionInfo.getUserContextOpt()).isEmpty();
+        assertThat(exceptionInfo.getClazz()).isNotNull();
+        assertThat(exceptionInfo.getEndpoint()).isNotNull();
+        assertThat(exceptionInfo.getMessage()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("ExceptionInfo를 생성한다.")
+    void createExceptionInfo() throws Exception {
+        // when & then
+        ExceptionInfo exceptionInfo = createExceptionInfo(clazz, message, requestUri, method, userContext);
+        assertThat(exceptionInfo.getUserContextOpt()).containsSame(userContext);
+        assertThat(exceptionInfo.getClazz()).isEqualTo(clazz);
+        assertThat(exceptionInfo.getEndpoint()).isEqualTo(method + " " + requestUri);
+        assertThat(exceptionInfo.getMessage()).isEqualTo(message);
+    }
+
+    private ExceptionInfo createExceptionInfo(String clazz, String message, String requestUri, String method,
+        UserContext userContext) {
+        return ExceptionInfo.builder()
+            .clazz(clazz)
+            .message(message)
+            .requestUri(requestUri)
+            .method(method)
+            .userContextOpt(Optional.ofNullable(userContext))
+            .build();
+    }
+
+}

--- a/src/test/java/com/example/temp/common/infrastructure/exceptionsender/DiscordDiscordBodyValueTest.java
+++ b/src/test/java/com/example/temp/common/infrastructure/exceptionsender/DiscordDiscordBodyValueTest.java
@@ -1,0 +1,82 @@
+package com.example.temp.common.infrastructure.exceptionsender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.temp.common.dto.UserContext;
+import com.example.temp.common.exception.ExceptionInfo;
+import com.example.temp.common.infrastructure.exceptionsender.DiscordExceptionSender.DiscordBodyValue;
+import com.example.temp.common.infrastructure.exceptionsender.DiscordExceptionSender.DiscordBodyValue.Embed;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DiscordDiscordBodyValueTest {
+
+    @Test
+    @DisplayName("사용자의 정보와 함께 DiscordBodyValue를 생성한다.")
+    void create() throws Exception {
+        // given
+        ExceptionInfo exceptionInfo = createExceptionInfo("clazz", "message", "/hello", "POST",
+            UserContext.builder().id(1L).build());
+
+        // when
+        DiscordBodyValue discordBodyValue = new DiscordBodyValue(exceptionInfo);
+
+        // then
+        List<Embed> embeds = discordBodyValue.getEmbeds();
+        assertThat(embeds).hasSize(1);
+        Embed embed = embeds.get(0);
+        assertThat(embed.getTitle()).isEqualTo(exceptionInfo.getClazz());
+        assertThat(embed.getDescription()).isEqualTo(createEmbedDescriptionIfLogin(exceptionInfo));
+    }
+
+    @Test
+    @DisplayName("사용자가 로그인하지 않았어도 DiscordBodyValue를 생성한다.")
+    void createIfNotLogin() throws Exception {
+        // given
+        ExceptionInfo exceptionInfo = createExceptionInfo("clazz", "message", "/hello", "POST", null);
+
+        // when
+        DiscordBodyValue discordBodyValue = new DiscordBodyValue(exceptionInfo);
+
+        // then
+        List<Embed> embeds = discordBodyValue.getEmbeds();
+        assertThat(embeds).hasSize(1);
+        Embed embed = embeds.get(0);
+        assertThat(embed.getTitle()).isEqualTo(exceptionInfo.getClazz());
+        assertThat(embed.getDescription()).isEqualTo(createEmbedDescriptionIfNotLogin(exceptionInfo));
+    }
+
+    private String createEmbedDescriptionIfLogin(ExceptionInfo exceptionInfo) {
+        UserContext userContext = exceptionInfo.getUserContextOpt().get();
+        return createMessageFormat(exceptionInfo, userContext.toString());
+    }
+
+    private String createEmbedDescriptionIfNotLogin(ExceptionInfo exceptionInfo) {
+        return createMessageFormat(exceptionInfo, "로그인하지 않은 사용자");
+    }
+
+    private String createMessageFormat(ExceptionInfo exceptionInfo, String loginUserInfo) {
+        return String.format(
+            """
+                **Endpoint**
+                %s
+                **Message**
+                %s
+                **Login User Info**
+                %s
+                """, exceptionInfo.getEndpoint(), exceptionInfo.getMessage(), loginUserInfo);
+    }
+
+    private ExceptionInfo createExceptionInfo(String clazz, String message, String requestUri, String method,
+        UserContext userContext) {
+        return ExceptionInfo.builder()
+            .clazz(clazz)
+            .message(message)
+            .requestUri(requestUri)
+            .method(method)
+            .userContextOpt(Optional.ofNullable(userContext))
+            .build();
+    }
+}

--- a/src/test/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSenderTest.java
+++ b/src/test/java/com/example/temp/common/infrastructure/exceptionsender/DiscordExceptionSenderTest.java
@@ -1,0 +1,86 @@
+package com.example.temp.common.infrastructure.exceptionsender;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.example.temp.common.exception.ExceptionInfo;
+import com.example.temp.common.exception.ExceptionSenderNotWorkingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.io.IOException;
+import java.util.Optional;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+class DiscordExceptionSenderTest {
+
+    DiscordExceptionSender discordExceptionSender;
+
+    WebClient webClient;
+
+    static MockWebServer mockDiscord;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        mockDiscord = new MockWebServer();
+        mockDiscord.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockDiscord.shutdown();
+    }
+
+    @BeforeEach
+    void setUp() {
+        String baseUrl = String.format("http://localhost:%s", mockDiscord.getPort());
+        webClient = WebClient.create(baseUrl);
+        discordExceptionSender = new DiscordExceptionSender(new ObjectMapper(), webClient);
+    }
+
+    @Test
+    @DisplayName("ExceptionInfo를 전달에 성공함녀 NO_CONTENT 상태를 반환한다.")
+    void sendExceptionInfo() throws Exception {
+        // given
+        ExceptionInfo exceptionInfo = createExceptionInfo();
+        mockDiscord.enqueue(new MockResponse().setResponseCode(HttpStatus.NO_CONTENT.value()));
+
+        // when & then
+        assertDoesNotThrow(() -> discordExceptionSender.send(exceptionInfo));
+    }
+
+    @ParameterizedTest
+    @DisplayName("요청의 결과로 NO_CONTENT 이외의 상태코드를 받으면 ExceptionSenderNotWorkingException를 던진다.")
+    @ValueSource(ints = {200, 201, 400, 404, 500})
+    void sendFail(int statusCode) throws Exception {
+        // given
+        ExceptionInfo exceptionInfo = createExceptionInfo();
+        mockDiscord.enqueue(new MockResponse().setResponseCode(statusCode));
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> discordExceptionSender.send(exceptionInfo))
+            .isInstanceOf(ExceptionSenderNotWorkingException.class);
+    }
+
+    private ExceptionInfo createExceptionInfo() {
+        return ExceptionInfo.builder()
+            .clazz("clazz")
+            .message("message")
+            .requestUri("/hello")
+            .method("POST")
+            .userContextOpt(Optional.empty())
+            .build();
+    }
+}

--- a/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
+++ b/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
@@ -45,10 +45,12 @@ class GlobalExceptionHandlerUnitTest {
     void handleException() throws Exception {
         // given
         Exception exception = new Exception("에러에러");
+        HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(requestMock.getRequestURI()).thenReturn("https://test");
+        Mockito.when(requestMock.getMethod()).thenReturn("POST");
 
         // when
-        ResponseEntity<ErrorResponse> response = handler.handleServerException(exception,
-            Mockito.mock(HttpServletRequest.class));
+        ResponseEntity<ErrorResponse> response = handler.handleServerException(exception, requestMock);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
+++ b/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.common.exception.ErrorResponse;
+import com.example.temp.common.exception.ExceptionSenderNotWorkingException;
 import com.example.temp.common.exception.GlobalExceptionHandler;
 import com.example.temp.common.infrastructure.exceptionsender.ExceptionSender;
 import jakarta.servlet.http.HttpServletRequest;
@@ -57,8 +58,22 @@ class GlobalExceptionHandlerUnitTest {
 
         ErrorResponse body = response.getBody();
         assertThat(body.getMessage()).isEqualTo(ErrorResponse.SERVER_ERROR_MSG);
-
     }
+
+@Test
+@DisplayName("ExceptionSenderNotWorkingException이 발생하면 INTERNAL_SERVER_ERROR를 반환한다.")
+void handleExceptionSenderNotWorkingException() throws Exception {
+    // given
+
+    ExceptionSenderNotWorkingException exception = Mockito.mock(ExceptionSenderNotWorkingException.class);
+    Mockito.when(exception.getMessage()).thenReturn("메세지");
+
+    // when
+    ResponseEntity<ErrorResponse> response = handler.handleExceptionSenderNotWorkingException(exception);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+}
 
     @Test
     @DisplayName("handleBadRequestStatus가 실행되면 BAD_REQUEST 상태를 반환한다")

--- a/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
+++ b/src/test/java/com/example/temp/exception/GlobalExceptionHandlerUnitTest.java
@@ -6,14 +6,22 @@ import com.example.temp.common.exception.ApiException;
 import com.example.temp.common.exception.ErrorCode;
 import com.example.temp.common.exception.ErrorResponse;
 import com.example.temp.common.exception.GlobalExceptionHandler;
+import com.example.temp.common.infrastructure.exceptionsender.ExceptionSender;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+@ExtendWith(MockitoExtension.class)
 class GlobalExceptionHandlerUnitTest {
 
-    GlobalExceptionHandler handler = new GlobalExceptionHandler();
+    ExceptionSender exceptionSender = Mockito.mock(ExceptionSender.class);
+
+    GlobalExceptionHandler handler = new GlobalExceptionHandler(exceptionSender);
 
     @Test
     @DisplayName("handleApiException이 실행되면 ErrorCode가 들고 있는 status와 message를 반환한다.")
@@ -39,7 +47,8 @@ class GlobalExceptionHandlerUnitTest {
         Exception exception = new Exception("에러에러");
 
         // when
-        ResponseEntity<ErrorResponse> response = handler.handleServerException(exception);
+        ResponseEntity<ErrorResponse> response = handler.handleServerException(exception,
+            Mockito.mock(HttpServletRequest.class));
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] Exception 발생 시 디스코드로 알림을 보내는 기능 구현

~~테스트는 나중에 작성할게요. 내일 예비군이라 더는 못해요~~ ~~

## 🏌🏻 리뷰 포인트
**DummyExceptionSender 생성**
디스코드나 슬랙 등으로 메세지를 전달하는 과정은 테스트가 불가능하다고 생각해요.
우리 서비스의 범위를 벗어나는 부분이기 때문에 해당 부분을 Dummy 객체로 만들어줬습니다.
테스트할 때는 DummyExceptionSender, 그 외 환경에서는 DiscordExceptionSender가 동작하도록 만들어주었습니다.
(지금 생각해보니 Local 프로필에서도 Dummy를 쓰는 게 좋겠네요!!)

**.DiscordExceptionSender 내부 BodyValue 클래스가 지저분한거 같은데요?!**
객체분리하려면 더 분리할 수 있기는 한데요. 저는 저정도가 최선이라고 생각합니다.
조금 지저분해 보이긴 하지만, 저 BodyValue 내부의 지저분한 애들이 모두 같은 책임을 공유하고 있어서요.(메세지를 만들어주는 역할)
오히려 분리하면 관리하기 어렵겠다 판단했습니다.

## 🧘🏻 기타 사항
**디스코드로 전달되는 정보들**
지금은 500번 서버 에러가 발생했을 때, 아래 정보들을 넘겨주고 있어요.
<img width="341" alt="스크린샷 2024-03-05 오전 2 04 52" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/29b58fdd-61d8-4b01-aaec-c890621b8342">

원래는 사용자가 입력한 파라미터, 바디값도 메세지 안에 넣으려고 했는데요..! 결론은 안했습니다.
대공사가 될 거 같은데 시간이 부족해서 지금은 못할 거 같아요!

만약 사용자가 민감정보를 입력했다면 해당 정보는 마스킹을 해야 하잖아요?
이와 관련해서 고민들이 꼬리를 물어가지구요. 꽤나 대공사가 될 거 같아서 구조를 확실하게 짜고 설계하고 싶어서 우선 보류해뒀습니다.

당장 내일이라도 해보고 싶은데 요즘 너무 바쁘네요 ㅠㅠ
빠른 시일 안에 리팩토링하겠습니다. 꼭!!

**@TestConfiguration 대신 @Configuration, @Profile("test")를 사용한 이유**
TestConfiguration을 쓰면 Spring Container에 직접 Import를 해줘야 하더라구요.
수많은 SpringBootTest를 건들기가 너무너무 귀찮아서 위 방식을 사용했습니다.
-> 조만간 테스트 관련해서 리팩토링이 들어갈 생각이라 최대한 간단하게 했습니다.

**WebClientFactory 왜 안쓰셨나요?**
DiscordExceptionSender에서는 WebClient를 따로 구현해서 쓰고 있습니다. (DiscordConfig 참고)
이전에 로그인 관련 작업할 때 사용했던 WebClientFactory를 왜 안썼냐! 하면 경로가 노출되기 때문입니다.
Discord의 웹훅은 메세지를 전달할 때, 경로에 WebHookId와 Key가 들어있습니다(도대체 왜..?)
<img width="476" alt="스크린샷 2024-03-12 오전 12 38 01" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/a1efe125-0386-4fe3-8e33-ec20381093a6">

해당 경로가 노출되면 안되겠다 판단해 WebClientFactory를 사용하지 않고 직접 구현체를 만들어줬습니다.

**WebHook 보낸 뒤...**
서버에서는 요청을 보낸 뒤 204 응답이 온 경우에만 성공으로 판단하고 있어요.
디스코드 웹훅 문서를 참고했습니다.
<img width="596" alt="스크린샷 2024-03-12 오전 12 42 35" src="https://github.com/GymHubCommunity/GymHub-BE/assets/67636607/37095117-cfdc-410a-96b0-efe49f53b6a2">

**okhttp, MockWebServer 의존성은 왜 추가했나요?**
WebClient 테스트를 편하게 하기 위해서입니다.
맨 처음에 Mocking으로 처리해주려 했는데 처리해야 하는 부분들이 많았습니다.
인터넷을 찾아보니까 WebClient를 테스트할 때 가장 권장하는 방식이 MockWebServer를 띄우는 거라고 하네요.
테스트하면서 보니까 동작은 이 순서로 이뤄지는거같아요.
1. MockWebServer를 실행하면 랜덤한 포트에 서버를 띄운다.
2. 해당 서버는 큐로 구성되어 있다. request를 받으면 큐에 저장된 순서대로 response를 반환한다.

-> 이 방식으로 WebClient를 손쉽게 Mocking할 수 있습니다.

## 참고 문서
https://discord.com/developers/docs/resources/channel#embed-object
https://www.baeldung.com/spring-mocking-webclient

close #176 