### PR TITLE
[#178] feat: 회원이 계정 Privacy 정책을 변경할 때, 팔로우 전략을 함께 바꾸도록 구현

### DIFF
--- a/src/main/java/com/example/temp/member/domain/Member.java
+++ b/src/main/java/com/example/temp/member/domain/Member.java
@@ -134,6 +134,7 @@ public class Member {
 
     public void changePrivacy(PrivacyPolicy privacyPolicy) {
         this.privacyPolicy = privacyPolicy;
+        this.followStrategy = privacyPolicy.getDefaultFollowStrategy();
     }
 
     public boolean isPublicAccount() {

--- a/src/main/java/com/example/temp/member/domain/PrivacyPolicy.java
+++ b/src/main/java/com/example/temp/member/domain/PrivacyPolicy.java
@@ -1,12 +1,17 @@
 package com.example.temp.member.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum PrivacyPolicy {
-    PUBLIC("공개 계정"),
-    PRIVATE("비공개 계정");
+    PUBLIC("공개 계정", FollowStrategy.EAGER),
+    PRIVATE("비공개 계정", FollowStrategy.LAZY);
 
     private final String text;
+    private final FollowStrategy defaultFollowStrategy;
 
-    PrivacyPolicy(String text) {
+    PrivacyPolicy(String text, FollowStrategy defaultFollowStrategy) {
         this.text = text;
+        this.defaultFollowStrategy = defaultFollowStrategy;
     }
 }

--- a/src/test/java/com/example/temp/member/domain/MemberTest.java
+++ b/src/test/java/com/example/temp/member/domain/MemberTest.java
@@ -110,6 +110,7 @@ class MemberTest {
 
         // then
         assertThat(member.getPrivacyPolicy()).isEqualTo(PUBLIC);
+        assertThat(member.getFollowStrategy()).isEqualTo(PUBLIC.getDefaultFollowStrategy());
     }
 
     @ParameterizedTest
@@ -126,5 +127,6 @@ class MemberTest {
 
         // then
         assertThat(member.getPrivacyPolicy()).isEqualTo(PRIVATE);
+        assertThat(member.getFollowStrategy()).isEqualTo(PRIVATE.getDefaultFollowStrategy());
     }
 }


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 회원이 계정 Privacy 정책을 변경할 때, 팔로우 전략을 함께 바꾸는 기능 구현

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
없습니다.

close #178 