### PR TITLE
[#180] memberId로 게시글 리스트 조회 api 추가 

### DIFF
--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -1,5 +1,6 @@
 package com.example.temp.post.application;
 
+import static com.example.temp.common.exception.ErrorCode.*;
 import static com.example.temp.common.exception.ErrorCode.AUTHENTICATED_FAIL;
 import static com.example.temp.common.exception.ErrorCode.IMAGE_NOT_FOUND;
 import static com.example.temp.common.exception.ErrorCode.POST_NOT_FOUND;
@@ -113,9 +114,15 @@ public class PostService {
 
     public PostResponse findPostsByMember(Long memberId, UserContext userContext, Pageable pageable) {
         validateLoginUser(userContext);
+        Member findMember = validateMember(memberId);
         Slice<Post> posts = postRepository.findAllByMemberIdOrderByRegisteredAtDesc(
-            memberId, pageable);
+            findMember.getId(), pageable);
         return PostResponse.from(posts);
+    }
+
+    private Member validateMember(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new ApiException(MEMBER_NOT_FOUND));
     }
 
     private void updatePostImages(PostUpdateRequest request, Post post) {

--- a/src/main/java/com/example/temp/post/application/PostService.java
+++ b/src/main/java/com/example/temp/post/application/PostService.java
@@ -13,7 +13,6 @@ import com.example.temp.follow.domain.FollowRepository;
 import com.example.temp.follow.domain.FollowStatus;
 import com.example.temp.hashtag.application.HashtagService;
 import com.example.temp.hashtag.domain.Hashtag;
-import com.example.temp.hashtag.domain.HashtagRepository;
 import com.example.temp.image.domain.Image;
 import com.example.temp.image.domain.ImageRepository;
 import com.example.temp.member.domain.Member;
@@ -54,7 +53,6 @@ public class PostService {
     private final ImageRepository imageRepository;
     private final PostImageRepository postImageRepository;
     private final PostHashtagRepository postHashtagRepository;
-    private final HashtagRepository hashtagRepository;
     private final HashtagService hashtagService;
     private final CommentRepository commentRepository;
 
@@ -110,6 +108,13 @@ public class PostService {
             .map(tag -> postRepository.findAllPostByHashtag("#" + tag, pageable))
             .orElseGet(() -> postRepository.findAllPost(pageable));
         return PostSearchResponse.from(posts);
+    }
+
+    public PostResponse findPostsByMember(Long memberId, UserContext userContext, Pageable pageable) {
+        findMember(userContext);
+        Slice<Post> posts = postRepository.findAllByMemberIdOrderByRegisteredAtDesc(
+            memberId, pageable);
+        return PostResponse.from(posts);
     }
 
     private void updatePostImages(PostUpdateRequest request, Post post) {

--- a/src/main/java/com/example/temp/post/domain/PostRepository.java
+++ b/src/main/java/com/example/temp/post/domain/PostRepository.java
@@ -17,6 +17,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByMemberId(@Param("memberId") Long memberId);
 
+    Slice<Post> findAllByMemberIdOrderByRegisteredAtDesc(@Param("memberId") Long memberId, Pageable pageable);
+
     @Query("SELECT p "
         + "FROM Post p "
         + "WHERE p.member.privacyPolicy = 'PUBLIC' "

--- a/src/main/java/com/example/temp/post/presentation/MemberPostController.java
+++ b/src/main/java/com/example/temp/post/presentation/MemberPostController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class UserPostController {
+public class MemberPostController {
 
     private final PostService postService;
 

--- a/src/main/java/com/example/temp/post/presentation/UserPostController.java
+++ b/src/main/java/com/example/temp/post/presentation/UserPostController.java
@@ -1,0 +1,31 @@
+package com.example.temp.post.presentation;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import com.example.temp.common.annotation.Login;
+import com.example.temp.common.dto.UserContext;
+import com.example.temp.post.application.PostService;
+import com.example.temp.post.dto.response.PostResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserPostController {
+
+    private final PostService postService;
+
+    @GetMapping("/members/{memberId}/posts")
+    public ResponseEntity<PostResponse> getPostsByMember(
+        @PathVariable("memberId") Long memberId,
+        @Login UserContext userContext,
+        @PageableDefault(sort = "registeredAt", direction = DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(postService.findPostsByMember(memberId, userContext, pageable));
+    }
+}

--- a/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/example/temp/post/domain/PostRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.example.temp.post.domain;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
@@ -266,6 +267,67 @@ class PostRepositoryTest {
 
         //then
         assertThat(postContents).isSortedAccordingTo(Comparator.comparing(Post::getRegisteredAt).reversed());
+    }
+
+    @DisplayName("memberId로 사용자가 작성한 게시글 리스트를 조회할 수 있다.")
+    @Test
+    void findAllByMemberIdOrderByRegisteredAtDesc() {
+        //given
+        Member member = saveMember("user@email.com", "유저1");
+        Hashtag hashtag = saveHashtag("#hashtag");
+        saveImage("이미지1");
+        saveImage("이미지2");
+        saveImage("이미지3");
+        savePost(member, "게시글1", List.of("이미지1"), List.of("#hashtag"));
+        savePost(member, "게시글2", List.of("이미지2"), List.of("#hashtag"));
+        savePost(member, "게시글3", List.of("이미지3"), List.of("#hashtag"));
+
+        //when
+        Slice<Post> posts = postRepository.findAllByMemberIdOrderByRegisteredAtDesc(member.getId(),
+            PageRequest.of(0, 5));
+
+        //then
+        assertThat(posts.getContent()).hasSize(3)
+            .extracting("content")
+            .containsExactly("게시글3", "게시글2", "게시글1");
+    }
+
+    @DisplayName("존재하지 않는 memberId로 조회 시 반환된 게시글은 0이다.")
+    @Test
+    void findAllByNotFoundMember() {
+        //given
+        Member member = saveMember("user@email.com", "유저1");
+        Hashtag hashtag = saveHashtag("#hashtag");
+        saveImage("이미지1");
+        savePost(member, "게시글1", List.of("이미지1"), List.of("#hashtag"));
+
+        //when
+        Slice<Post> posts = postRepository.findAllByMemberIdOrderByRegisteredAtDesc(member.getId() - 1,
+            PageRequest.of(0, 5));
+
+        //then
+        assertThat(posts.getContent()).isEmpty();
+    }
+
+    @DisplayName("게시글은 최신 순으로 조회된다.")
+    @Test
+    void postsOrderByRegisteredAtDesc() {
+        //given
+        Member member = saveMember("user@email.com", "유저1");
+        Hashtag hashtag = saveHashtag("#hashtag");
+        saveImage("이미지1");
+        saveImage("이미지2");
+        saveImage("이미지3");
+        savePost(member, "게시글1", List.of("이미지1"), List.of("#hashtag"));
+        savePost(member, "게시글2", List.of("이미지2"), List.of("#hashtag"));
+        savePost(member, "게시글3", List.of("이미지3"), List.of("#hashtag"));
+
+        //when
+        Slice<Post> posts = postRepository.findAllByMemberIdOrderByRegisteredAtDesc(member.getId(),
+            PageRequest.of(0, 5));
+
+        //then
+        assertThat(posts.getContent()).isSortedAccordingTo(Comparator.comparing(Post::getRegisteredAt).reversed());
     }
 
     private Member saveMember(String email, String nickname) {


### PR DESCRIPTION
## 👊🏻 작업 내용

- [X] memberId로 게시글 리스트 조회

## 🏌🏻 리뷰 포인트
특별한 리뷰 포인트는 없습니다. 
해당 기능은 uri에서 posts보다는 members로 시작하기 때문에 member 도메인에서 관리하는게 좋을 것 같다는 생각에 member 도메인에서 구현하려고 했지만 조금 어색하다고 느꼈습니다. 새로운 컨트롤러가 필요하다는 신호라고 느끼고 UserPostController로 분리해서 구현하였습니다.

## 🧘🏻 기타 사항

close #180 