### PR TITLE
[#188] 가상 S3 프로토콜을 HTTPS로 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - DEBUG=1
       - EXTRA_CORS_ALLOWED_ORIGINS=http://localhost:3000,https://gymhub.vercel.app
       - DATA_DIR=/tmp/localstack/data
+      - USE_SSL = 1
       - PORT_WEB_UI=${LOCALSTACK_WEB_UI_PORT:-8081}
       - LAMBDA_EXECUTOR=local
       - DOCKER_SOCK=unix:///var/run/docker.sock


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] 가상 S3 프로토콜을 HTTPS로 변경

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
프론트엔드의 요구에 따라 가상 S3의 프로토콜을 https로 변경합니다.

close #188 