### PR TITLE
[#190] 하루에 한 개의 운동기록만 생성하도록 변경

### DIFF
--- a/src/main/java/com/example/temp/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/temp/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     // 공통
     TEST(HttpStatus.BAD_REQUEST, "테스트용 예외 메시지입니다."),
     EXTENSION_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "해당 확장자는 지원하지 않습니다"),
+    RESOURCE_CONFLICT(HttpStatus.CONFLICT, "자원의 충돌이 일어났습니다."),
 
     // 인증
     AUTHENTICATED_FAIL(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
@@ -70,7 +71,8 @@ public enum ErrorCode {
     TRACK_CANT_EMPTY(HttpStatus.BAD_REQUEST, "운동기록 내 트랙은 최소 한 개 이상 존재해야 합니다."),
     SET_CANT_EMPTY(HttpStatus.BAD_REQUEST, "트랙 내 세트는 최소 한 개 이상 존재해야 합니다."),
     SET_WEIGHT_INVALID(HttpStatus.BAD_REQUEST, "세트의 무게는 0보다 커야 합니다."),
-    SET_REPEAT_CNT_INVALID(HttpStatus.BAD_REQUEST, "세트의 반복 횟수는 0보다 커야 합니다.");
+    SET_REPEAT_CNT_INVALID(HttpStatus.BAD_REQUEST, "세트의 반복 횟수는 0보다 커야 합니다."),
+    RECORD_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 날짜에 해당하는 운동 기록이 이미 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/temp/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -74,6 +75,12 @@ public class GlobalExceptionHandler {
     private FieldError getFirstFieldError(MethodArgumentNotValidException exception) {
         BindingResult bindingResult = exception.getBindingResult();
         return bindingResult.getFieldErrors().get(0);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException() {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(ErrorResponse.create(ErrorCode.RESOURCE_CONFLICT.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -40,12 +40,16 @@ public class ExerciseRecordService {
 
     @Transactional
     public long create(UserContext userContext, ExerciseRecordCreateRequest request) {
+        LocalDate now = LocalDate.now();
+        if (exerciseRecordRepository.alreadyExists(userContext.id(), now)) {
+            throw new ApiException(ErrorCode.RECORD_ALREADY_EXISTS);
+        }
         Member member = findMember(userContext);
         List<String> machineNames = request.tracks().stream()
             .map(TrackCreateRequest::machineName)
             .toList();
         Map<String, BodyPart> machineToMajorBodyPartMap = createMachineToMajorBodyPartMap(machineNames);
-        ExerciseRecord exerciseRecord = request.toEntityWith(member, machineToMajorBodyPartMap);
+        ExerciseRecord exerciseRecord = request.toEntityWith(member, machineToMajorBodyPartMap, now);
         exerciseRecordRepository.save(exerciseRecord);
         return exerciseRecord.getId();
     }

--- a/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
+++ b/src/main/java/com/example/temp/record/application/ExerciseRecordService.java
@@ -19,7 +19,6 @@ import com.example.temp.record.dto.response.ExerciseRecordResponse;
 import com.example.temp.record.dto.response.RetrievePeriodExerciseRecordsResponse;
 import com.example.temp.record.dto.response.RetrieveRecordSnapshotsResponse;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,29 +65,15 @@ public class ExerciseRecordService {
             .map(ExerciseRecordResponse::from)
             .toList();
 
-        Map<LocalDate, List<ExerciseRecordResponse>> exerciseRecordMap = convertListToMapByDate(datePeriod,
-            exerciseRecords);
+        Map<LocalDate, ExerciseRecordResponse> exerciseRecordMap = convertListToMapByDate(exerciseRecords);
         return RetrievePeriodExerciseRecordsResponse.from(exerciseRecordMap);
     }
 
-    private Map<LocalDate, List<ExerciseRecordResponse>> convertListToMapByDate(DatePeriod datePeriod,
+    private Map<LocalDate, ExerciseRecordResponse> convertListToMapByDate(
         List<ExerciseRecordResponse> exerciseRecords) {
-        Map<LocalDate, List<ExerciseRecordResponse>> result = createInitStatusMapByDate(datePeriod);
+        Map<LocalDate, ExerciseRecordResponse> result = new HashMap<>();
         for (ExerciseRecordResponse exerciseRecord : exerciseRecords) {
-            if (!result.containsKey(exerciseRecord.recordDate())) {
-                throw new IllegalArgumentException("year와 month가 일치하지 않는 운동 결과가 발생했습니다.");
-            }
-            result.get(exerciseRecord.recordDate()).add(exerciseRecord);
-        }
-        return result;
-    }
-
-    private Map<LocalDate, List<ExerciseRecordResponse>> createInitStatusMapByDate(DatePeriod datePeriod) {
-        Map<LocalDate, List<ExerciseRecordResponse>> result = new HashMap<>();
-        LocalDate cursor = datePeriod.getStartDate();
-        while (!cursor.isAfter(datePeriod.getLastDate())) {
-            result.put(cursor, new ArrayList<>());
-            cursor = cursor.plusDays(1L);
+            result.put(exerciseRecord.recordDate(), exerciseRecord);
         }
         return result;
     }

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecord.java
@@ -14,7 +14,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +24,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "records")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ExerciseRecord extends BaseTimeEntity {
@@ -63,10 +61,10 @@ public class ExerciseRecord extends BaseTimeEntity {
         }
     }
 
-    public static ExerciseRecord create(Member member, List<Track> tracks) {
+    public static ExerciseRecord create(Member member, List<Track> tracks, LocalDate now) {
         return ExerciseRecord.builder()
             .member(member)
-            .recordDate(LocalDate.now())
+            .recordDate(now)
             .tracks(tracks)
             .isSnapshot(false)
             .build();

--- a/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
+++ b/src/main/java/com/example/temp/record/domain/ExerciseRecordRepository.java
@@ -40,4 +40,10 @@ public interface ExerciseRecordRepository extends JpaRepository<ExerciseRecord, 
         + "ORDER BY er.id DESC")
     Slice<ExerciseRecord> findNextSnapshotsByMember(@Param("lastId") Long lastId, Pageable pageable,
         @Param("member") Member member);
+
+    @Query("SELECT COUNT(er) > 0 FROM ExerciseRecord er "
+        + "WHERE er.member.id = :memberId "
+        + "AND er.recordDate = :now "
+        + "AND er.isSnapshot = false")
+    boolean alreadyExists(Long memberId, LocalDate now);
 }

--- a/src/main/java/com/example/temp/record/dto/request/ExerciseRecordCreateRequest.java
+++ b/src/main/java/com/example/temp/record/dto/request/ExerciseRecordCreateRequest.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -19,11 +20,11 @@ public record ExerciseRecordCreateRequest(
     List<@Valid TrackCreateRequest> tracks
 ) {
 
-    public ExerciseRecord toEntityWith(Member member, Map<String, BodyPart> machineToMajorBodyPartMap) {
+    public ExerciseRecord toEntityWith(Member member, Map<String, BodyPart> machineToMajorBodyPartMap, LocalDate now) {
         List<Track> tracks = this.tracks.stream()
             .map(trackCreateRequest -> trackCreateRequest.toEntityUsing(machineToMajorBodyPartMap))
             .toList();
-        return ExerciseRecord.create(member, tracks);
+        return ExerciseRecord.create(member, tracks, now);
     }
 
     public record TrackCreateRequest(

--- a/src/main/java/com/example/temp/record/dto/request/ExerciseRecordUpdateRequest.java
+++ b/src/main/java/com/example/temp/record/dto/request/ExerciseRecordUpdateRequest.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,7 @@ public record ExerciseRecordUpdateRequest(
         List<Track> tracks = this.tracks.stream()
             .map(trackUpdateRequest -> trackUpdateRequest.toEntityUsing(machineToMajorBodyPartMap))
             .toList();
-        return ExerciseRecord.create(member, tracks);
+        return ExerciseRecord.create(member, tracks, LocalDate.now());
     }
 
     public record TrackUpdateRequest(

--- a/src/main/java/com/example/temp/record/dto/response/RetrievePeriodExerciseRecordsResponse.java
+++ b/src/main/java/com/example/temp/record/dto/response/RetrievePeriodExerciseRecordsResponse.java
@@ -10,9 +10,9 @@ public record RetrievePeriodExerciseRecordsResponse(
     List<RetrievePeriodRecordsElement> results
 ) {
 
-    public static RetrievePeriodExerciseRecordsResponse from(Map<LocalDate, List<ExerciseRecordResponse>> result) {
+    public static RetrievePeriodExerciseRecordsResponse from(Map<LocalDate, ExerciseRecordResponse> result) {
         List<RetrievePeriodRecordsElement> results = new ArrayList<>();
-        for (Entry<LocalDate, List<ExerciseRecordResponse>> entry : result.entrySet()) {
+        for (Entry<LocalDate, ExerciseRecordResponse> entry : result.entrySet()) {
             results.add(RetrievePeriodRecordsElement.of(entry.getKey(), entry.getValue()));
         }
         return new RetrievePeriodExerciseRecordsResponse(results);
@@ -20,12 +20,12 @@ public record RetrievePeriodExerciseRecordsResponse(
 
     public record RetrievePeriodRecordsElement(
         String date,
-        List<ExerciseRecordResponse> exerciseRecords
+        ExerciseRecordResponse exerciseRecord
     ) {
 
         public static RetrievePeriodRecordsElement of(LocalDate localDate,
-            List<ExerciseRecordResponse> exerciseRecords) {
-            return new RetrievePeriodRecordsElement(localDate.toString(), exerciseRecords);
+            ExerciseRecordResponse exerciseRecord) {
+            return new RetrievePeriodRecordsElement(localDate.toString(), exerciseRecord);
         }
     }
 }

--- a/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
+++ b/src/test/java/com/example/temp/record/application/ExerciseRecordServiceTest.java
@@ -183,13 +183,13 @@ class ExerciseRecordServiceTest {
             exerciseRecordService.retrievePeriodExerciseRecords(loginUserContext, MonthlyDatePeriod.of(year, month));
 
         // then
-        int totalCntInMonth = LocalDate.of(year, month, 1).lengthOfMonth();
-        assertThat(response.results()).hasSize(totalCntInMonth);
+        assertThat(response.results()).hasSize(1);
         RetrievePeriodRecordsElement periodRecordsElement = response.results().stream()
             .filter(each -> each.date().equals(recordDate.toString()))
             .findAny()
             .get();
-        assertThat(periodRecordsElement.exerciseRecords()).isNotEmpty();
+        assertThat(periodRecordsElement.exerciseRecord().recordId()).isNotNull();
+        assertThat(periodRecordsElement.exerciseRecord().recordDate()).isEqualTo(recordDate);
     }
 
     @Test
@@ -203,14 +203,9 @@ class ExerciseRecordServiceTest {
         // when
         RetrievePeriodExerciseRecordsResponse response =
             exerciseRecordService.retrievePeriodExerciseRecords(loginUserContext, MonthlyDatePeriod.of(year, month));
+
         // then
-        int totalCntInMonth = LocalDate.of(year, month, 1).lengthOfMonth();
-        assertThat(response.results()).hasSize(totalCntInMonth);
-        RetrievePeriodRecordsElement periodRecordsElement = response.results().stream()
-            .filter(each -> each.date().equals(LocalDate.of(year, month, 1).toString()))
-            .findAny()
-            .get();
-        assertThat(periodRecordsElement.exerciseRecords()).isEmpty();
+        assertThat(response.results()).isEmpty();
     }
 
     @Test
@@ -228,13 +223,7 @@ class ExerciseRecordServiceTest {
             exerciseRecordService.retrievePeriodExerciseRecords(loginUserContext, MonthlyDatePeriod.of(year, month));
 
         // then
-        int totalCntInMonth = LocalDate.of(year, month, 1).lengthOfMonth();
-        assertThat(response.results()).hasSize(totalCntInMonth);
-        RetrievePeriodRecordsElement periodRecordsElement = response.results().stream()
-            .filter(each -> each.date().equals(recordDate.toString()))
-            .findAny()
-            .get();
-        assertThat(periodRecordsElement.exerciseRecords()).isEmpty();
+        assertThat(response.results()).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
+++ b/src/test/java/com/example/temp/record/domain/ExerciseRecordTest.java
@@ -10,10 +10,9 @@ import com.example.temp.member.domain.FollowStrategy;
 import com.example.temp.member.domain.Member;
 import com.example.temp.member.domain.PrivacyPolicy;
 import com.example.temp.member.domain.nickname.Nickname;
+import java.time.LocalDate;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ class ExerciseRecordTest {
         Track track = createTrack("머신1");
 
         // when
-        ExerciseRecord exerciseRecord = ExerciseRecord.create(member, List.of(track));
+        ExerciseRecord exerciseRecord = ExerciseRecord.create(member, List.of(track), LocalDate.now());
 
         // then
         assertThat(exerciseRecord.getMember()).isEqualTo(member);
@@ -42,7 +41,7 @@ class ExerciseRecordTest {
         Member member = createMember("nick1");
 
         // when & then
-        assertThatThrownBy(() -> ExerciseRecord.create(member, Collections.emptyList()))
+        assertThatThrownBy(() -> ExerciseRecord.create(member, Collections.emptyList(), LocalDate.now()))
             .isInstanceOf(ApiException.class)
             .hasMessageContaining(ErrorCode.TRACK_CANT_EMPTY.getMessage());
     }
@@ -54,7 +53,7 @@ class ExerciseRecordTest {
         Member member = createMember("nick1");
 
         // when & then
-        assertThatThrownBy(() -> ExerciseRecord.create(member, null))
+        assertThatThrownBy(() -> ExerciseRecord.create(member, null, LocalDate.now()))
             .isInstanceOf(NullPointerException.class);
     }
 
@@ -88,7 +87,7 @@ class ExerciseRecordTest {
         // given
         Member member = createMember("nick1");
         Track track = createTrack("머신1");
-        ExerciseRecord original = ExerciseRecord.create(member, List.of(track));
+        ExerciseRecord original = ExerciseRecord.create(member, List.of(track), LocalDate.now());
         assertThat(original.isSnapshot()).isFalse();
 
         // when

--- a/src/test/java/com/example/temp/record/dto/request/ExerciseRecordCreateRequestTest.java
+++ b/src/test/java/com/example/temp/record/dto/request/ExerciseRecordCreateRequestTest.java
@@ -8,6 +8,7 @@ import com.example.temp.record.domain.SetInTrack;
 import com.example.temp.record.domain.Track;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest.TrackCreateRequest;
 import com.example.temp.record.dto.request.ExerciseRecordCreateRequest.TrackCreateRequest.SetInTrackCreateRequest;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -60,7 +61,7 @@ class ExerciseRecordCreateRequestTest {
         ExerciseRecordCreateRequest request = new ExerciseRecordCreateRequest(List.of(trackCreateRequest));
 
         // when
-        ExerciseRecord exerciseRecord = request.toEntityWith(null, new HashMap<>());
+        ExerciseRecord exerciseRecord = request.toEntityWith(null, new HashMap<>(), LocalDate.now());
 
         // then
         assertThat(exerciseRecord.getTracks()).hasSize(1)


### PR DESCRIPTION
## 👊🏻 작업 내용

- [x] API 명세 변경. 운동기록을 조회할 때, 기존에는 List로 운동기록을 보내줬지만 하나의 운동기록만 받도록 변경
- [x] 운동기록을 생성할 때, 동일한 날짜에 여러 운동기록이 등록되지 않도록 구현

## 🏌🏻 리뷰 포인트
없습니다.

## 🧘🏻 기타 사항
없습니다.

close #190 